### PR TITLE
ci: ignore update nvm and node engines from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,10 +78,13 @@
 		},
 		{
 			"matchManagers": ["nvm"],
-			"groupName": "node-version",
-			"rangeStrategy": "pin"
+			"enabled": false
 		},
-
+		{
+			"matchDepNames": ["node"],
+			"matchFileNames": ["**/package.json"],
+			"enabled": false
+		},
 		{
 			"matchUpdateTypes": [
 				"pin",


### PR DESCRIPTION
<img width="808" height="376" alt="image" src="https://github.com/user-attachments/assets/a27263a2-ab03-4a33-8283-a34963339964" />
<img width="1257" height="644" alt="image" src="https://github.com/user-attachments/assets/babeb72a-e463-4017-beaa-0df48d381d8f" />

renovateがnodeのengineを書き換えるのを防ぐ設定に変更しました

## Summary by CodeRabbit

## Chores

* 依存関係管理の設定を更新しました。Node関連パッケージの自動更新を無効化し、設定ルールを簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->