### PR TITLE
fix(wallet): update JWT header type to openid4vci-proof+jwt

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -308,7 +308,7 @@ func (w *Wallet) convertEntryToSavedCredential(entry types.CredentialEntry) (*Sa
 func (w *Wallet) generateJWTProof(key IKeyEntry, did *idprofTypes.IdentityProfile, nonce *string, aud string) (string, error) {
 	header := map[string]interface{}{
 		"alg": "ES256",
-		"typ": "JWT",
+		"typ": "openid4vci-proof+jwt",
 		"kid": did.ID,
 	}
 


### PR DESCRIPTION
### Summary
The `typ` header in the JWT Proof is set to “JWT”. The specification requires “openid4vci-proof+jwt” as a MUST, and a Credential Issuer that validates the `typ` will reject the Credential Request.
I have made corrections to comply with these specifications.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * デジタル認証のJWT証明形式を業界標準に準拠するよう更新しました。これにより相互運用性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->