### PR TITLE
fix(wallet): add validation for missing credential issuer in credential offer

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -475,13 +475,13 @@ func (w *Wallet) validateCredentialOffer(offer *CredentialOffer) (string, error)
 		return "", fmt.Errorf("credential offer is required")
 	}
 
+	if err := validateCredentialIssuerIdentifier(offer.CredentialIssuer); err != nil {
+		return "", err
+	}
+
 	preAuthGrant := offer.Grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"]
 	if preAuthGrant == nil {
 		return "", fmt.Errorf("pre-authorization code is not included in the offer")
-	}
-
-	if offer.CredentialIssuer == nil {
-		return "", fmt.Errorf("credential issuer is not included in the offer")
 	}
 
 	if len(offer.CredentialConfigurationIDs) == 0 {
@@ -494,6 +494,32 @@ func (w *Wallet) validateCredentialOffer(offer *CredentialOffer) (string, error)
 	}
 
 	return preAuthCode, nil
+}
+
+func validateCredentialIssuerIdentifier(issuer *url.URL) error {
+	if issuer == nil {
+		return fmt.Errorf("credential issuer is not included in the offer")
+	}
+
+	if issuer.Scheme == "" {
+		return fmt.Errorf("credential issuer must include a scheme")
+	}
+	if !strings.EqualFold(issuer.Scheme, "https") {
+		if !env.IsHTTPAllowed() || !strings.EqualFold(issuer.Scheme, "http") {
+			return fmt.Errorf("credential issuer must use https scheme")
+		}
+	}
+	if issuer.Host == "" {
+		return fmt.Errorf("credential issuer must include a host")
+	}
+	if issuer.User != nil {
+		return fmt.Errorf("credential issuer must not include user info")
+	}
+	if issuer.RawQuery != "" || issuer.ForceQuery || issuer.Fragment != "" || issuer.RawFragment != "" {
+		return fmt.Errorf("credential issuer must not include query or fragment")
+	}
+
+	return nil
 }
 
 // fetchCredentialMetadata fetches issuer and authorization server metadata.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -480,6 +480,10 @@ func (w *Wallet) validateCredentialOffer(offer *CredentialOffer) (string, error)
 		return "", fmt.Errorf("pre-authorization code is not included in the offer")
 	}
 
