### PR TITLE
fix(core): sd-jwt-vc issuer metadata URL construction for iss with path components

### DIFF
--- a/issuer+verifier/src/providers/verify-presentation-dc-sd-jwt.provider.ts
+++ b/issuer+verifier/src/providers/verify-presentation-dc-sd-jwt.provider.ts
@@ -50,14 +50,21 @@ export const verifyVerifiablePresentationDcSdJwt = (): VerifyVerifiablePresentat
           })
         }
         let metadataUrl: string
-        if (issUri.pathname !== '/') {
-          metadataUrl = new URL(
-            `.well-known/jwt-vc-issuer/${issUri.pathname.replace(/^\/+/, '')}`,
-            issUri
-          ).toString()
+        // Remove any terminating / from pathname as per spec
+        const pathname = issUri.pathname.replace(/\/+$/, '')
+        if (pathname === '' || pathname === '/') {
+          // Use origin to ensure pathname is replaced, not appended
+          metadataUrl = new URL('.well-known/jwt-vc-issuer', issUri.origin).toString()
         } else {
-          metadataUrl = new URL('.well-known/jwt-vc-issuer', issUri).toString()
+          // Remove leading / and insert between host and path component
+          const pathWithoutLeadingSlash = pathname.replace(/^\/+/, '')
+          // Use origin to ensure pathname is replaced, not appended
+          metadataUrl = new URL(
+            `.well-known/jwt-vc-issuer/${pathWithoutLeadingSlash}`,
+            issUri.origin
+          ).toString()
         }
+        console.log('jwt-vc-issuer metadataUrl:', metadataUrl)
         const metadataResponse = await fetch(metadataUrl)
         if (!metadataResponse.ok) {
           throw err('INVALID_SD_JWT', {

--- a/issuer+verifier/test/providers/verify-presentation-dc-sd-jwt.provider.spec.ts
+++ b/issuer+verifier/test/providers/verify-presentation-dc-sd-jwt.provider.spec.ts
@@ -87,7 +87,7 @@ describe('sd-jwt provider', () => {
   })
 
   it('fetches metadata for issuer with path segment', async () => {
-    const issuerWithPath = `${issuer}/tenant`
+    const issuerWithPath = `${issuer}/tenant/1234`
     const sdJwtWithPath = await issueSdJwt(issuerWithPath)
     const fetchSpy = mockFetch({ issuer: issuerWithPath, jwks: { keys: [publicJwk] } })
 
@@ -97,7 +97,8 @@ describe('sd-jwt provider', () => {
 
     assert.equal(result, true)
     const call = fetchSpy.mock.calls[0]
-    assert.equal(call.arguments[0], `${issuer}/.well-known/jwt-vc-issuer/tenant`)
+    // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc-13#section-5.1
+    assert.equal(call.arguments[0], `${issuer}/.well-known/jwt-vc-issuer/tenant/1234`)
   })
 
   it('verifies SD-JWT using jwks_uri in issuer metadata', async () => {


### PR DESCRIPTION
## Summary
Updated the issuer metadata discovery logic to align with **Section 5.1** of the **SD-JWT VC** specification (draft-13).

## Changes
Fixed the metadata URL construction to correctly handle cases where the `iss` value contains a path component.

According to the spec, if the `iss` is something like `https://example.com/ip/issuer1`, the metadata URL must be constructed by inserting the well-known path between the host and the path component.

- **Current (Incorrect):** `https://example.com/ip/issuer1/.well-known/jwt-vc-issuer` (or similar)
- **Correct (Fixed):** `https://example.com/.well-known/jwt-vc-issuer/ip/issuer1`

## References
- [draft-ietf-oauth-sd-jwt-vc-13#section-5.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc-13#section-5.1)