### PR TITLE
fix(wallet): set empty User-Agent header in Request URI requests

### DIFF
--- a/wallet/presenter/plugins/oid4vp/oid4vp.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Oid4vpPresenter struct {
-	X509TrustChainRoots     *x509.CertPool
+	X509TrustChainRoots *x509.CertPool
 	// InsecureSkipX509Verify skips certificate verification for testing purposes.
 	// WARNING: This should NEVER be set to true in production environments.
 	// This is only for conformance testing with self-signed or non-standard certificates.
@@ -151,10 +151,10 @@ func (p *Oid4vpPresenter) Present(protocol types.SupportedPresentationProtocol, 
 func (p *Oid4vpPresenter) createJARMResponse(vpToken, presentationSubmission string, request *types.PresentationRequest, encAlg, encEnc string, verifierJWKS *jose.JSONWebKeySet) (string, error) {
 	// Create the response payload
 	payload := map[string]interface{}{
-		"vp_token":               vpToken,
+		"vp_token":                vpToken,
 		"presentation_submission": presentationSubmission,
 	}
-	
+
 	// Add state if present
 	if request != nil && request.State != "" {
 		payload["state"] = request.State
@@ -516,7 +516,7 @@ func (b *requestBuilder) WithRequestObject(obj string) *requestBuilder {
 	clientID, err := parseOID4VPClientID(b.req.ClientID)
 	if err == nil && clientID.prefix == OID4VPClientIDPrefixX509SanDNS {
 		var certificates *[]*x509.Certificate = nil
-		
+
 		if b.insecureSkipX509Verify {
 			// For testing: Parse certificates from x5c WITHOUT calling x509.Verify(),
 			// which in Go 1.20+ performs strict standards compliance checks that reject

--- a/wallet/presenter/plugins/oid4vp/oid4vp.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp.go
@@ -712,6 +712,7 @@ func (b *requestBuilder) WithRequestObjectURI(uri string, method RequestURIMetho
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 	}
+	req.Header.Set("User-Agent", "")
 	resp, err := client.Do(req)
 	if err != nil {
 		b.errValidation = fmt.Errorf("failed to send %s request to %s: %w", method, uri, err)

--- a/wallet/presenter/plugins/oid4vp/oid4vp_test.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -887,26 +888,37 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 		m := mockserver.NewMockServer()
 		defer m.Close()
 
+		var called atomic.Bool
+
 		m.HandleFunc("/request-object", func(w http.ResponseWriter, r *http.Request) {
-			if r.Header.Get("User-Agent") != "" {
-				t.Fatalf("User-Agent is not empty string")
+			called.Store(true)
+			if ua := r.Header.Get("User-Agent"); ua != "" {
+				t.Errorf("User-Agent is not empty string, got %q",ua)
 			}
+			w.WriteHeader(http.StatusOK)
 		})
 
 		requestObjectURI, _ := url.Parse(m.URL() + "/request-object")
 
 		rb := requestBuilder{}
 		rb.WithRequestObjectURI(requestObjectURI.String(), RequestURIMethodGET)
+		if !called.Load(){
+			t.Fatal("handler was not invoked")
+		}
 	})
 
 	t.Run("Delete default User-Agent header (POST)", func(t *testing.T) {
 		m :=mockserver.NewMockServer()
 		defer m.Close()
 
+		var called atomic.Bool
+
 		m.HandleFunc("/request-object",func(w http.ResponseWriter, r *http.Request) {
-			if r.Header.Get("User-Agent") != ""{
-				t.Fatalf("User-Agent is not empty string")
+			called.Store(true)
+			if ua := r.Header.Get("User-Agent"); ua != ""{
+				t.Errorf("User-Agent is not empty string,got %q",ua)
 			}
+			w.WriteHeader(http.StatusOK)
 		})
 		
 
@@ -914,5 +926,8 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 
 		rb := requestBuilder{}
 		rb.WithRequestObjectURI(requestObjectURI.String(),RequestURIMethodPOST)
+		if !called.Load(){
+			t.Fatal("handler was not invoked")
+		}
 	})
 }

--- a/wallet/presenter/plugins/oid4vp/oid4vp_test.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp_test.go
@@ -887,12 +887,12 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 		m := mockserver.NewMockServer()
 		defer m.Close()
 
-		called :=false
+		called := false
 
 		m.HandleFunc("/request-object", func(w http.ResponseWriter, r *http.Request) {
-			called = true 
+			called = true
 			if ua := r.Header.Get("User-Agent"); ua != "" {
-				t.Errorf("User-Agent is not empty string, got %q",ua)
+				t.Errorf("User-Agent is not empty string, got %q", ua)
 			}
 			w.WriteHeader(http.StatusOK)
 		})
@@ -901,21 +901,21 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 
 		rb := requestBuilder{}
 		rb.WithRequestObjectURI(requestObjectURI.String(), RequestURIMethodGET)
-		if !called{
+		if !called {
 			t.Fatal("handler was not invoked")
 		}
 	})
 
 	t.Run("Delete default User-Agent header (POST)", func(t *testing.T) {
-		m :=mockserver.NewMockServer()
+		m := mockserver.NewMockServer()
 		defer m.Close()
 
-		called :=false
+		called := false
 
 		m.HandleFunc("/request-object", func(w http.ResponseWriter, r *http.Request) {
-			called = true 
+			called = true
 			if ua := r.Header.Get("User-Agent"); ua != "" {
-				t.Errorf("User-Agent is not empty string, got %q",ua)
+				t.Errorf("User-Agent is not empty string, got %q", ua)
 			}
 			w.WriteHeader(http.StatusOK)
 		})
@@ -924,7 +924,7 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 
 		rb := requestBuilder{}
 		rb.WithRequestObjectURI(requestObjectURI.String(), RequestURIMethodPOST)
-		if !called{
+		if !called {
 			t.Fatal("handler was not invoked")
 		}
 	})

--- a/wallet/presenter/plugins/oid4vp/oid4vp_test.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp_test.go
@@ -881,3 +881,38 @@ func TestOid4vpPresenter_RequestObject_WithX5C_X509SanDNS_SuccessAndFailures(t *
 		t.Fatalf("expected hostname mismatch error, got: %v", err)
 	}
 }
+
+func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
+	t.Run("Delete default User-Agent header (GET)", func(t *testing.T) {
+		m := mockserver.NewMockServer()
+		defer m.Close()
+
+		m.HandleFunc("/request-object", func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("User-Agent") != "" {
+				t.Fatalf("User-Agent is not empty string")
+			}
+		})
+
+		requestObjectURI, _ := url.Parse(m.URL() + "/request-object")
+
+		rb := requestBuilder{}
+		rb.WithRequestObjectURI(requestObjectURI.String(), RequestURIMethodGET)
+	})
+
+	t.Run("Delete default User-Agent header (POST)", func(t *testing.T) {
+		m :=mockserver.NewMockServer()
+		defer m.Close()
+
+		m.HandleFunc("/request-object",func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("User-Agent") != ""{
+				t.Fatalf("User-Agent is not empty string")
+			}
+		})
+		
+
+		requestObjectURI, _ := url.Parse(m.URL() + "/request-object")
+
+		rb := requestBuilder{}
+		rb.WithRequestObjectURI(requestObjectURI.String(),RequestURIMethodPOST)
+	})
+}

--- a/wallet/presenter/plugins/oid4vp/oid4vp_test.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -888,10 +887,10 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 		m := mockserver.NewMockServer()
 		defer m.Close()
 
-		var called atomic.Bool
+		called :=false
 
 		m.HandleFunc("/request-object", func(w http.ResponseWriter, r *http.Request) {
-			called.Store(true)
+			called = true 
 			if ua := r.Header.Get("User-Agent"); ua != "" {
 				t.Errorf("User-Agent is not empty string, got %q",ua)
 			}
@@ -902,7 +901,7 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 
 		rb := requestBuilder{}
 		rb.WithRequestObjectURI(requestObjectURI.String(), RequestURIMethodGET)
-		if !called.Load(){
+		if !called{
 			t.Fatal("handler was not invoked")
 		}
 	})
@@ -911,22 +910,21 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 		m :=mockserver.NewMockServer()
 		defer m.Close()
 
-		var called atomic.Bool
+		called :=false
 
-		m.HandleFunc("/request-object",func(w http.ResponseWriter, r *http.Request) {
-			called.Store(true)
-			if ua := r.Header.Get("User-Agent"); ua != ""{
-				t.Errorf("User-Agent is not empty string,got %q",ua)
+		m.HandleFunc("/request-object", func(w http.ResponseWriter, r *http.Request) {
+			called = true 
+			if ua := r.Header.Get("User-Agent"); ua != "" {
+				t.Errorf("User-Agent is not empty string, got %q",ua)
 			}
 			w.WriteHeader(http.StatusOK)
 		})
-		
 
 		requestObjectURI, _ := url.Parse(m.URL() + "/request-object")
 
 		rb := requestBuilder{}
-		rb.WithRequestObjectURI(requestObjectURI.String(),RequestURIMethodPOST)
-		if !called.Load(){
+		rb.WithRequestObjectURI(requestObjectURI.String(), RequestURIMethodPOST)
+		if !called{
 			t.Fatal("handler was not invoked")
 		}
 	})


### PR DESCRIPTION
Request URI へのリクエストで User-Agent ヘッダーが見えないように空文字に設定しました。
以上の条件が満たせているかをGetとPostでテストしています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * HTTP リクエスト送信時の User-Agent ヘッダーの扱いを明確化しました。外部サービスとの互換性と送信の安定性が向上します。

* **テスト**
  * GET/POST のリクエストで User-Agent ヘッダーが送信されないことを検証する単体テストを追加しました。外部エンドポイントへの送信動作を確認しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->