### PR TITLE
feat(issuer): add dc+sd-jwt credential issuance support

### DIFF
--- a/issuer+verifier/src/credential-issuer.types.ts
+++ b/issuer+verifier/src/credential-issuer.types.ts
@@ -239,6 +239,11 @@ const credentialConfigurationSchema = z.object({
    * If present, it's an array of claim names specifying the order in which they should be displayed.
    */
   order: z.array(z.string()).optional(),
+
+  /**
+   * (Optional) Verifiable Credential Type for dc+sd-jwt format credentials.
+   */
+  vct: z.string().optional(),
 })
 
 const credentialIssuerSchema = z.string().url().brand('CredentialIssuer')

--- a/issuer+verifier/src/credential-request.types.ts
+++ b/issuer+verifier/src/credential-request.types.ts
@@ -5,6 +5,7 @@ export enum CredentialFormats {
   JWT_VC_JSON = 'jwt_vc_json',
   JWT_VC_JSON_LD = 'jwt_vc_json-ld',
   LDP_VC = 'ldp_vc',
+  DC_SD_JWT = 'dc+sd-jwt',
 }
 
 export enum ProofTypes {

--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -1,4 +1,6 @@
-import { base64url } from 'jose'
+import { base64url, calculateJwkThumbprint } from 'jose'
+import { SDJwtInstance } from '@sd-jwt/core'
+import { ES256, digest, generateSalt } from '@sd-jwt/crypto-nodejs'
 import { Cnonce } from './cnonce.types'
 import {
   CredentialConfigurationId,
@@ -75,13 +77,25 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
       const jwtVcIssuerMetadata: JwtVcIssuerResponse = {
         issuer: metadata.credential_issuer,
       }
+      // Enrich JWKS keys with kid (JWK thumbprint) so verifiers can match
+      // the kid in SD-JWT headers to the correct issuer public key
       const issuerKeys = await keyStore$.fetch(id)
       if (issuerKeys && issuerKeys.length > 0) {
         jwtVcIssuerMetadata.jwks = {
-          keys: issuerKeys.map((keypair) => {
-            const { publicKey } = keypair
-            return publicKey
-          }),
+          keys: await Promise.all(
+            issuerKeys.map(async (keypair) => {
+              const { publicKey } = keypair
+              if (publicKey.kid) {
+                return publicKey
+              }
+              try {
+                const kid = await calculateJwkThumbprint(publicKey)
+                return { ...publicKey, kid }
+              } catch {
+                return publicKey
+              }
+            })
+          ),
         }
       }
       return jwtVcIssuerMetadata
@@ -155,7 +169,6 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
           message: 'Credential request format is not specified.',
         })
       }
-      const issueCredentialProvider = selectProvider(issueCredential$, format)
 
       // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#name-credential-request-2
       const credentialConfiguration = metadata.credential_configurations_supported
@@ -202,7 +215,9 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
           message: 'Failed to verify Proof.',
         })
       }
-      if (!verifyProof.header.kid) {
+      // Accept kid (DID-based) or jwk (raw public key) as proof of possession.
+      // dc+sd-jwt proofs use jwk for the cnf claim; jwt_vc_json proofs use kid.
+      if (!verifyProof.header.kid && !verifyProof.header.jwk) {
         throw err('INVALID_PROOF', {
           message: 'Unsupported proof header.',
         })
@@ -223,12 +238,6 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
         }
       }
 
-      const verifiableCredential = issueCredentialProvider.createCredential(
-        issuer,
-        configuration,
-        verifyProof,
-        options?.claims
-      )
       const keyAlg = options?.alg ?? 'ES256'
       if (
         !configuration.credential_signing_alg_values_supported ||
@@ -238,6 +247,80 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
           message: 'Unsupported key algorithm.',
         })
       }
