### PR TITLE
fix(issuer): jwt proof header validation and iat

### DIFF
--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -769,12 +769,25 @@ For the type definition of the credential response, see [issuer+verifier/src/cre
 
 **JWT credential proofs (`proofs.jwt`)**
 
-When the request includes JWT credential proofs, the issuer flow builds a verification context from issuer metadata (`credential_issuer`) and `options.proofJwt`, and passes it to the [credential-proof-jwt provider](https://github.com/trustknots/vcknots/blob/main/issuer%2Bverifier/src/providers/credential-proof-jwt.provider.ts) so claims such as `aud` and `iss` are checked per OID4VCI.
-
 - **Pre-authorized code flow**: use `proofJwt: { usePreAuth: true }`. The proof JWT must **not** carry an **`iss`** claim.
-- **Authorization code flow** (or similar client-bound context): use `proofJwt: { usePreAuth: false, clientId: '...' }` with the OAuth `client_id` for that credential request. `iss` must equal that `client_id` or the Credential Issuer Identifier.
+- **Authorization code flow**: Not supported.
 
-If you omit `proofJwt`, JWT proofs are treated like the authorization-code path (`usePreAuth: false`). With no `clientId`, only the Credential Issuer Identifier is effectively available for `iss` comparison when `iss` is present. Set `proofJwt` explicitly to match your token flow.
+#### JWT proof JOSE protected header
+
+For protected-header validation behavior, see [credential-proof-jwt.provider.ts](https://github.com/trustknots/vcknots/blob/main/issuer%2Bverifier/src/providers/credential-proof-jwt.provider.ts). The normative description is in [OpenID for Verifiable Credential Issuance 1.0 — JWT proof type](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-jwt-proof-type) (chapter and section numbers may change in revised specifications).
+
+- **`typ`**: Must be `openid4vci-proof+jwt` (explicit typing per RFC 8725).
+- **`alg`**: `none` and symmetric signatures (MAC, IANA JWA identifiers starting with `HS*`) are rejected.
+- **`kid` / `jwk` / `x5c`**: **Must not appear more than one at a time.** **At least one** of them is required (if none are present, the result is `INVALID_PROOF`).
+- **`trust_chain`**: Not currently supported.
+
+Per-header behavior:
+
+| Header | Behavior |
+|--------|----------|
+| **`kid`** | Resolved as a DID URL (`did:…` with an optional `#fragment`) via **`did-provider`**; the signature is verified with the public key of the matching `verificationMethod`. |
+| **`jwk`** | Verification uses the JWK in the header. JWKs that include **private key material (e.g. `d`)** are rejected. |
+| **`x5c`** | The certificate chain is validated with **`certificate-provider`**, then the signature is verified with the public key of the leaf certificate. When using `x5c`, register **`certificate-provider`** in the provider list when initializing Vcknots. |
 
 **Error cases**:
 - `ISSUER_NOT_FOUND`: An unregistered Issuer is configured
@@ -782,7 +795,7 @@ If you omit `proofJwt`, JWT proofs are treated like the authorization-code path 
 - `INVALID_REQUEST`: `format` is not set
 - `UNSUPPORTED_CREDENTIAL_TYPE`: The specified `credential_definition` or `proof_type` is not supported
 - `INVALID_CREDENTIAL_REQUEST`: The `proof` is missing or not supported, or the configuration id is invalid, etc.
-- `INVALID_PROOF`: The `proof` cannot be verified, an unsupported header is set, or a `nonce` is missing
+- `INVALID_PROOF`: The `proof` cannot be verified, the header does not conform to OID4VCI JWT proof rules (e.g. `typ` / `alg` / combinations of `kid`, `jwk`, and `x5c`), an unsupported header is set, or a `nonce` is missing
 - `UNSUPPORTED_ISSUER_KEY_ALG`: The Issuer’s signing algorithm is not supported
 - `AUTHZ_ISSUER_KEY_NOT_FOUND`: The Issuer’s key cannot be found
 - `INTERNAL_SERVER_ERROR`: Signing failed

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -770,12 +770,26 @@ issueCredential(
 
 **JWT クレデンシャルプルーフ（`proofs.jwt`）について**
 
-リクエストに JWT 形式のクレデンシャルプルーフが含まれる場合、Issuer はメタデータの `credential_issuer` と `options.proofJwt` から検証コンテキストを組み立て、[credential-proof-jwt プロバイダー](https://github.com/trustknots/vcknots/blob/main/issuer%2Bverifier/src/providers/credential-proof-jwt.provider.ts)に渡して `aud` / `iss` 等を OID4VCI に沿って検証します。
-
 - **事前認可コードフロー**でアクセストークンを得ている場合: `proofJwt: { usePreAuth: true }`。プルーフ JWT に **`iss` クレームを付けない**必要があります。
-- **認可コードフロー**など通常のクライアント文脈の場合: `proofJwt: { usePreAuth: false, clientId: '...' }`（当該クレデンシャルリクエストの OAuth `client_id`）。`iss` はその `client_id` または Credential Issuer Identifier と一致する必要があります。
+- **認可コードフロー**：未対応
 
-`proofJwt` を省略した場合、JWT プルーフは「認可コード側」の扱い（`usePreAuth: false`）となり、`clientId` 未指定時は `iss` の比較対象が Credential Issuer Identifier のみ実質有効になります。フローに合わせて明示的に設定してください。
+
+#### JWT proof の JOSE 保護ヘッダ
+
+JOSE 保護ヘッダの検証内容は [credential-proof-jwt.provider.ts](https://github.com/trustknots/vcknots/blob/main/issuer%2Bverifier/src/providers/credential-proof-jwt.provider.ts) を参照してください。根拠となる記述は [OpenID for Verifiable Credential Issuance 1.0 — JWT proof type](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-jwt-proof-type) を参照してください（仕様の章・節番号は改訂で変わる場合があります）。
+
+- **`typ`**: `openid4vci-proof+jwt` であること（RFC 8725 に基づく明示的タイピング）。
+- **`alg`**: `none` および IANA JWA の **対称署名（MAC、`HS*` で始まる識別子）** は拒否されます。
+- **`kid` / `jwk` / `x5c`**: **同時に複数を含めてはいけません**。また **少なくともいずれか 1 つは必須**です（いずれも無い場合も `INVALID_PROOF`）。
+- **`trust_chain`**: 現在未対応です。
+
+keyごとの動き:
+
+| ヘッダ | 動き |
+|--------|------|
+| **`kid`** | DID URL（`did:…` とオプションの `#fragment`）として **`did-provider`** で解決し、該当する `verificationMethod` の公開鍵で署名を検証します。 |
+| **`jwk`** | ヘッダ内の JWK で検証します。**秘密鍵材料（例: `d`）が含まれる JWK は拒否**されます。 |
+| **`x5c`** | 証明書チェーンを **`certificate-provider`** で検証したうえで、先頭証明書の公開鍵で検証します。`x5c` を使う構成では、Vcknots 初期化時に **`certificate-provider` をプロバイダ一覧へ登録**してください。 |
 
 **エラーケース**:
 - `ISSUER_NOT_FOUND`: 未登録のIssuerが設定された
@@ -783,7 +797,7 @@ issueCredential(
 - `INVALID_REQUEST`: `format`が未設定
 - `UNSUPPORTED_CREDENTIAL_TYPE`: 指定された`credential_definition`もしくは`proof_type`がサポートされていない
 - `INVALID_CREDENTIAL_REQUEST`: `proof`が見つからないかサポートされていない、設定 ID 不備など
-- `INVALID_PROOF`: `proof`が検証できない、未サポートのheaderが設定された、`nonce`が見つからない
+- `INVALID_PROOF`: `proof`が検証できない、OID4VCI の JWT proof に合わないヘッダ（`typ` / `alg` / `kid`・`jwk`・`x5c` の組み合わせなど）、未サポートの header、`nonce`が見つからない
 - `UNSUPPORTED_ISSUER_KEY_ALG`: Issuerの署名アルゴリズムがサポートされていない
 - `AUTHZ_ISSUER_KEY_NOT_FOUND`: Issuerの鍵が見つからない
 - `INTERNAL_SERVER_ERROR`: 署名に失敗した

--- a/issuer+verifier/src/credential-proof-jwt.types.ts
+++ b/issuer+verifier/src/credential-proof-jwt.types.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 import { CredentialIssuer } from './credential-issuer.types'
 
-/** OID4VCI JWT proof: aud must match credentialIssuer; iss rules depend on usePreAuth (draft 13 §7.2.1.1). */
 export const credentialProofJwtVerifyContextSchema = z.discriminatedUnion('usePreAuth', [
   z.object({
     usePreAuth: z.literal(true),

--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -258,11 +258,6 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
               message: 'Failed to verify Proof.',
             })
           }
-          if (!verifyProof.header.kid) {
-            throw err('INVALID_PROOF', {
-              message: 'Unsupported proof header.',
-            })
-          }
           subject = verifyProof.header.kid
 
           if (options?.cnonce) {

--- a/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
+++ b/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
@@ -10,6 +10,9 @@ import { DiVpProof } from '../proofs.types'
 const DEFAULT_PROOF_JWT_MAX_TOKEN_AGE_SECONDS = 300
 const DEFAULT_PROOF_JWT_CLOCK_TOLERANCE_SECONDS = 60
 
+/** OID4VCI §7.2.1.1 — JWT proof JOSE header `typ` (explicit typing per RFC 8725 §3.11). */
+export const OID4VCI_JWT_PROOF_TYP = 'openid4vci-proof+jwt'
+
 /** Options for {@link credentialProofJWT} (proof JWT `iat` window per OID4VCI §7.2.2). */
 export type CredentialProofJwtFactoryOptions = {
   /** Maximum age of proof JWT `iat` in seconds. Default: 300 (5 minutes). */
@@ -60,6 +63,11 @@ export const credentialProofJWT = (
       if (typeof proofAlg !== 'string') {
         throw raise('INVALID_PROOF', {
           message: 'Unsupported Proof Header alg value.',
+        })
+      }
+      if (proofJwtHeader.typ !== OID4VCI_JWT_PROOF_TYP) {
+        throw raise('INVALID_PROOF', {
+          message: `Proof JWT header typ must be "${OID4VCI_JWT_PROOF_TYP}".`,
         })
       }
       let publicKeyJwk: JsonWebKey

--- a/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
+++ b/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
@@ -13,7 +13,7 @@ const DEFAULT_PROOF_JWT_CLOCK_TOLERANCE_SECONDS = 60
 /** OID4VCI §F.1 — JWT proof JOSE header `typ` (explicit typing per RFC 8725 §3.11). */
 export const OID4VCI_JWT_PROOF_TYP = 'openid4vci-proof+jwt'
 
-/** OID4VCI §7.2.1.1 — `alg` MUST NOT be `none` or an IANA symmetric (HMAC) JWS algorithm. */
+/** OID4VCI §F.1 — `alg` MUST NOT be `none` or an IANA symmetric (HMAC) JWS algorithm. */
 function isProhibitedProofJwtAlg(alg: string): boolean {
   const trimmed = alg.trim()
   if (trimmed.length === 0) return true
@@ -22,7 +22,7 @@ function isProhibitedProofJwtAlg(alg: string): boolean {
   return /^hs/i.test(trimmed)
 }
 
-/** Options for {@link credentialProofJWT} (proof JWT `iat` window per OID4VCI §7.2.2). */
+/** Options for {@link credentialProofJWT} (proof JWT `iat` validation per OID4VCI 1.0 §F.1). */
 export type CredentialProofJwtFactoryOptions = {
   /** Maximum age of proof JWT `iat` in seconds. Default: 300 (5 minutes). */
   maxTokenAgeSeconds?: number

--- a/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
+++ b/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
@@ -1,4 +1,11 @@
-import { decodeJwt, decodeProtectedHeader, importJWK, jwtVerify } from 'jose'
+import {
+  decodeJwt,
+  decodeProtectedHeader,
+  importJWK,
+  importSPKI,
+  jwtVerify,
+  type JWSHeaderParameters,
+} from 'jose'
 import { ProofJwt } from '../credential.types'
 import { raise } from '../errors/vcknots.error'
 import { WithProviderRegistry, withProviderRegistry } from './provider.registry'
@@ -6,9 +13,14 @@ import type { CredentialProofJwtVerifyContext } from '../credential-proof-jwt.ty
 import type { CredentialProofProvider } from './provider.types'
 import { selectProvider } from './provider.utils'
 import { DiVpProof } from '../proofs.types'
+import type { ProviderRegistry } from './provider.registry'
 
 const DEFAULT_PROOF_JWT_MAX_TOKEN_AGE_SECONDS = 300
 const DEFAULT_PROOF_JWT_CLOCK_TOLERANCE_SECONDS = 60
+const PROOF_JWT_MUTUALLY_EXCLUSIVE_HEADER_MESSAGE =
+  'Proof JWT header: kid, jwk, and x5c are mutually exclusive (OID4VCI 1.0 §F.1).'
+const PROOF_JWT_MISSING_KEY_REFERENCE_MESSAGE =
+  'Proof JWT header must contain one of kid, jwk, or x5c (OID4VCI 1.0 §F.1).'
 
 /** OID4VCI §F.1 — JWT proof JOSE header `typ` (explicit typing per RFC 8725 §3.11). */
 export const OID4VCI_JWT_PROOF_TYP = 'openid4vci-proof+jwt'
@@ -20,6 +32,147 @@ function isProhibitedProofJwtAlg(alg: string): boolean {
   if (trimmed.toLowerCase() === 'none') return true
   // JWA HMAC family: HS256, HS384, HS512, HS512/256, …
   return /^hs/i.test(trimmed)
+}
+
+function resolveProofBindingMethod(header: JWSHeaderParameters): 'kid' | 'jwk' | 'x5c' {
+  const hasKid = typeof header.kid === 'string' && header.kid.trim().length > 0
+  const hasJwk = header.jwk !== undefined
+  const hasX5c = Array.isArray(header.x5c) && header.x5c.length > 0
+  const present = [hasKid, hasJwk, hasX5c].filter(Boolean).length
+
+  if (present === 0) {
+    throw raise('INVALID_PROOF', {
+      message: PROOF_JWT_MISSING_KEY_REFERENCE_MESSAGE,
+    })
+  }
+  if (present > 1) {
+    throw raise('INVALID_PROOF', {
+      message: PROOF_JWT_MUTUALLY_EXCLUSIVE_HEADER_MESSAGE,
+    })
+  }
+  if (hasKid) return 'kid'
+  if (hasJwk) return 'jwk'
+  return 'x5c'
+}
+
+function derBase64ToPem(derBase64: string): string {
+  const body =
+    derBase64
+      .replace(/\s+/g, '')
+      .match(/.{1,64}/g)
+      ?.join('\n') ?? derBase64
+  return `-----BEGIN CERTIFICATE-----\n${body}\n-----END CERTIFICATE-----\n`
+}
+
+async function resolveDidPublicKeyJwk(
+  providers: ProviderRegistry,
+  kid: string
+): Promise<JsonWebKey> {
+  const didSplit = kid.split(':')
+  if (didSplit.length < 3 || didSplit[0] !== 'did') {
+    throw raise('INVALID_PROOF', {
+      message: `Invalid DID format: ${kid}`,
+    })
+  }
+
+  const didProvider$ = providers.get('did-provider')
+  if (!didProvider$ || didProvider$.length === 0) {
+    throw raise('INVALID_PROOF', {
+      message: 'No kid or unsupported did type detected.',
+    })
+  }
+  const didProvider = selectProvider(didProvider$, didSplit[1])
+
+  const did = kid.split('#')[0] ?? kid
+  let didDoc = await didProvider.resolveDid(kid).catch(() => null)
+  if (!didDoc && did !== kid) {
+    didDoc = await didProvider.resolveDid(did).catch(() => null)
+  }
+
+  const verificationMethod =
+    didDoc?.verificationMethod?.find((it) => it.id === kid) ??
+    didDoc?.verificationMethod?.find((it) => it.publicKeyJwk !== undefined)
+
+  if (!verificationMethod?.publicKeyJwk) {
+    throw raise('INVALID_PROOF', {
+      message: 'Unsupported did type detected.',
+    })
+  }
+
+  return verificationMethod.publicKeyJwk
+}
+
+async function resolveHeaderPublicKey(
+  providers: ProviderRegistry,
+  proofJwtHeader: JWSHeaderParameters,
+  proofAlg: string
+): Promise<CryptoKey | Uint8Array> {
+  const bindingMethod = resolveProofBindingMethod(proofJwtHeader)
+
+  if (bindingMethod === 'kid') {
+    const publicKeyJwk = await resolveDidPublicKeyJwk(providers, proofJwtHeader.kid as string)
+    return await importJWK(publicKeyJwk, proofAlg)
+  }
+
+  if (bindingMethod === 'jwk') {
+    const jwk = proofJwtHeader.jwk
+    if (jwk === null || typeof jwk !== 'object' || Array.isArray(jwk)) {
+      throw raise('INVALID_PROOF', {
+        message: 'Proof JWT header jwk must be a JSON object.',
+      })
+    }
+    if ('d' in jwk && jwk.d !== undefined) {
+      throw raise('INVALID_PROOF', {
+        message: 'Proof JWT header jwk must contain a public key only.',
+      })
+    }
+    try {
+      return await importJWK(jwk as JsonWebKey, proofAlg)
+    } catch (e) {
+      throw raise('INVALID_PROOF', {
+        message: `Failed to import proof JWT jwk: ${e instanceof Error ? e.message : String(e)}`,
+        cause: e,
+      })
+    }
+  }
+
+  if (bindingMethod === 'x5c') {
+    const x5c = proofJwtHeader.x5c
+    if (!Array.isArray(x5c) || x5c.length === 0) {
+      throw raise('INVALID_PROOF', {
+        message: 'Proof JWT header x5c must contain at least one certificate.',
+      })
+    }
+
+    const certificate$ = providers.get('certificate-provider')
+    const certificateChain = x5c.map(derBase64ToPem)
+    const certValid = await certificate$.validate(certificateChain)
+    if (!certValid) {
+      throw raise('INVALID_PROOF', {
+        message: 'x5c certificate chain is invalid.',
+      })
+    }
+
+    const publicKeyPem = certificate$.getPublicKey(certificateChain[0])
+    if (!publicKeyPem) {
+      throw raise('INVALID_PROOF', {
+        message: 'Unable to extract public key from x5c certificate chain.',
+      })
+    }
+
+    try {
+      return await importSPKI(publicKeyPem, proofAlg)
+    } catch (e) {
+      throw raise('INVALID_PROOF', {
+        message: `Failed to import proof JWT x5c public key: ${e instanceof Error ? e.message : String(e)}`,
+        cause: e,
+      })
+    }
+  }
+
+  throw raise('INVALID_PROOF', {
+    message: `Unsupported proof binding method: ${bindingMethod satisfies never}`,
+  })
 }
 
 /** Options for {@link credentialProofJWT} (proof JWT `iat` validation per OID4VCI 1.0 §F.1). */
@@ -84,36 +237,8 @@ export const credentialProofJWT = (
           message: `Proof JWT header typ must be "${OID4VCI_JWT_PROOF_TYP}".`,
         })
       }
-      let publicKeyJwk: JsonWebKey
-      if (proofJwtHeader.kid) {
-        const didSplit = proofJwtHeader.kid.split(':')
-        if (didSplit.length < 3 || didSplit[0] !== 'did') {
-          throw raise('INVALID_PROOF', {
-            message: `Invalid DID format: ${proofJwtHeader.kid}`,
-          })
-        }
-        const didProvider$ = this.providers.get('did-provider')
-        if (!didProvider$ || didProvider$.length === 0) {
-          throw raise('INVALID_PROOF', {
-            message: 'No kid or unsupported did type detected.',
-          })
-        }
-        const didProvider = selectProvider(didProvider$, didSplit[1])
-        const didDoc = await didProvider.resolveDid(proofJwtHeader.kid)
-        if (!didDoc || !didDoc.verificationMethod || !didDoc.verificationMethod[0].publicKeyJwk) {
-          throw raise('INVALID_PROOF', {
-            message: 'Unsupported did type detected.',
-          })
-        }
-        publicKeyJwk = didDoc.verificationMethod[0].publicKeyJwk
-      } else {
-        throw raise('INVALID_PROOF', {
-          message: 'Unsupported Proof Header.',
-        })
-      }
-
-      const keyJwk = await importJWK(publicKeyJwk, proofAlg)
-      const protectedProof = await jwtVerify(proof, keyJwk, {
+      const verificationKey = await resolveHeaderPublicKey(this.providers, proofJwtHeader, proofAlg)
+      const protectedProof = await jwtVerify(proof, verificationKey, {
         algorithms: [proofAlg],
         maxTokenAge,
         clockTolerance,

--- a/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
+++ b/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
@@ -7,7 +7,24 @@ import type { CredentialProofProvider } from './provider.types'
 import { selectProvider } from './provider.utils'
 import { DiVpProof } from '../proofs.types'
 
-export const credentialProofJWT = (): CredentialProofProvider & WithProviderRegistry => {
+const DEFAULT_PROOF_JWT_MAX_TOKEN_AGE_SECONDS = 300
+const DEFAULT_PROOF_JWT_CLOCK_TOLERANCE_SECONDS = 60
+
+/** Options for {@link credentialProofJWT} (proof JWT `iat` window per OID4VCI §7.2.2). */
+export type CredentialProofJwtFactoryOptions = {
+  /** Maximum age of proof JWT `iat` in seconds. Default: 300 (5 minutes). */
+  maxTokenAgeSeconds?: number
+  /** Clock skew tolerance in seconds for time-based claims. Default: 60. */
+  clockToleranceSeconds?: number
+}
+
+export const credentialProofJWT = (
+  factoryOptions?: CredentialProofJwtFactoryOptions
+): CredentialProofProvider & WithProviderRegistry => {
+  const maxTokenAge = factoryOptions?.maxTokenAgeSeconds ?? DEFAULT_PROOF_JWT_MAX_TOKEN_AGE_SECONDS
+  const clockTolerance =
+    factoryOptions?.clockToleranceSeconds ?? DEFAULT_PROOF_JWT_CLOCK_TOLERANCE_SECONDS
+
   return {
     kind: 'credential-proof-provider',
     name: 'default-credential-proof-jwt-provider',
@@ -76,6 +93,20 @@ export const credentialProofJWT = (): CredentialProofProvider & WithProviderRegi
       const keyJwk = await importJWK(publicKeyJwk, proofAlg)
       const protectedProof = await jwtVerify(proof, keyJwk, {
         algorithms: [proofAlg],
+        maxTokenAge,
+        clockTolerance,
+      }).catch((e: unknown) => {
+        const code =
+          e !== null && typeof e === 'object' && 'code' in e
+            ? String((e as { code: unknown }).code)
+            : undefined
+        if (code === 'ERR_JWT_EXPIRED' || code === 'ERR_JWT_CLAIM_VALIDATION_FAILED') {
+          throw raise('INVALID_PROOF', {
+            message: 'Proof JWT is outside the allowed issuance time window.',
+            cause: e,
+          })
+        }
+        throw e
       })
 
       if (

--- a/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
+++ b/issuer+verifier/src/providers/credential-proof-jwt.provider.ts
@@ -10,8 +10,17 @@ import { DiVpProof } from '../proofs.types'
 const DEFAULT_PROOF_JWT_MAX_TOKEN_AGE_SECONDS = 300
 const DEFAULT_PROOF_JWT_CLOCK_TOLERANCE_SECONDS = 60
 
-/** OID4VCI §7.2.1.1 — JWT proof JOSE header `typ` (explicit typing per RFC 8725 §3.11). */
+/** OID4VCI §F.1 — JWT proof JOSE header `typ` (explicit typing per RFC 8725 §3.11). */
 export const OID4VCI_JWT_PROOF_TYP = 'openid4vci-proof+jwt'
+
+/** OID4VCI §7.2.1.1 — `alg` MUST NOT be `none` or an IANA symmetric (HMAC) JWS algorithm. */
+function isProhibitedProofJwtAlg(alg: string): boolean {
+  const trimmed = alg.trim()
+  if (trimmed.length === 0) return true
+  if (trimmed.toLowerCase() === 'none') return true
+  // JWA HMAC family: HS256, HS384, HS512, HS512/256, …
+  return /^hs/i.test(trimmed)
+}
 
 /** Options for {@link credentialProofJWT} (proof JWT `iat` window per OID4VCI §7.2.2). */
 export type CredentialProofJwtFactoryOptions = {
@@ -63,6 +72,11 @@ export const credentialProofJWT = (
       if (typeof proofAlg !== 'string') {
         throw raise('INVALID_PROOF', {
           message: 'Unsupported Proof Header alg value.',
+        })
+      }
+      if (isProhibitedProofJwtAlg(proofAlg)) {
+        throw raise('INVALID_PROOF', {
+          message: 'Proof JWT alg must not be "none" or a symmetric (MAC) algorithm.',
         })
       }
       if (proofJwtHeader.typ !== OID4VCI_JWT_PROOF_TYP) {

--- a/issuer+verifier/src/providers/index.ts
+++ b/issuer+verifier/src/providers/index.ts
@@ -1,6 +1,7 @@
 export * from './provider.types'
 export * from './provider.registry'
 
+export * from './credential-proof-jwt.provider'
 export * from './credential-offer.provider'
 
 export * from './presentation-exchange.provider'

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -893,8 +893,7 @@ describe('IssuerFlow', () => {
       })
     })
 
-    it('should throw "INVALID_PROOF" if verified proof has no kid in header', async () => {
-      // 1. Arrange
+    it('should issue a credential when verified proof header has no kid (e.g. jwk/x5c binding)', async () => {
       const issuer = CredentialIssuer('did:example:issuer')
       const metadata = {
         credential_issuer: issuer,
@@ -911,20 +910,33 @@ describe('IssuerFlow', () => {
         proofs: { jwt: ['dummy-jwt'] },
       })
       const verifiedProofWithoutKid = {
-        header: { alg: 'ES256K' }, // kid is missing
+        header: { alg: 'ES256K' },
         payload: { iss: 'did:example:user', aud: issuer, nonce: 'nonce' },
       }
+      const signedCredential = 'signed.credential.jwt'
       mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
       mock.method(mockCredentialProofProvider, 'verifyProof', async () => verifiedProofWithoutKid)
+      mock.method(mockIssueCredentialProvider, 'createCredential', async () => signedCredential)
       mockCredentialProofProvider.canHandle.mock.mockImplementation(
         (type) => type === ProofTypes.JWT
       )
+      mockIssueCredentialProvider.canHandle.mock.mockImplementation(
+        (format) => format === CredentialFormats.JWT_VC_JSON
+      )
 
-      // 2. Act & 3. Assert
-      await assert.rejects(issuerFlow.issueCredential(issuer, credentialRequest), {
-        name: 'INVALID_PROOF',
-        message: 'Unsupported proof header.',
-      })
+      const response = await issuerFlow.issueCredential(issuer, credentialRequest, { alg: 'ES256' })
+
+      assert.ok(response)
+      assert.equal(response.credentials?.[0]?.credential, signedCredential)
+      assert.equal(mockIssueCredentialProvider.createCredential.mock.callCount(), 1)
+      assert.deepStrictEqual(
+        mockIssueCredentialProvider.createCredential.mock.calls[0].arguments[2],
+        {
+          subject: undefined,
+          claims: undefined,
+          keyAlg: 'ES256',
+        }
+      )
     })
 
     it('should issue a credential when a valid c_nonce proof is provided', async () => {

--- a/issuer+verifier/test/providers/credential-proof-jwt.provider.spec.ts
+++ b/issuer+verifier/test/providers/credential-proof-jwt.provider.spec.ts
@@ -1,3 +1,6 @@
+import { X509Certificate } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import assert from 'node:assert/strict'
 import { describe, it, before, mock } from 'node:test'
 import {
@@ -7,14 +10,43 @@ import {
 import type { CredentialProofJwtVerifyContext } from '../../src/credential-proof-jwt.types'
 import { CredentialIssuer } from '../../src/credential-issuer.types'
 import type { CredentialProofProvider, DidProvider } from '../../src/providers/provider.types'
-import { WithProviderRegistry } from '../../src/providers/provider.registry'
-import { generateKeyPair, SignJWT, exportJWK, JWTPayload } from 'jose'
-import { VcknotsError, raise } from '../../src/errors/vcknots.error'
-import { DidDocument, JsonWebKey } from '../../src/did.types'
+import type { WithProviderRegistry } from '../../src/providers/provider.registry'
+import { certificate } from '../../src/providers/certificate.provider'
+import {
+  exportJWK,
+  generateKeyPair,
+  importPKCS8,
+  type JWTHeaderParameters,
+  type JWTPayload,
+  SignJWT,
+} from 'jose'
+import { raise, type VcknotsError } from '../../src/errors/vcknots.error'
+import type { DidDocument, JsonWebKey } from '../../src/did.types'
 
 describe('CredentialProofJwtProvider', () => {
+  const resolveSamplePath = (fileName: string): string => {
+    const candidates = [
+      join(process.cwd(), 'server/samples/certificate-openid-test', fileName),
+      join(process.cwd(), '../server/samples/certificate-openid-test', fileName),
+    ]
+    const path = candidates.find((candidate) => existsSync(candidate))
+    assert(path, `sample file not found: ${fileName}`)
+    return path
+  }
+
+  const certificatePem = readFileSync(
+    resolveSamplePath('certificate_openid.pem'),
+    'utf-8'
+  )
+  const privateKeyPem = readFileSync(
+    resolveSamplePath('private_key_openid.pem'),
+    'utf-8'
+  )
+
   let keys: { publicKey: CryptoKey; privateKey: CryptoKey }
   let publicKeyJwk: JsonWebKey
+  let x5cPrivateKey: CryptoKey
+  let x5cHeaderValue: string
   const credentialIssuer = CredentialIssuer('https://issuer.example.com')
   const clientId = 'test-client'
   const testDid = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH'
@@ -61,7 +93,7 @@ describe('CredentialProofJwtProvider', () => {
     payload: JWTPayload,
     alg: string,
     kid: string,
-    customHeader?: object
+    customHeader?: Partial<JWTHeaderParameters>
   ) => {
     return await new SignJWT(payload)
       .setProtectedHeader({ alg, kid, typ: OID4VCI_JWT_PROOF_TYP, ...customHeader })
@@ -69,11 +101,24 @@ describe('CredentialProofJwtProvider', () => {
       .sign(keys.privateKey)
   }
 
+  const createTestProofWithHeader = async (
+    payload: JWTPayload,
+    protectedHeader: JWTHeaderParameters,
+    signKey: CryptoKey = keys.privateKey
+  ) => {
+    return await new SignJWT(payload)
+      .setProtectedHeader(protectedHeader)
+      .setIssuedAt()
+      .sign(signKey)
+  }
+
   before(async () => {
     keys = await generateKeyPair('ES256')
     const jwk = await exportJWK(keys.publicKey)
     assert(jwk.kty, 'kty must be defined')
     publicKeyJwk = jwk as JsonWebKey
+    x5cPrivateKey = await importPKCS8(privateKeyPem, 'ES256')
+    x5cHeaderValue = new X509Certificate(certificatePem).raw.toString('base64')
   })
 
   it('should have correct properties', () => {
@@ -92,6 +137,10 @@ describe('CredentialProofJwtProvider', () => {
   describe('verifyProof', () => {
     const prohibitedProofJwtAlgMessage =
       'Proof JWT alg must not be "none" or a symmetric (MAC) algorithm.'
+    const mutualExclusiveKidJwkX5cMessage =
+      'Proof JWT header: kid, jwk, and x5c are mutually exclusive (OID4VCI 1.0 §F.1).'
+    const missingKidJwkX5cMessage =
+      'Proof JWT header must contain one of kid, jwk, or x5c (OID4VCI 1.0 §F.1).'
 
     const setupProvider = (): CredentialProofProvider & WithProviderRegistry => {
       const provider = credentialProofJWT()
@@ -99,6 +148,9 @@ describe('CredentialProofJwtProvider', () => {
       mock.method(provider.providers, 'get', (name: string) => {
         if (name === 'did-provider') {
           return [mockDidProvider]
+        }
+        if (name === 'certificate-provider') {
+          return certificate()
         }
         return []
       })
@@ -210,15 +262,98 @@ describe('CredentialProofJwtProvider', () => {
       })
     })
 
-    it('should throw INVALID_PROOF if kid is missing in header', async () => {
+    it('should verify a valid proof when jwk is used in header', async () => {
       const provider = setupProvider()
-      const proof = await new SignJWT({ aud: credentialIssuer })
-        .setProtectedHeader({ alg: 'ES256', typ: OID4VCI_JWT_PROOF_TYP }) // No kid
-        .sign(keys.privateKey)
-      await assert.rejects(provider.verifyProof(proof), (err: VcknotsError) => {
-        assert.equal(err.name, 'INVALID_PROOF')
-        assert.equal(err.message, 'Unsupported Proof Header.')
-        return true
+      const proof = await createTestProofWithHeader(
+        { aud: credentialIssuer, nonce: 'test-nonce' },
+        { alg: 'ES256', jwk: publicKeyJwk, typ: OID4VCI_JWT_PROOF_TYP }
+      )
+
+      const result = await provider.verifyProof(proof, preAuthCtx)
+
+      assert.ok(result)
+      assert.equal(result.payload.aud, credentialIssuer)
+      assert.deepEqual(result.header.jwk, publicKeyJwk)
+      assert.equal(result.header.typ, OID4VCI_JWT_PROOF_TYP)
+    })
+
+    it('should verify a valid proof when x5c is used in header', async () => {
+      const provider = setupProvider()
+      const proof = await createTestProofWithHeader(
+        { aud: credentialIssuer, nonce: 'test-nonce' },
+        { alg: 'ES256', typ: OID4VCI_JWT_PROOF_TYP, x5c: [x5cHeaderValue] },
+        x5cPrivateKey
+      )
+
+      const result = await provider.verifyProof(proof, preAuthCtx)
+
+      assert.ok(result)
+      assert.equal(result.payload.aud, credentialIssuer)
+      assert.deepEqual(result.header.x5c, [x5cHeaderValue])
+      assert.equal(result.header.typ, OID4VCI_JWT_PROOF_TYP)
+    })
+
+    it('should throw INVALID_PROOF if key reference header is missing', async () => {
+      const provider = setupProvider()
+      const proof = await createTestProofWithHeader(
+        { aud: credentialIssuer, nonce: 'test-nonce' },
+        { alg: 'ES256', typ: OID4VCI_JWT_PROOF_TYP }
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: missingKidJwkX5cMessage,
+      })
+    })
+
+    it('should throw INVALID_PROOF if kid and jwk are both present', async () => {
+      const provider = setupProvider()
+      const proof = await createTestProofWithHeader(
+        { aud: credentialIssuer, nonce: 'test-nonce' },
+        { alg: 'ES256', kid: testKid, jwk: publicKeyJwk, typ: OID4VCI_JWT_PROOF_TYP }
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: mutualExclusiveKidJwkX5cMessage,
+      })
+    })
+
+    it('should throw INVALID_PROOF if kid and x5c are both present', async () => {
+      const provider = setupProvider()
+      const proof = await createTestProofWithHeader(
+        { aud: credentialIssuer, nonce: 'test-nonce' },
+        { alg: 'ES256', kid: testKid, typ: OID4VCI_JWT_PROOF_TYP, x5c: [x5cHeaderValue] },
+        x5cPrivateKey
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: mutualExclusiveKidJwkX5cMessage,
+      })
+    })
+
+    it('should throw INVALID_PROOF if jwk and x5c are both present', async () => {
+      const provider = setupProvider()
+      const proof = await createTestProofWithHeader(
+        { aud: credentialIssuer, nonce: 'test-nonce' },
+        { alg: 'ES256', jwk: publicKeyJwk, typ: OID4VCI_JWT_PROOF_TYP, x5c: [x5cHeaderValue] },
+        x5cPrivateKey
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: mutualExclusiveKidJwkX5cMessage,
+      })
+    })
+
+    it('should throw INVALID_PROOF if header jwk contains private key material', async () => {
+      const provider = setupProvider()
+      const privateJwk = { ...publicKeyJwk, d: 'private-key-material' }
+      const proof = await createTestProofWithHeader(
+        { aud: credentialIssuer, nonce: 'test-nonce' },
+        { alg: 'ES256', jwk: privateJwk, typ: OID4VCI_JWT_PROOF_TYP },
+        keys.privateKey
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: 'Proof JWT header jwk must contain a public key only.',
       })
     })
 

--- a/issuer+verifier/test/providers/credential-proof-jwt.provider.spec.ts
+++ b/issuer+verifier/test/providers/credential-proof-jwt.provider.spec.ts
@@ -90,6 +90,9 @@ describe('CredentialProofJwtProvider', () => {
   })
 
   describe('verifyProof', () => {
+    const prohibitedProofJwtAlgMessage =
+      'Proof JWT alg must not be "none" or a symmetric (MAC) algorithm.'
+
     const setupProvider = (): CredentialProofProvider & WithProviderRegistry => {
       const provider = credentialProofJWT()
       // Mock the get method of the provider registry
@@ -147,6 +150,63 @@ describe('CredentialProofJwtProvider', () => {
       await assert.rejects(provider.verifyProof('invalid-jwt'), (err: VcknotsError) => {
         assert.equal(err.name, 'INVALID_PROOF')
         return true
+      })
+    })
+
+    const unverifiedProofJwt = (
+      header: Record<string, unknown>,
+      payload: Record<string, unknown>
+    ): string => {
+      const enc = (obj: Record<string, unknown>) =>
+        Buffer.from(JSON.stringify(obj)).toString('base64url')
+      return `${enc(header)}.${enc(payload)}.x`
+    }
+
+    it('should throw INVALID_PROOF if alg is none', async () => {
+      const provider = setupProvider()
+      const proof = unverifiedProofJwt(
+        { alg: 'none', typ: OID4VCI_JWT_PROOF_TYP, kid: testKid },
+        { aud: credentialIssuer, iat: Math.floor(Date.now() / 1000) }
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: prohibitedProofJwtAlgMessage,
+      })
+    })
+
+    it('should throw INVALID_PROOF if alg is None (case-insensitive)', async () => {
+      const provider = setupProvider()
+      const proof = unverifiedProofJwt(
+        { alg: 'None', typ: OID4VCI_JWT_PROOF_TYP, kid: testKid },
+        { aud: credentialIssuer, iat: Math.floor(Date.now() / 1000) }
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: prohibitedProofJwtAlgMessage,
+      })
+    })
+
+    it('should throw INVALID_PROOF if alg is HS256', async () => {
+      const provider = setupProvider()
+      const proof = unverifiedProofJwt(
+        { alg: 'HS256', typ: OID4VCI_JWT_PROOF_TYP, kid: testKid },
+        { aud: credentialIssuer, iat: Math.floor(Date.now() / 1000) }
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: prohibitedProofJwtAlgMessage,
+      })
+    })
+
+    it('should throw INVALID_PROOF if alg is hs384 (HMAC / symmetric family)', async () => {
+      const provider = setupProvider()
+      const proof = unverifiedProofJwt(
+        { alg: 'hs384', typ: OID4VCI_JWT_PROOF_TYP, kid: testKid },
+        { aud: credentialIssuer, iat: Math.floor(Date.now() / 1000) }
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: prohibitedProofJwtAlgMessage,
       })
     })
 

--- a/issuer+verifier/test/providers/credential-proof-jwt.provider.spec.ts
+++ b/issuer+verifier/test/providers/credential-proof-jwt.provider.spec.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 import { describe, it, before, mock } from 'node:test'
-import { credentialProofJWT } from '../../src/providers/credential-proof-jwt.provider'
+import {
+  credentialProofJWT,
+  OID4VCI_JWT_PROOF_TYP,
+} from '../../src/providers/credential-proof-jwt.provider'
 import type { CredentialProofJwtVerifyContext } from '../../src/credential-proof-jwt.types'
 import { CredentialIssuer } from '../../src/credential-issuer.types'
 import type { CredentialProofProvider, DidProvider } from '../../src/providers/provider.types'
@@ -61,7 +64,7 @@ describe('CredentialProofJwtProvider', () => {
     customHeader?: object
   ) => {
     return await new SignJWT(payload)
-      .setProtectedHeader({ alg, kid, ...customHeader })
+      .setProtectedHeader({ alg, kid, typ: OID4VCI_JWT_PROOF_TYP, ...customHeader })
       .setIssuedAt()
       .sign(keys.privateKey)
   }
@@ -110,6 +113,7 @@ describe('CredentialProofJwtProvider', () => {
       assert.equal(result.payload.aud, credentialIssuer)
       assert.equal(result.payload.nonce, 'test-nonce')
       assert.equal(result.header.alg, 'ES256')
+      assert.equal(result.header.typ, OID4VCI_JWT_PROOF_TYP)
       assert.equal(result.header.kid, testKid)
       assert.strictEqual(result.payload.iss, undefined)
     })
@@ -149,12 +153,38 @@ describe('CredentialProofJwtProvider', () => {
     it('should throw INVALID_PROOF if kid is missing in header', async () => {
       const provider = setupProvider()
       const proof = await new SignJWT({ aud: credentialIssuer })
-        .setProtectedHeader({ alg: 'ES256' }) // No kid
+        .setProtectedHeader({ alg: 'ES256', typ: OID4VCI_JWT_PROOF_TYP }) // No kid
         .sign(keys.privateKey)
       await assert.rejects(provider.verifyProof(proof), (err: VcknotsError) => {
         assert.equal(err.name, 'INVALID_PROOF')
         assert.equal(err.message, 'Unsupported Proof Header.')
         return true
+      })
+    })
+
+    it('should throw INVALID_PROOF if typ is not openid4vci-proof+jwt', async () => {
+      const provider = setupProvider()
+      const proof = await createTestProof(
+        { aud: credentialIssuer },
+        'ES256',
+        testKid,
+        { typ: 'JWT' }
+      )
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: `Proof JWT header typ must be "${OID4VCI_JWT_PROOF_TYP}".`,
+      })
+    })
+
+    it('should throw INVALID_PROOF if typ is missing in header', async () => {
+      const provider = setupProvider()
+      const proof = await new SignJWT({ aud: credentialIssuer })
+        .setProtectedHeader({ alg: 'ES256', kid: testKid })
+        .setIssuedAt()
+        .sign(keys.privateKey)
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: `Proof JWT header typ must be "${OID4VCI_JWT_PROOF_TYP}".`,
       })
     })
 
@@ -209,7 +239,7 @@ describe('CredentialProofJwtProvider', () => {
       const provider = setupProvider()
       const otherKeys = await generateKeyPair('ES256')
       const proof = await new SignJWT({ aud: credentialIssuer })
-        .setProtectedHeader({ alg: 'ES256', kid: testKid })
+        .setProtectedHeader({ alg: 'ES256', kid: testKid, typ: OID4VCI_JWT_PROOF_TYP })
         .setIssuedAt()
         .sign(otherKeys.privateKey) // Signed with a different key
       await assert.rejects(provider.verifyProof(proof), (err: Error & { code?: string }) => {
@@ -223,7 +253,7 @@ describe('CredentialProofJwtProvider', () => {
       const provider = setupProvider()
       const issuedAt = new Date(Date.now() - 400 * 1000)
       const proof = await new SignJWT({ aud: credentialIssuer, nonce: 'n' })
-        .setProtectedHeader({ alg: 'ES256', kid: testKid })
+        .setProtectedHeader({ alg: 'ES256', kid: testKid, typ: OID4VCI_JWT_PROOF_TYP })
         .setIssuedAt(issuedAt)
         .sign(keys.privateKey)
       await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
@@ -242,7 +272,7 @@ describe('CredentialProofJwtProvider', () => {
       })
       const issuedAt = new Date(Date.now() - 400 * 1000)
       const proof = await new SignJWT({ aud: credentialIssuer, nonce: 'n' })
-        .setProtectedHeader({ alg: 'ES256', kid: testKid })
+        .setProtectedHeader({ alg: 'ES256', kid: testKid, typ: OID4VCI_JWT_PROOF_TYP })
         .setIssuedAt(issuedAt)
         .sign(keys.privateKey)
       const result = await provider.verifyProof(proof, preAuthCtx)

--- a/issuer+verifier/test/providers/credential-proof-jwt.provider.spec.ts
+++ b/issuer+verifier/test/providers/credential-proof-jwt.provider.spec.ts
@@ -219,6 +219,36 @@ describe('CredentialProofJwtProvider', () => {
       })
     })
 
+    it('should throw INVALID_PROOF when proof JWT iat exceeds factory maxTokenAge', async () => {
+      const provider = setupProvider()
+      const issuedAt = new Date(Date.now() - 400 * 1000)
+      const proof = await new SignJWT({ aud: credentialIssuer, nonce: 'n' })
+        .setProtectedHeader({ alg: 'ES256', kid: testKid })
+        .setIssuedAt(issuedAt)
+        .sign(keys.privateKey)
+      await assert.rejects(provider.verifyProof(proof, preAuthCtx), {
+        name: 'INVALID_PROOF',
+        message: 'Proof JWT is outside the allowed issuance time window.',
+      })
+    })
+
+    it('should verify when iat is within a larger factory maxTokenAgeSeconds', async () => {
+      const provider = credentialProofJWT({ maxTokenAgeSeconds: 600 })
+      mock.method(provider.providers, 'get', (name: string) => {
+        if (name === 'did-provider') {
+          return [mockDidProvider]
+        }
+        return []
+      })
+      const issuedAt = new Date(Date.now() - 400 * 1000)
+      const proof = await new SignJWT({ aud: credentialIssuer, nonce: 'n' })
+        .setProtectedHeader({ alg: 'ES256', kid: testKid })
+        .setIssuedAt(issuedAt)
+        .sign(keys.privateKey)
+      const result = await provider.verifyProof(proof, preAuthCtx)
+      assert.ok(result)
+    })
+
     it('should throw INVALID_PROOF if payload claims are invalid (missing aud)', async () => {
       const provider = setupProvider()
       const proof = await createTestProof({ iss: clientId }, 'ES256', testKid) // Missing aud

--- a/server/single/src/example.ts
+++ b/server/single/src/example.ts
@@ -1,5 +1,13 @@
 import 'dotenv/config'
 import { createServer } from '@trustknots/server-core'
-
+import { credentialProofJWT } from '@trustknots/vcknots/providers'
 // Create a server in-memory Providers
-createServer()
+// createServer()
+createServer({
+  providers: [
+    credentialProofJWT({
+      maxTokenAgeSeconds: 600,
+      clockToleranceSeconds: 60,
+    }),
+  ],
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * JWT proof 要件を明確化：JOSE保護ヘッダの必須項目・禁止アルゴリズム・`kid`/`jwk`/`x5c` の相互排他と少なくとも1つ必須、`trust_chain` 未対応、INVALID_PROOF の説明強化。

* **New Features**
  * JWT proof 検証にトークン最大有効期間とクロック許容値を設定可能に。
  * 証明書チェーン（x5c）を用いたキー参照をサポート。

* **Tests**
  * 仕様に沿った多様な検証・境界ケースのテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->