### PR TITLE
fix(wallet): update descriptor map to use root path for VP token

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -731,7 +731,7 @@ func (w *Wallet) buildDescriptorMap(credentials []*SavedCredential, flavor *cred
 		descriptorMap = append(descriptorMap, presenterTypes.DescriptorMapItem{
 			ID:     descriptionItemID,
 			Format: vpFormat,
-			Path:   fmt.Sprintf("$.vp_token[%d]", i),
+			Path:   "$",
 			PathNested: &presenterTypes.DescriptorMapItem{
 				ID:     descriptionItemID,
 				Format: vcFormat,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -712,6 +712,10 @@ func (w *Wallet) buildDescriptorMap(credentials []*SavedCredential, flavor *cred
 	var descriptorMap []presenterTypes.DescriptorMapItem
 	for i := range credentials {
 		descriptionItemID := uuid.New().String()
+		descriptorPath := "$"
+		if len(credentials) > 1 {
+			descriptorPath = fmt.Sprintf("$[%d]", i)
+		}
 		// Temporary compatibility workaround:
 		// the current verifier/request-object flow still requires
 		// presentation_submission.descriptor_map, and dc+sd-jwt must point to the
@@ -723,7 +727,7 @@ func (w *Wallet) buildDescriptorMap(credentials []*SavedCredential, flavor *cred
 			descriptorMap = append(descriptorMap, presenterTypes.DescriptorMapItem{
 				ID:     descriptionItemID,
 				Format: vpFormat,
-				Path:   "$",
+				Path:   descriptorPath,
 			})
 			continue
 		}
@@ -731,7 +735,7 @@ func (w *Wallet) buildDescriptorMap(credentials []*SavedCredential, flavor *cred
 		descriptorMap = append(descriptorMap, presenterTypes.DescriptorMapItem{
 			ID:     descriptionItemID,
 			Format: vpFormat,
-			Path:   "$",
+			Path:   descriptorPath,
 			PathNested: &presenterTypes.DescriptorMapItem{
 				ID:     descriptionItemID,
 				Format: vcFormat,

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
 	"github.com/trustknots/vcknots/wallet/credential"
 	"github.com/trustknots/vcknots/wallet/credstore"
 	idprofTypes "github.com/trustknots/vcknots/wallet/idprof/types"
@@ -1189,22 +1190,11 @@ func TestBuildDescriptorMap_UsesVPTokenRootPathForJwtVP(t *testing.T) {
 	flavor := credential.JwtVc
 
 	descriptorMap, err := controller.buildDescriptorMap([]*SavedCredential{{}}, &flavor)
-	if err != nil {
-		t.Fatalf("buildDescriptorMap() returned error: %v", err)
-	}
-	if len(descriptorMap) != 1 {
-		t.Fatalf("expected descriptor map length 1, got %d", len(descriptorMap))
-	}
-
-	if descriptorMap[0].Path != "$" {
-		t.Fatalf("expected top-level path '$', got %q", descriptorMap[0].Path)
-	}
-	if descriptorMap[0].PathNested == nil {
-		t.Fatalf("expected nested path for jwt_vp_json format")
-	}
-	if descriptorMap[0].PathNested.Path != "$.verifiableCredential[0]" {
-		t.Fatalf("expected nested vc path '$.verifiableCredential[0]', got %q", descriptorMap[0].PathNested.Path)
-	}
+	require.NoError(t, err)
+	require.Len(t, descriptorMap, 1)
+	require.Equal(t, "$", descriptorMap[0].Path)
+	require.NotNil(t, descriptorMap[0].PathNested)
+	require.Equal(t, "$.verifiableCredential[0]", descriptorMap[0].PathNested.Path)
 }
 
 func TestBuildDescriptorMap_UsesVPTokenRootPathForAllJwtDescriptors(t *testing.T) {
@@ -1212,16 +1202,12 @@ func TestBuildDescriptorMap_UsesVPTokenRootPathForAllJwtDescriptors(t *testing.T
 	flavor := credential.JwtVc
 
 	descriptorMap, err := controller.buildDescriptorMap([]*SavedCredential{{}, {}}, &flavor)
-	if err != nil {
-		t.Fatalf("buildDescriptorMap() returned error: %v", err)
-	}
-	if len(descriptorMap) != 2 {
-		t.Fatalf("expected descriptor map length 2, got %d", len(descriptorMap))
-	}
+	require.NoError(t, err)
+	require.Len(t, descriptorMap, 2)
 
 	for i, item := range descriptorMap {
-		if item.Path != "$" {
-			t.Fatalf("descriptorMap[%d].Path: expected '$', got %q", i, item.Path)
-		}
+		require.Equalf(t, "$", item.Path, "descriptorMap[%d].Path", i)
+		require.NotNilf(t, item.PathNested, "descriptorMap[%d].PathNested", i)
+		require.Equalf(t, fmt.Sprintf("$.verifiableCredential[%d]", i), item.PathNested.Path, "descriptorMap[%d].PathNested.Path", i)
 	}
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1206,8 +1206,23 @@ func TestBuildDescriptorMap_UsesVPTokenRootPathForAllJwtDescriptors(t *testing.T
 	require.Len(t, descriptorMap, 2)
 
 	for i, item := range descriptorMap {
-		require.Equalf(t, "$", item.Path, "descriptorMap[%d].Path", i)
+		require.Equalf(t, fmt.Sprintf("$[%d]", i), item.Path, "descriptorMap[%d].Path", i)
 		require.NotNilf(t, item.PathNested, "descriptorMap[%d].PathNested", i)
 		require.Equalf(t, fmt.Sprintf("$.verifiableCredential[%d]", i), item.PathNested.Path, "descriptorMap[%d].PathNested.Path", i)
+	}
+}
+
+func TestBuildDescriptorMap_UsesVPTokenRootPathForALLSdJwtDescriptors(t *testing.T) {
+	controller := createTestControllerWithDefaults(t)
+	flavor := credential.SDJwtVC
+
+	descriptorMap, err := controller.buildDescriptorMap([]*SavedCredential{{}, {}}, &flavor)
+	require.NoError(t, err)
+	require.Len(t, descriptorMap, 2)
+
+	for i, item := range descriptorMap {
+		require.Equalf(t, fmt.Sprintf("$[%d]", i), item.Path, "descriptorMap[%d].Path", i)
+		require.Equalf(t, "dc+sd-jwt", item.Format, "descriptorMap[%d].Format", i)
+		require.Nilf(t, item.PathNested, "descriptorMap[%d].PathNested", i)
 	}
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1183,3 +1183,45 @@ func TestApplyOID4VPRequestOptions(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildDescriptorMap_UsesVPTokenRootPathForJwtVP(t *testing.T) {
+	controller := createTestControllerWithDefaults(t)
+	flavor := credential.JwtVc
+
+	descriptorMap, err := controller.buildDescriptorMap([]*SavedCredential{{}}, &flavor)
+	if err != nil {
+		t.Fatalf("buildDescriptorMap() returned error: %v", err)
+	}
+	if len(descriptorMap) != 1 {
+		t.Fatalf("expected descriptor map length 1, got %d", len(descriptorMap))
+	}
+
+	if descriptorMap[0].Path != "$" {
+		t.Fatalf("expected top-level path '$', got %q", descriptorMap[0].Path)
+	}
+	if descriptorMap[0].PathNested == nil {
+		t.Fatalf("expected nested path for jwt_vp_json format")
+	}
+	if descriptorMap[0].PathNested.Path != "$.verifiableCredential[0]" {
+		t.Fatalf("expected nested vc path '$.verifiableCredential[0]', got %q", descriptorMap[0].PathNested.Path)
+	}
+}
+
+func TestBuildDescriptorMap_UsesVPTokenRootPathForAllJwtDescriptors(t *testing.T) {
+	controller := createTestControllerWithDefaults(t)
+	flavor := credential.JwtVc
+
+	descriptorMap, err := controller.buildDescriptorMap([]*SavedCredential{{}, {}}, &flavor)
+	if err != nil {
+		t.Fatalf("buildDescriptorMap() returned error: %v", err)
+	}
+	if len(descriptorMap) != 2 {
+		t.Fatalf("expected descriptor map length 2, got %d", len(descriptorMap))
+	}
+
+	for i, item := range descriptorMap {
+		if item.Path != "$" {
+			t.Fatalf("descriptorMap[%d].Path: expected '$', got %q", i, item.Path)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

In the current implementation, the `path` used in the `descriptor_map` of the Presentation Submission is set to `$.vp_token[n]`, which differs from the specification’s requirement of `$` (for a single VP) or `$[n]` (for multiple VPs). A specification-compliant Verifier cannot access the Credential within the VP Token.
This issue has now been resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 記述子マップのパス処理を統一し、複数の検証済み資格情報を扱う際の整合性と安定性を向上

* **Tests**
  * JWTおよびSD-JWT形式の検証済み資格情報に対するユニットテストを追加し、動作の確実性を強化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->