### PR TITLE
fix:OID4VP ID3 conformance test warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true
+  }

--- a/server/multi/src/example.ts
+++ b/server/multi/src/example.ts
@@ -61,8 +61,6 @@ serve({ fetch: app.fetch, port: Number.parseInt(process.env.PORT ?? '8080') }, a
   // By default, issuerId, authorizationServerId, and verifierId use the baseUrl
   const issuerURL = `${baseUrl}/issuers/${encodeURIComponent(baseUrl)}`
   const authzURL = `${baseUrl}/authorizations/${encodeURIComponent(baseUrl)}`
-  const verifierURL = `${baseUrl}/verifiers/${encodeURIComponent(baseUrl)}`
-  verifierMetadataConfig.client_uri = verifierURL
   await initializeVerifierMetadata(baseUrl, verifierMetadataConfig)
 
   issuerMetadataConfig.credential_issuer = CredentialIssuer(baseUrl)

--- a/server/samples/verifier_metadata.json
+++ b/server/samples/verifier_metadata.json
@@ -1,6 +1,4 @@
 {
-	"client_name": "Sample Verifier App",
-	"client_uri": "https://virifier.example.com",
 	"vp_formats": {
 		"jwt_vc_json": {
 			"alg_values_supported": ["ES256"]

--- a/server/single/src/example.ts
+++ b/server/single/src/example.ts
@@ -58,7 +58,6 @@ serve({ fetch: app.fetch, port: Number.parseInt(process.env.PORT ?? '8080') }, a
   console.log(`Server is running on http://localhost:${info.port}`)
 
   // Execute initialization (using the default settings)
-  verifierMetadataConfig.client_uri = `${baseUrl}`
   await initializeVerifierMetadata(baseUrl, verifierMetadataConfig)
 
   issuerMetadataConfig.credential_issuer = CredentialIssuer(`${baseUrl}`)


### PR DESCRIPTION
## Changes

### 1. Added `redirect_uri` to the response after signature verification
- Updated the response to include `redirect_uri` after signature verification.

### 2. Removed unnecessary parameters from `client_metadata`
- Removed unnecessary parameters (`client_name`, `client_uri`, `client_id_scheme`) from `client_metadata` to address warnings.

### 3. Updated `transaction_data` control
- Made the inclusion of `transaction_data` configurable via parameters when creating an Authorization Request.

### Example Usage
<details>
<summary>Curl command to create Authorization Request</summary>

```bash
curl --location 'http://localhost:8080/request-object' \
--header 'Content-Type: application/json' \
--data '{
    "query": {
        "presentation_definition": {
            "id": "example",
            "name": "",
            "purpose": "",
            "submission_requirements": [],
            "input_descriptors": [
                {
                    "id": "University Degree Credentials",
                    "name": "Example",
                    "purpose": "to verify your UniversityDegree Credential",
                    "format": {
                        "dc+sd-jwt": {
                            "sd-jwt_alg_values": [
                                "ES256"
                            ],
                            "kb-jwt_alg_values": [
                                "ES256"
                            ]
                        }
                    },
                    "constraints": {
                        "fields": [
                            {
                                "path": [
                                    "$.vct"
                                ],
                                "filter": {
                                    "type": "string",
                                    "const": "urn:eudi:pid:1"
                                }
                            },
                            {
                                "path": [
                                    "$.family_name"
                                ],
                                "intent_to_retain": false
                            },
                            {
                                "path": [
                                    "$.given_name"
                                ],
                                "intent_to_retain": false
                            },
                            {
                                "path": [
                                    "$.age_equal_or_over.18"
                                ],
                                "intent_to_retain": false
                            }
                        ]
                    }
                }
            ]
        }
    },
    "state": "example-state",
    "client_id": "x509_san_dns:localhost",
    "is_transaction_data": false,
    "response_uri": "http://localhost:8080/dummy"
}'