### PR TITLE
fix: wallet oid4vp uri exclusivity

### DIFF
--- a/wallet/presenter/plugins/oid4vp/oid4vp.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp.go
@@ -304,6 +304,17 @@ func (b *requestBuilder) validate() error {
 	return nil
 }
 
+// validateRedirectAndResponseURIExclusivity enforces the OID4VP rule that a
+// single request MUST NOT carry both redirect_uri and response_uri. response_uri
+// is used with response_mode=direct_post[.jwt]; redirect_uri is used otherwise.
+// Returns a non-nil error only when both values are present.
+func validateRedirectAndResponseURIExclusivity(redirectURIFromParam, responseURIFromParam string) error {
+	if redirectURIFromParam != "" && responseURIFromParam != "" {
+		return fmt.Errorf("redirect_uri and response_uri must not both be present in the same request")
+	}
+	return nil
+}
+
 // setParamsWithInterfaceMap sets the CredentialPresentationRequest fields from a map of any parameters,
 // tracking any missing required parameters.
 // Missing required parameters are recorded in b.errValidation and set as empty strings.
@@ -374,7 +385,14 @@ func (b *requestBuilder) setParamsWithAnyMap(params map[string]any) {
 
 	b.req.ResponseMode = OAuthAuthzReqResponseMode(getParam("response_mode", true))
 
-	b.req.ResponseURI = getParam("response_uri", b.req.ResponseMode == OAuthAuthzReqResponseModeDirectPost)
+	responseURIFromParam := getParam("response_uri", b.req.ResponseMode == OAuthAuthzReqResponseModeDirectPost)
+
+	if err := validateRedirectAndResponseURIExclusivity(redirectURIFromParam, responseURIFromParam); err != nil {
+		b.errValidation = err
+		return
+	}
+
+	b.req.ResponseURI = responseURIFromParam
 
 	if pd := getParam("presentation_definition", true); pd != "" {
 		// Handle presentation_definition as either string (JSON) or map

--- a/wallet/presenter/plugins/oid4vp/oid4vp.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp.go
@@ -304,10 +304,10 @@ func (b *requestBuilder) validate() error {
 	return nil
 }
 
-// validateRedirectAndResponseURIExclusivity enforces the OID4VP rule that a
-// single request MUST NOT carry both redirect_uri and response_uri. response_uri
-// is used with response_mode=direct_post[.jwt]; redirect_uri is used otherwise.
-// Returns a non-nil error only when both values are present.
+// validateRedirectAndResponseURIExclusivity returns an error when the
+// redirect_uri and response_uri request parameters are both set. Per OID4VP
+// they are mutually exclusive on the wire: response_uri is used with
+// response_mode=direct_post[.jwt], redirect_uri otherwise.
 func validateRedirectAndResponseURIExclusivity(redirectURIFromParam, responseURIFromParam string) error {
 	if redirectURIFromParam != "" && responseURIFromParam != "" {
 		return fmt.Errorf("redirect_uri and response_uri must not both be present in the same request")

--- a/wallet/presenter/plugins/oid4vp/oid4vp.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp.go
@@ -307,7 +307,7 @@ func (b *requestBuilder) validate() error {
 // validateRedirectAndResponseURIExclusivity returns an error when the
 // redirect_uri and response_uri request parameters are both set. Per OID4VP
 // they are mutually exclusive on the wire: response_uri is used with
-// response_mode=direct_post[.jwt], redirect_uri otherwise.
+// response_mode=direct_post (and its JWT variant), redirect_uri otherwise.
 func validateRedirectAndResponseURIExclusivity(redirectURIFromParam, responseURIFromParam string) error {
 	if redirectURIFromParam != "" && responseURIFromParam != "" {
 		return fmt.Errorf("redirect_uri and response_uri must not both be present in the same request")

--- a/wallet/presenter/plugins/oid4vp/oid4vp_test.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp_test.go
@@ -604,6 +604,9 @@ func TestOid4vpPresenter_ParsePresentationRequest_QueryParamValidations(t *testi
 			wantErr: true,
 			errSub:  "response_uri must use https scheme",
 		},
+		// redirect_uri matches the client_id-derived value on purpose so the
+		// mismatch check (redirectURIFromParam vs redirectURIFromClientID) does
+		// not fire first and the new exclusivity check is exercised.
 		{
 			name:    "redirect_uri and response_uri must not coexist",
 			uri:     "openid4vp://present?client_id=redirect_uri:http://example.com/cb&response_type=vp_token&nonce=n&presentation_definition=%7B%22id%22%3A%22def%22%7D&response_mode=direct_post&redirect_uri=http://example.com/cb&response_uri=https://example.com/response",

--- a/wallet/presenter/plugins/oid4vp/oid4vp_test.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp_test.go
@@ -155,7 +155,6 @@ func TestOid4vpPresenter_ParsePresentationRequest(t *testing.T) {
 		"presentation_definition": map[string]any{
 			"id": "test-def",
 		},
-		"redirect_uri":    "http://example.com/callback",
 		"response_uri":    "https://example.com/response",
 		"client_metadata": clientMetadata,
 	}
@@ -287,7 +286,6 @@ func TestOid4vpPresenter_WithRequestObject_TypHeader(t *testing.T) {
 		"presentation_definition": map[string]any{
 			"id": "test-def",
 		},
-		"redirect_uri":    "http://example.com/callback",
 		"response_uri":    "https://example.com/response",
 		"client_metadata": clientMetadata,
 	}
@@ -393,7 +391,6 @@ func TestOid4vpPresenter_WithRequestObject_IssClaimIgnored(t *testing.T) {
 		"presentation_definition": map[string]any{
 			"id": "test-def",
 		},
-		"redirect_uri":    "http://example.com/callback",
 		"response_uri":    "https://example.com/response",
 		"client_metadata": clientMetadata,
 	}
@@ -454,7 +451,6 @@ func TestOid4vpPresenter_WithRequestObject_StandardClaimsValidation(t *testing.T
 			"presentation_definition": map[string]any{
 				"id": "test-def",
 			},
-			"redirect_uri":    "http://example.com/callback",
 			"response_uri":    "https://example.com/response",
 			"client_metadata": clientMetadata,
 		}
@@ -549,7 +545,6 @@ func TestOid4vpPresenter_WithRequestObject_StandardClaimsValidation(t *testing.T
 			"presentation_definition": map[string]any{
 				"id": "test-def",
 			},
-			"redirect_uri":    "http://example.com/callback",
 			"response_uri":    "https://example.com/response",
 			"client_metadata": clientMetadata,
 		}
@@ -608,6 +603,12 @@ func TestOid4vpPresenter_ParsePresentationRequest_QueryParamValidations(t *testi
 			uri:     "openid4vp://present?client_id=redirect_uri:http://example.com/cb&response_type=vp_token&nonce=n&presentation_definition=%7B%22id%22%3A%22def%22%7D&response_mode=direct_post&response_uri=http://example.com/response",
 			wantErr: true,
 			errSub:  "response_uri must use https scheme",
+		},
+		{
+			name:    "redirect_uri and response_uri must not coexist",
+			uri:     "openid4vp://present?client_id=redirect_uri:http://example.com/cb&response_type=vp_token&nonce=n&presentation_definition=%7B%22id%22%3A%22def%22%7D&response_mode=direct_post&redirect_uri=http://example.com/cb&response_uri=https://example.com/response",
+			wantErr: true,
+			errSub:  "redirect_uri and response_uri must not both be present",
 		},
 	}
 
@@ -770,7 +771,6 @@ func TestOid4vpPresenter_RequestParameterJWT_Success(t *testing.T) {
 		"presentation_definition": map[string]any{
 			"id": "test-def",
 		},
-		"redirect_uri":    "http://example.com/callback",
 		"response_uri":    "https://example.com/response",
 		"client_metadata": clientMetadata,
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * OID4VP プレゼンテーションリクエストの検証を強化しました。`redirect_uri` と `response_uri` が同時に指定された場合、検証エラーが返されます。
* **テスト**
  * 上記の排他チェックを追加するなど、関連するテストケースを更新して挙動を検証するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->