### PR TITLE
fix: add validation for duplicate display.locale

### DIFF
--- a/issuer+verifier/src/credential-issuer.types.ts
+++ b/issuer+verifier/src/credential-issuer.types.ts
@@ -245,79 +245,127 @@ const credentialIssuerSchema = z.string().url().brand('CredentialIssuer')
 
 const credentialConfigurationIdSchema = z.string().brand('CredentialConfigurationId')
 
+const validateUniqueLocaleArray = <T extends { locale?: string }>(
+  arr: T[] | undefined,
+  ctx: z.RefinementCtx,
+  path: (string | number)[]
+) => {
+  if (!arr) return
+  const localeList = new Set<string>()
+  arr.forEach((item, i) => {
+    const loc = item.locale?.toLowerCase()
+    if (!loc) return
+    if (localeList.has(loc)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate display locale: ${loc}`,
+        path: [...path, i, 'locale'],
+      })
+    }
+    localeList.add(loc)
+  })
+}
+
 /**
  * Zod schema for CredentialIssuerMetadata.
  * Represents the metadata of a Credential Issuer.
  * This is typically published at a well-known URI (`/.well-known/openid-credential-issuer`).
  * Based on OpenID for Verifiable Credential Issuance specification.
  */
-const credentialIssuerMetadataSchema = z.object({
-  /**
-   * The issuer's identifier (URL).
-   */
-  credential_issuer: credentialIssuerSchema,
+const credentialIssuerMetadataSchema = z
+  .object({
+    /**
+     * The issuer's identifier (URL).
+     */
+    credential_issuer: credentialIssuerSchema,
 
-  /**
-   * URL of the issuer's OAuth 2.0 Authorization Server.
-   * Required if the issuer uses OAuth 2.0 for authorization.
-   */
-  authorization_servers: z.array(z.string().url()).optional(),
+    /**
+     * URL of the issuer's OAuth 2.0 Authorization Server.
+     * Required if the issuer uses OAuth 2.0 for authorization.
+     */
+    authorization_servers: z.array(z.string().url()).optional(),
 
-  /**
-   * URL of the Credential Endpoint.
-   */
-  credential_endpoint: z.string().url(),
+    /**
+     * URL of the Credential Endpoint.
+     */
+    credential_endpoint: z.string().url(),
 
-  /**
-   * (Optional) URL of the Batch Credential Endpoint.
-   */
-  batch_credential_endpoint: z.string().url().optional(),
+    /**
+     * (Optional) URL of the Batch Credential Endpoint.
+     */
+    batch_credential_endpoint: z.string().url().optional(),
 
-  /**
-   * (Optional) URL of the Deferred Credential Endpoint.
-   */
-  deferred_credential_endpoint: z.string().url().optional(),
+    /**
+     * (Optional) URL of the Deferred Credential Endpoint.
+     */
+    deferred_credential_endpoint: z.string().url().optional(),
 
-  /**
-   * (Optional) A JSON array of strings representing supported JWA [RFC7518]
-   * encryption algorithm (alg values) for encrypting credential responses.
-   */
-  credential_response_encryption_alg_values_supported: z.array(z.string()).optional(),
+    /**
+     * (Optional) A JSON array of strings representing supported JWA [RFC7518]
+     * encryption algorithm (alg values) for encrypting credential responses.
+     */
+    credential_response_encryption_alg_values_supported: z.array(z.string()).optional(),
 
-  /**
-   * (Optional) A JSON array of strings representing supported JWA [RFC7518]
-   * encryption algorithm (enc values) for encrypting credential responses.
-   */
-  credential_response_encryption_enc_values_supported: z.array(z.string()).optional(),
+    /**
+     * (Optional) A JSON array of strings representing supported JWA [RFC7518]
+     * encryption algorithm (enc values) for encrypting credential responses.
+     */
+    credential_response_encryption_enc_values_supported: z.array(z.string()).optional(),
 
-  /**
-   * (Optional) Boolean value specifying whether the issuer requires credential
-   * responses to be encrypted. Default is false.
-   */
-  require_credential_response_encryption: z.boolean().optional(),
+    /**
+     * (Optional) Boolean value specifying whether the issuer requires credential
+     * responses to be encrypted. Default is false.
+     */
+    require_credential_response_encryption: z.boolean().optional(),
 
-  /**
-   * (Optional) A JSON object map where keys are credential configuration IDs
-   * and values are objects containing metadata about the supported credential type.
-   * This effectively replaces or complements `credential_manifest_uri`.
-   * fix
-   * https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#name-credential-issuer-metadata-p
-   * REQUIRED. Object that describes specifics of the Credential that the Credential Issuer supports issuance of.
-   */
-  credential_configurations_supported: z.record(z.string(), credentialConfigurationSchema),
-  // .optional(),
+    /**
+     * (Optional) A JSON object map where keys are credential configuration IDs
+     * and values are objects containing metadata about the supported credential type.
+     * This effectively replaces or complements `credential_manifest_uri`.
+     * fix
+     * https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#name-credential-issuer-metadata-p
+     * REQUIRED. Object that describes specifics of the Credential that the Credential Issuer supports issuance of.
+     */
+    credential_configurations_supported: z.record(z.string(), credentialConfigurationSchema),
+    // .optional(),
 
-  /**
-   * (Optional) URL of the Credential Manifest for this issuer.
-   * This manifest contains a list of credential types the issuer can issue.
-   */
-  credential_manifest_uri: z.string().url().optional(),
+    /**
+     * (Optional) URL of the Credential Manifest for this issuer.
+     * This manifest contains a list of credential types the issuer can issue.
+     */
+    credential_manifest_uri: z.string().url().optional(),
 
-  /**
-   * (Optional) Information about the issuer for display purposes in the wallet.
-   */
-  display: z.array(issuerDisplaySchema).optional(),
-})
+    /**
+     * (Optional) Information about the issuer for display purposes in the wallet.
+     */
+    display: z.array(issuerDisplaySchema).optional(),
+  })
+  .superRefine((data, ctx) => {
+    // Validate that issuerDisplay locales are unique
+    validateUniqueLocaleArray(data.display, ctx, ['display'])
+
+    for (const [id, config] of Object.entries(data.credential_configurations_supported ?? {})) {
+      // Validate that credentialDisplay locales are unique
+      validateUniqueLocaleArray(config.display, ctx, [
+        'credential_configurations_supported',
+        id,
+        'display',
+      ])
+
+      // Validate that claimDisplay locales are unique
+      const claims = config.credential_definition?.credentialSubject ?? {}
+      for (const [key, claim] of Object.entries(claims)) {
+        validateUniqueLocaleArray(claim.display, ctx, [
+          'credential_configurations_supported',
+          id,
+          'credential_definition',
+          'credentialSubject',
+          key,
+          'display',
+        ])
+      }
+    }
+  })
 
 export type CredentialConfigurationId = z.infer<typeof credentialConfigurationIdSchema>
 

--- a/issuer+verifier/src/credential-issuer.types.ts
+++ b/issuer+verifier/src/credential-issuer.types.ts
@@ -253,8 +253,8 @@ const validateUniqueLocaleArray = <T extends { locale?: string }>(
   if (!arr) return
   const localeList = new Set<string>()
   arr.forEach((item, i) => {
-    const loc = item.locale?.toLowerCase()
-    if (!loc) return
+    if (item.locale === undefined) return
+    const loc = typeof item.locale === 'string' ? item.locale.trim().toLowerCase() : item.locale
     if (localeList.has(loc)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 認証情報発行者のメタデータ検証をさらに強化しました。display設定や各認証情報の表示、クレーム表示リスト内でのロケール値の重複を大文字小文字を区別せずに検出します。
  * 重複検出時のエラーメッセージがより正確になり、問題箇所の特定が容易になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->