### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/汎用テンプレート---generic-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/汎用テンプレート---generic-issue-template.md
@@ -1,0 +1,35 @@
+---
+name: 汎用テンプレート / Generic Issue Template
+about: バグ報告、改善要望、仕様確認などに利用する汎用テンプレート / A generic template for bug reports, enhancement
+  requests, and specification-related issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## 概要 / Summary
+概要を記載してください。  
+Please describe the summary of this issue.
+
+## コンポーネント / Component
+- **モジュール / Module**: [対象となるモジュールを記載してください / Please specify the relevant module]
+
+## 仕様要件（必要な場合のみ） / Specification Requirements (if applicable)
+※ 仕様と現在の動作にずれがある場合、または仕様を根拠として補足が必要な場合に記載してください。  
+Please fill in this section only if there is a gap between the current behavior and the specification, or if specification-based clarification is needed.
+
+- **セクション / Section**:
+[根拠となる仕様の箇所を記載してください / Please specify the relevant section of the specification]
+
+- **原文 / Original Text**:  
+[根拠となる仕様の原文を記載してください / Please quote the original text from the specification]
+
+## 現在の動作 / Current Behavior
+[現状の動作と、必要に応じて該当コード・ログ・スクリーンショット等を記載してください / Please describe the current behavior, and include relevant code, logs, or screenshots if needed]
+
+## 期待される動作 / Expected Behavior
+[期待される動作を記載してください / Please describe the expected behavior]
+
+## 影響 / Impact
+[現状の動作のままだと生じる影響を記載してください / Please describe the impact if the current behavior remains unchanged]


### PR DESCRIPTION
add a generic issue template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub issue テンプレートを追加し、issue 報告のプロセスを標準化しました。新しいテンプレートは、概要、コンポーネント選択、仕様要件、現在の動作、期待される動作などの構造化されたセクションを含み、より効率的で一貫性のある issue 報告を実現します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->