### PR TITLE
fix: remove unnecessary ParseRequestURI

### DIFF
--- a/wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go
+++ b/wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go
@@ -328,18 +328,9 @@ func main() {
 		oid4vpURI = os.Args[1]
 		logger.Info("Using OID4VP URI from command line", "uri", oid4vpURI)
 
-		req, err := presenterDisp.ParseRequestURI(oid4vpURI)
-		if err != nil {
-			logger.Error("Failed to parse OID4VP request", "error", err)
-			os.Exit(1)
-		}
-		logger.Info("Parsed OID4VP request", "nonce", req.Nonce, "client_id", req.ClientID)
-
 		options = &sdjwtvc.SdJwtVcPresentationOptions{
-			SelectedClaims:    []string{"given_name", "family_name"},
+			SelectedClaims:    []string{"given_name"},
 			RequireKeyBinding: true,
-			Audience:          req.ClientID,
-			Nonce:             req.Nonce,
 		}
 	} else {
 		oid4vpURI = fetchOID4VPURIFromServer(savedCred, logger)


### PR DESCRIPTION
I fixed a problem caused by the request object being retrieved multiple times when running `server_integration_sdjwt.go` with parameters.

Cause: When ParseRequestURI is called, it attempts to retrieve the request object if it is passed by reference. Consequently, the request object was being retrieved once too many before PresentCredential was called.
Although this is not a problem according to the specification, it caused an error in the current version of VCKnots Verifier, so I have fixed it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * コンフォーマンスモードにおけるOID4VP リクエスト処理を簡素化しました。プレゼンテーション オプションの選択項目を調整し、特定のフィールド設定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->