### PR TITLE
fix: update pr title settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,16 @@
 	"lockFileMaintenance": { "enabled": true },
 	"semanticCommits": "enabled",
 	"branchPrefix": "build/",
+	"pin": {
+		"group": {
+		"commitMessageTopic": "{{#if groupName}}{{groupName}}{{else}}{{#if (lookup upgrades 1)}}dependencies{{else}}{{depName}}{{/if}}{{/if}}"
+		}
+	},
+	"pinDigest": {
+		"group": {
+		"commitMessageTopic": "{{#if groupName}}{{groupName}}{{else}}{{#if (lookup upgrades 1)}}dependencies{{else}}{{depName}}{{/if}}{{/if}}"
+		}
+	},
 	"packageRules": [
 		{
 			"matchManagers": ["gradle"],
@@ -68,7 +78,7 @@
 			],
 			"commitMessagePrefix": "build:",
 			"commitMessageAction": "update",
-			"commitMessageTopic": "{{#if groupName}}{{groupName}}{{else}}{{depName}}{{/if}}"
+    		"commitMessageTopic": "{{#if groupName}}{{groupName}}{{else}}{{#if (lookup upgrades 1)}}dependencies{{else}}{{depName}}{{/if}}{{/if}}"
 		},
 
 		{


### PR DESCRIPTION

- 動作確認：
  - 1枚目が修正前、2枚目が修正後です（issuer+verifierなど`groupName`がある際はdependencesではなく、`groupName`がPRのタイトルに使われるようになったと思います）

<img width="725" height="989" alt="image" src="https://github.com/user-attachments/assets/e9f8c8d2-160d-4571-9e2a-cae977bbe0c6" />

<img width="785" height="731" alt="image" src="https://github.com/user-attachments/assets/47625f53-1e68-4690-b727-d210b0b03eaa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Renovate configuration for improved organization of dependency update commit messages, with refined logic for pinned and digest-based dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->