+
+      const issuerKeys = await keyStore$.fetch(issuer)
+      const keys = issuerKeys.find((keypair) => keypair.privateKey.alg === keyAlg)
+      if (!keys) {
+        throw err('AUTHZ_ISSUER_KEY_NOT_FOUND', {
+          message: 'Issuer key not found.',
+        })
+      }
+
+      // dc+sd-jwt: issue as SD-JWT with cnf claim for key binding
+      if (format === 'dc+sd-jwt') {
+        const holderJwk = verifyProof.header.jwk
+        const vct = configuration.vct ?? 'VerifiableCredential'
+
+        // Build claims from credential definition, coercing values by declared type
+        const sdJwtClaims: Record<string, unknown> = {}
+        const credentialSubject = configuration.credential_definition.credentialSubject
+        if (credentialSubject && Object.keys(credentialSubject).length > 0 && options?.claims) {
+          for (const [key, value] of Object.entries(credentialSubject)) {
+            if (value.mandatory === true && !(key in options.claims)) {
+              throw err('INVALID_CLAIMS', {
+                message: `Mandatory claim "${key}" is missing.`,
+              })
+            }
+            if (key in options.claims) {
+              if (value.value_type === 'string') {
+                sdJwtClaims[key] = String(options.claims[key])
+              } else if (value.value_type === 'number') {
+                sdJwtClaims[key] = Number(options.claims[key])
+              } else {
+                sdJwtClaims[key] = options.claims[key]
+              }
+            }
+          }
+        }
+
+        const kid = await calculateJwkThumbprint(keys.publicKey)
+        const signer = await ES256.getSigner(keys.privateKey)
+        const sdJwtInstance = new SDJwtInstance({
+          hasher: digest,
+          signer,
+          saltGenerator: () => generateSalt(8),
+          signAlg: ES256.alg,
+        })
+
+        const sdJwtPayload = {
+          iss: issuer,
+          vct,
+          iat: Math.floor(Date.now() / 1000),
+          sub: verifyProof.header.kid,
+          ...(holderJwk ? { cnf: { jwk: holderJwk } } : {}),
+          ...sdJwtClaims,
+        }
+
+        const sdJwt = await sdJwtInstance.issue(sdJwtPayload, undefined, {
+          header: { kid },
+        })
+
+        return {
+          credential: sdJwt,
+          c_nonce: nonce,
+          c_nonce_expires_in: options?.cnonce?.c_nonce_expires_in ?? 86400,
+        }
+      }
+
+      // jwt_vc_json: wrap credential in JWT envelope using format-specific provider.
+      // selectProvider is called here (not earlier) because no provider handles dc+sd-jwt.
+      const issueCredentialProvider = selectProvider(issueCredential$, format)
+      const verifiableCredential = issueCredentialProvider.createCredential(
+        issuer,
+        configuration,
+        verifyProof,
+        options?.claims
+      )
       const jwtHeader = {
         alg: keyAlg,
         typ: 'JWT',
@@ -246,13 +329,6 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
         vc: verifiableCredential,
         iss: verifiableCredential.issuer,
         sub: verifyProof.header.kid,
-      }
-      const issuerKeys = await keyStore$.fetch(issuer)
-      const keys = issuerKeys.find((keypair) => keypair.privateKey.alg === keyAlg)
-      if (!keys) {
-        throw err('AUTHZ_ISSUER_KEY_NOT_FOUND', {
-          message: 'Issuer key not found.',
-        })
       }
       const keyProvider = selectProvider(key$, keyAlg)
       const signature = await keyProvider.sign(keys.privateKey, keyAlg, jwtPayload, jwtHeader)