+	if offer.CredentialIssuer ==  nil {
+		return "", fmt.Errorf("credential issuer is not included in the offer")
+	}
+
 	if len(offer.CredentialConfigurationIDs) == 0 {
 		return "", fmt.Errorf("credential configuration IDs are empty")
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -512,9 +512,6 @@ func validateCredentialIssuerIdentifier(issuer *url.URL) error {
 	if issuer.Host == "" {
 		return fmt.Errorf("credential issuer must include a host")
 	}
-	if issuer.User != nil {
-		return fmt.Errorf("credential issuer must not include user info")
-	}
 	if issuer.RawQuery != "" || issuer.ForceQuery || issuer.Fragment != "" || issuer.RawFragment != "" {
 		return fmt.Errorf("credential issuer must not include query or fragment")
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -480,7 +480,7 @@ func (w *Wallet) validateCredentialOffer(offer *CredentialOffer) (string, error)
 		return "", fmt.Errorf("pre-authorization code is not included in the offer")
 	}
 
-	if offer.CredentialIssuer ==  nil {
+	if offer.CredentialIssuer == nil {
 		return "", fmt.Errorf("credential issuer is not included in the offer")
 	}
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1704,22 +1704,16 @@ func TestWallet_validateCredentialOffer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w, err := NewWallet()
-			if err != nil {
-				t.Fatalf("could not construct receiver type: %v", err)
-			}
+			require.NoError(t, err)
+
 			got, gotErr := w.validateCredentialOffer(tt.offer)
-			if gotErr != nil {
-				if !tt.wantErr {																																														
-					t.Errorf("validateCredentialOffer() failed: %v", gotErr)
-				}
+			if tt.wantErr {
+				require.Error(t, gotErr)
 				return
 			}
-			if tt.wantErr {
-				t.Fatal("validateCredentialOffer() succeeded unexpectedly")
-			}
-			if got != tt.want {
-				t.Errorf("validateCredentialOffer() = %v, want %v", got, tt.want)
-			}
+
+			require.NoError(t, gotErr)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1630,3 +1630,96 @@ func TestBuildDescriptorMap_UsesVPTokenRootPathForALLSdJwtDescriptors(t *testing
 		require.Nilf(t, item.PathNested, "descriptorMap[%d].PathNested", i)
 	}
 }
+
+func TestWallet_validateCredentialOffer(t *testing.T) {
+	issuerURL, err := url.Parse("https://issuer.example.com")
+	require.NoError(t, err)
+
+	const preAuthGrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		offer   *CredentialOffer
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "nil offer",
+			offer:   nil,
+			wantErr: true,
+		},
+		{
+			name: "missing pre-authorization grant",
+			offer: &CredentialOffer{
+				CredentialIssuer:           issuerURL,
+				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants:                     map[string]*CredentialOfferGrant{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing credential issuer",
+			offer: &CredentialOffer{
+				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty credential configuration IDs",
+			offer: &CredentialOffer{
+				CredentialIssuer: issuerURL,
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty pre-authorization code",
+			offer: &CredentialOffer{
+				CredentialIssuer:           issuerURL,
+				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: ""},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid offer",
+			offer: &CredentialOffer{
+				CredentialIssuer:           issuerURL,
+				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			want: "pre-auth-code",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := NewWallet()
+			if err != nil {
+				t.Fatalf("could not construct receiver type: %v", err)
+			}
+			got, gotErr := w.validateCredentialOffer(tt.offer)
+			if gotErr != nil {
+				if !tt.wantErr {																																														
+					t.Errorf("validateCredentialOffer() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("validateCredentialOffer() succeeded unexpectedly")
+			}
+			if got != tt.want {
+				t.Errorf("validateCredentialOffer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -80,6 +80,14 @@ func createTestControllerWithDefaults(t *testing.T) *Wallet {
 	return controller
 }
 
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return parsed
+}
+
 func TestNewWallet(t *testing.T) {
 	controller := createTestControllerWithDefaults(t)
 	if controller == nil {
@@ -1634,15 +1642,19 @@ func TestBuildDescriptorMap_UsesVPTokenRootPathForALLSdJwtDescriptors(t *testing
 func TestWallet_validateCredentialOffer(t *testing.T) {
 	issuerURL, err := url.Parse("https://issuer.example.com")
 	require.NoError(t, err)
+	httpIssuerURL, err := url.Parse("http://issuer.example.com")
+	require.NoError(t, err)
 
 	const preAuthGrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
 
 	tests := []struct {
 		name string // description of this test case
 		// Named input parameters for target function.
-		offer   *CredentialOffer
-		want    string
-		wantErr bool
+		offer           *CredentialOffer
+		httpAllowed     bool
+		want            string
+		wantErr         bool
+		wantErrContains string
 	}{
 		{
 			name:    "nil offer",
@@ -1667,6 +1679,66 @@ func TestWallet_validateCredentialOffer(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "credential issuer must include host",
+			offer: &CredentialOffer{
+				CredentialIssuer:           mustParseURL(t, "https:///issuer"),
+				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "credential issuer must include a host",
+		},
+		{
+			name: "credential issuer must use https by default",
+			offer: &CredentialOffer{
+				CredentialIssuer:           httpIssuerURL,
+				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "credential issuer must use https scheme",
+		},
+		{
+			name: "credential issuer allows http when configured",
+			offer: &CredentialOffer{
+				CredentialIssuer:           httpIssuerURL,
+				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			httpAllowed: true,
+			want:        "pre-auth-code",
+		},
+		{
+			name: "credential issuer must not include query",
+			offer: &CredentialOffer{
+				CredentialIssuer:           mustParseURL(t, "https://issuer.example.com?foo=bar"),
+				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "credential issuer must not include query or fragment",
+		},
+		{
+			name: "credential issuer must not include fragment",
+			offer: &CredentialOffer{
+				CredentialIssuer:           mustParseURL(t, "https://issuer.example.com#fragment"),
+				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "credential issuer must not include query or fragment",
 		},
 		{
 			name: "empty credential configuration IDs",
@@ -1703,12 +1775,22 @@ func TestWallet_validateCredentialOffer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			httpAllowed := env.IsHTTPAllowed()
+			debugMode := env.IsDebugMode()
+			defer env.SetHTTPAllowed(httpAllowed)
+			defer env.SetDebugMode(debugMode)
+			env.SetDebugMode(false)
+			env.SetHTTPAllowed(tt.httpAllowed)
+
 			w, err := NewWallet()
 			require.NoError(t, err)
 
 			got, gotErr := w.validateCredentialOffer(tt.offer)
 			if tt.wantErr {
 				require.Error(t, gotErr)
+				if tt.wantErrContains != "" {
+					require.Contains(t, gotErr.Error(), tt.wantErrContains)
+				}
 				return
 			}
 


### PR DESCRIPTION
# 概要
fix #174
- validateCredentialOfferにてoffer.CredentialIssuerのnilチェックを行うよう修正を行いました。
- 新たに validateCredentialOfferのユニットテストとしてTestWallet_validateCredentialOfferを追加し、通過を確認しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * クレデンシャルオファー検証を強化：発行者URLの必須化、スキームとホストの検証、ユーザー情報やクエリ/フラグメントの拒否、既定でHTTPSを要求（条件付きでHTTPを許可）。
  * 不正なオファーに対してより早期で厳密なエラー応答を返すよう改善。

* **テスト**
  * 様々な検証シナリオを網羅する単体テストを追加し、検証の動作とエラー処理を検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->