### PR TITLE
fix: align issuer metadata with implementation

### DIFF
--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -186,7 +186,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
             "format": "jwt_vc_json",
             "scope": "UniversityDegree",
             "cryptographic_binding_methods_supported": [
-                "jwk"
+                "did:key"
             ],
             "proof_types_supported": {
                 "jwt": {
@@ -214,6 +214,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
                 "claims": [
                     {
                         "path": [
+                            "credentialSubject",
                             "given_name"
                         ],
                         "mandatory": true,
@@ -230,6 +231,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
                     },
                     {
                         "path": [
+                            "credentialSubject",
                             "family_name"
                         ],
                         "display": [
@@ -245,6 +247,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
                     },
                     {
                         "path": [
+                            "credentialSubject",
                             "degree"
                         ],
                         "display": [
@@ -260,6 +263,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
                     },
                     {
                         "path": [
+                            "credentialSubject",
                             "gpa"
                         ],
                         "display": [

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -186,7 +186,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
             "format": "jwt_vc_json",
             "scope": "UniversityDegree",
             "cryptographic_binding_methods_supported": [
-                "jwk"
+                "did:key"
             ],
             "proof_types_supported": {
                 "jwt": {
@@ -214,6 +214,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
                 "claims": [
                     {
                         "path": [
+                            "credentialSubject",
                             "given_name"
                         ],
                         "mandatory": true,
@@ -230,6 +231,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
                     },
                     {
                         "path": [
+                            "credentialSubject",
                             "family_name"
                         ],
                         "display": [
@@ -245,6 +247,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
                     },
                     {
                         "path": [
+                            "credentialSubject",
                             "degree"
                         ],
                         "display": [
@@ -260,6 +263,7 @@ curl http://localhost:8080/.well-known/openid-credential-issuer
                     },
                     {
                         "path": [
+                            "credentialSubject",
                             "gpa"
                         ],
                         "display": [

--- a/issuer+verifier/src/providers/issue-credential-jwt-vc-json.provider.ts
+++ b/issuer+verifier/src/providers/issue-credential-jwt-vc-json.provider.ts
@@ -14,6 +14,9 @@ export type IssueCredentialProviderOptions = {
   identifier?: () => string
 }
 
+const credentialSubjectPath = (path: string[]) =>
+  path[0] === 'credentialSubject' ? path.slice(1) : path
+
 export const issueCredentialJwt = (
   providerOptions?: IssueCredentialProviderOptions
 ): IssueCredentialProvider & WithProviderRegistry => {
@@ -48,14 +51,15 @@ export const issueCredentialJwt = (
       const defCredentialMetadataClaims = configuration.credential_metadata?.claims
       if (defCredentialMetadataClaims && defCredentialMetadataClaims.length > 0) {
         for (const claim of defCredentialMetadataClaims) {
-          const value = getClaimValue(claimsSource, claim.path)
+          const subjectPath = credentialSubjectPath(claim.path)
+          const value = getClaimValue(claimsSource, subjectPath)
           if (claim.mandatory === true && value === undefined) {
             throw raise('INVALID_CLAIMS', {
               message: `Claim ${claim.path.join('.')} is not defined as mandatory in the credential definition.`,
             })
           }
           if (value !== undefined) {
-            setClaimValue(credentialSubject, claim.path, value)
+            setClaimValue(credentialSubject, subjectPath, value)
           }
         }
       }

--- a/issuer+verifier/src/providers/issue-credential-jwt-vc-json.provider.ts
+++ b/issuer+verifier/src/providers/issue-credential-jwt-vc-json.provider.ts
@@ -14,8 +14,21 @@ export type IssueCredentialProviderOptions = {
   identifier?: () => string
 }
 
-const credentialSubjectPath = (path: string[]) =>
-  path[0] === 'credentialSubject' ? path.slice(1) : path
+// const credentialSubjectPath = (path: string[]) =>
+//   path[0] === 'credentialSubject' ? path.slice(1) : path
+
+const credentialSubjectPath = (path: string[]) => {
+  if (path[0] !== 'credentialSubject') {
+    return path
+  }
+  const subjectPath = path.slice(1)
+  if (subjectPath.length === 0) {
+    throw raise('INVALID_CONFIGURATION', {
+      message: 'credential_metadata.claims[].path must point to a claim under credentialSubject.',
+    })
+  }
+  return subjectPath
+}
 
 export const issueCredentialJwt = (
   providerOptions?: IssueCredentialProviderOptions
@@ -52,7 +65,11 @@ export const issueCredentialJwt = (
       if (defCredentialMetadataClaims && defCredentialMetadataClaims.length > 0) {
         for (const claim of defCredentialMetadataClaims) {
           const subjectPath = credentialSubjectPath(claim.path)
-          const value = getClaimValue(claimsSource, subjectPath)
+          let value = getClaimValue(claimsSource, claim.path)
+          if (value === undefined && subjectPath.length !== claim.path.length) {
+            value = getClaimValue(claimsSource, subjectPath)
+          }
+          // const value = getClaimValue(claimsSource, subjectPath)
           if (claim.mandatory === true && value === undefined) {
             throw raise('INVALID_CLAIMS', {
               message: `Claim ${claim.path.join('.')} is not defined as mandatory in the credential definition.`,

--- a/server/core/src/routes/issue.ts
+++ b/server/core/src/routes/issue.ts
@@ -36,13 +36,15 @@ export const createIssueRouter = (context: VcknotsContext, baseUrl: string) => {
 
   issueApp.post('/credentials', async (c) => {
     const issueClaimsSample = {
-      given_name: 'test',
-      family_name: 'taro',
-      degree: '5',
-      gpa: 'test',
-      address: {
-        country: 'fuga',
-        region: 'xyz',
+      credentialSubject: {
+        given_name: 'test',
+        family_name: 'taro',
+        degree: '5',
+        gpa: 'test',
+        address: {
+          country: 'fuga',
+          region: 'xyz',
+        },
       },
     }
 

--- a/server/core/src/routes/issue.ts
+++ b/server/core/src/routes/issue.ts
@@ -36,15 +36,13 @@ export const createIssueRouter = (context: VcknotsContext, baseUrl: string) => {
 
   issueApp.post('/credentials', async (c) => {
     const issueClaimsSample = {
-      credentialSubject: {
-        given_name: 'test',
-        family_name: 'taro',
-        degree: '5',
-        gpa: 'test',
-        address: {
-          country: 'fuga',
-          region: 'xyz',
-        },
+      given_name: 'test',
+      family_name: 'taro',
+      degree: '5',
+      gpa: 'test',
+      address: {
+        country: 'fuga',
+        region: 'xyz',
       },
     }
 

--- a/server/samples/issuer_metadata.json
+++ b/server/samples/issuer_metadata.json
@@ -23,7 +23,7 @@
 		"UniversityDegreeCredential": {
 			"format": "jwt_vc_json",
 			"scope": "UniversityDegree",
-			"cryptographic_binding_methods_supported": ["jwk"],
+			"cryptographic_binding_methods_supported": ["did:key"],
 			"credential_signing_alg_values_supported": ["ES256"],
 			"credential_definition": {
 				"type": ["VerifiableCredential", "UniversityDegreeCredential"]
@@ -48,7 +48,7 @@
 				],
 				"claims": [
 					{
-						"path": ["given_name"],
+						"path": ["credentialSubject", "given_name"],
 						"display": [
 							{
 								"name": "Given Name",
@@ -62,7 +62,7 @@
 						"mandatory": true
 					},
 					{
-						"path": ["family_name"],
+						"path": ["credentialSubject", "family_name"],
 						"display": [
 							{
 								"name": "Surname",
@@ -75,7 +75,7 @@
 						]
 					},
 					{
-						"path": ["degree"],
+						"path": ["credentialSubject", "degree"],
 						"display": [
 							{
 								"name": "Degree",
@@ -88,7 +88,7 @@
 						]
 					},
 					{
-						"path": ["gpa"],
+						"path": ["credentialSubject", "gpa"],
 						"display": [
 							{
 								"name": "GPA",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * イシュアーメタデータの設定例を更新しました。

* **更新**
  * 認証バインディング方式を `jwk` から `did:key` に変更しました。
  * 大学学位認証資格情報のクレームパス構造を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->