--- a/server/samples/issuer_metadata.json
+++ b/server/samples/issuer_metadata.json
@@ -1,78 +1,133 @@
 {
-	"credential_issuer": "https://issuer.example.com",
-	"authorization_servers": ["https://authz.example.com"],
-	"credential_endpoint": "https://issuer.example.com/credential",
-	"batch_credential_endpoint": "https://issuer.example.com/batch_credential",
-	"deferred_credential_endpoint": "https://issuer.example.com/deferred_credential",
-	"credential_response_encryption": {
-		"alg_values_supported": ["ECDH-ES"],
-		"enc_values_supported": ["A128GCM"],
-		"encryption_required": false
-	},
-	"display": [
-		{
-			"name": "Example University",
-			"locale": "en-US"
-		},
-		{
-			"name": "Example Université",
-			"locale": "fr-FR"
-		}
-	],
-	"credential_configurations_supported": {
-		"UniversityDegreeCredential": {
-			"format": "jwt_vc_json",
-			"scope": "UniversityDegree",
-			"cryptographic_binding_methods_supported": ["did:example"],
-			"credential_signing_alg_values_supported": ["ES256"],
-			"credential_definition": {
-				"type": ["VerifiableCredential", "UniversityDegreeCredential"],
-				"credentialSubject": {
-					"given_name": {
-						"display": [
-							{
-								"name": "Given Name",
-								"locale": "en-US"
-							}
-						],
-						"mandatory": true,
-						"value_type": "string"
-					},
-					"family_name": {
-						"display": [
-							{
-								"name": "Surname",
-								"locale": "en-US"
-							}
-						]
-					},
-					"degree": {},
-					"gpa": {
-						"display": [
-							{
-								"name": "GPA"
-							}
-						]
-					}
-				}
-			},
-			"proof_types_supported": {
-				"jwt": {
-					"proof_signing_alg_values_supported": ["ES256"]
-				}
-			},
-			"display": [
-				{
-					"name": "University Credential",
-					"locale": "en-US",
-					"logo": {
-						"uri": "https://university.example.edu/public/logo.png",
-						"alt_text": "a square logo of a university"
-					},
-					"background_color": "#12107c",
-					"text_color": "#FFFFFF"
-				}
-			]
-		}
-	}
+  "credential_issuer": "https://issuer.example.com",
+  "authorization_servers": ["https://authz.example.com"],
+  "credential_endpoint": "https://issuer.example.com/credential",
+  "batch_credential_endpoint": "https://issuer.example.com/batch_credential",
+  "deferred_credential_endpoint": "https://issuer.example.com/deferred_credential",
+  "credential_response_encryption": {
+    "alg_values_supported": ["ECDH-ES"],
+    "enc_values_supported": ["A128GCM"],
+    "encryption_required": false
+  },
+  "display": [
+    {
+      "name": "Example University",
+      "locale": "en-US"
+    },
+    {
+      "name": "Example Université",
+      "locale": "fr-FR"
+    }
+  ],
+  "credential_configurations_supported": {
+    "UniversityDegreeCredential": {
+      "format": "jwt_vc_json",
+      "scope": "UniversityDegree",
+      "cryptographic_binding_methods_supported": ["did:example"],
+      "credential_signing_alg_values_supported": ["ES256"],
+      "credential_definition": {
+        "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+        "credentialSubject": {
+          "given_name": {
+            "display": [
+              {
+                "name": "Given Name",
+                "locale": "en-US"
+              }
+            ],
+            "mandatory": true,
+            "value_type": "string"
+          },
+          "family_name": {
+            "display": [
+              {
+                "name": "Surname",
+                "locale": "en-US"
+              }
+            ]
+          },
+          "degree": {},
+          "gpa": {
+            "display": [
+              {
+                "name": "GPA"
+              }
+            ]
+          }
+        }
+      },
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": ["ES256"]
+        }
+      },
+      "display": [
+        {
+          "name": "University Credential",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://university.example.edu/public/logo.png",
+            "alt_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ]
+    },
+    "UniversityDegreeCredentialSdJwt": {
+      "format": "dc+sd-jwt",
+      "scope": "UniversityDegreeSdJwt",
+      "cryptographic_binding_methods_supported": ["did:example"],
+      "credential_signing_alg_values_supported": ["ES256"],
+      "credential_definition": {
+        "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+        "credentialSubject": {
+          "given_name": {
+            "display": [
+              {
+                "name": "Given Name",
+                "locale": "en-US"
+              }
+            ],
+            "mandatory": true,
+            "value_type": "string"
+          },
+          "family_name": {
+            "display": [
+              {
+                "name": "Surname",
+                "locale": "en-US"
+              }
+            ]
+          },
+          "degree": {},
+          "gpa": {
+            "display": [
+              {
+                "name": "GPA"
+              }
+            ]
+          }
+        }
+      },
+      "vct": "UniversityDegreeCredential",
+      "proof_types_supported": {
+        "jwt": {
+          "proof_signing_alg_values_supported": ["ES256"]
+        }
+      },
+      "display": [
+        {
+          "name": "University Credential (SD-JWT)",
+          "locale": "en-US",
+          "logo": {
+            "uri": "https://university.example.edu/public/logo.png",
+            "alt_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
  ## Summary

  The issuer previously only supported `jwt_vc_json` format. This PR adds `dc+sd-jwt` issuance so the full OID4VP
  flow with Key Binding JWT (KB-JWT) can be exercised end-to-end.

  **`credential-request.types.ts`**
  - Add `DC_SD_JWT` to `CredentialFormats` enum

  **`credential-issuer.types.ts`**
  - Add optional `vct` field to `CredentialConfigurationSchema` (required by SD-JWT VC spec)

  **`issuer.flows.ts`**
  - Enrich JWKS response with `kid` (JWK thumbprint) so verifiers can match the `kid` in SD-JWT headers to the
  correct issuer public key
  - Relax proof header validation to accept `jwk` alongside `kid`, enabling the holder's public key to be embedded
  for the `cnf` claim
  - Add `dc+sd-jwt` issuance branch: issues SD-JWT with `iss`, `vct`, `cnf`, and typed claims; returns the SD-JWT
  string directly without a JWT envelope
  - Hoist issuer key lookup before the format branch so both paths share the same key validation
  - Defer `selectProvider` call to after the `dc+sd-jwt` branch (no registered provider handles `dc+sd-jwt` format)

  **`server/samples/issuer_metadata.json`**
  - Add `UniversityDegreeCredentialSdJwt` credential configuration with `format: dc+sd-jwt` and `vct`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * dc+sd-jwt形式の認証情報発行に対応
  * 認証情報設定にVerifiable Credential Type（VCT）フィールドを追加
  * 発行プロセスの暗号化バインディング検証を強化
  * 新しい大学学位認証情報設定テンプレートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->