### PR TITLE
chore(issuer+verifier): escape ci path

### DIFF
--- a/.github/workflows/ci-issuer+verifier.yml
+++ b/.github/workflows/ci-issuer+verifier.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: ["main"]
     paths:
-      - issuer+verifier/**
+      - issuer\+verifier/**
 
 jobs:
   core:


### PR DESCRIPTION

<img width="1339" height="403" alt="image" src="https://github.com/user-attachments/assets/74e89fc6-f00f-4fdd-a308-9108c51ae825" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * GitHub Actions ワークフローの path フィルター設定を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->