### PR TITLE
fix(wallet): support tx_code in pre-authorized code flow

### DIFF
--- a/wallet/receiver/dispatcher.go
+++ b/wallet/receiver/dispatcher.go
@@ -102,7 +102,7 @@ func (d *ReceivingDispatcher) FetchAuthorizationServerMetadata(endpoint common.U
 }
 
 // FetchAccessToken fetches access token using the appropriate plugin
-func (d *ReceivingDispatcher) FetchAccessToken(receivingType types.SupportedReceivingTypes, endpoint common.URIField, authzCode string) (*types.CredentialIssuanceAccessToken, error) {
+func (d *ReceivingDispatcher) FetchAccessToken(receivingType types.SupportedReceivingTypes, endpoint common.URIField, authzCode string, txCode string) (*types.CredentialIssuanceAccessToken, error) {
 	if authzCode == "" {
 		return nil, types.NewReceiverError(receivingType, endpoint.String(), "fetch_access_token", types.ErrAuthorizationFailed)
 	}
@@ -112,7 +112,7 @@ func (d *ReceivingDispatcher) FetchAccessToken(receivingType types.SupportedRece
 		return nil, err
 	}
 
-	token, err := plugin.FetchAccessToken(receivingType, endpoint, authzCode)
+	token, err := plugin.FetchAccessToken(receivingType, endpoint, authzCode, txCode)
 	if err != nil {
 		return nil, types.NewReceiverError(receivingType, endpoint.String(), "fetch_access_token", err)
 	}

--- a/wallet/receiver/dispatcher_test.go
+++ b/wallet/receiver/dispatcher_test.go
@@ -27,7 +27,7 @@ func (m *mockReceiver) FetchAuthorizationServerMetadata(endpoint common.URIField
 	return &types.AuthorizationServerMetadata{}, nil
 }
 
-func (m *mockReceiver) FetchAccessToken(receivingType types.SupportedReceivingTypes, endpoint common.URIField, authzCode string) (*types.CredentialIssuanceAccessToken, error) {
+func (m *mockReceiver) FetchAccessToken(receivingType types.SupportedReceivingTypes, endpoint common.URIField, authzCode string, txCode string) (*types.CredentialIssuanceAccessToken, error) {
 	if m.shouldError {
 		return nil, fmt.Errorf("mock error")
 	}
@@ -137,14 +137,14 @@ func TestReceivingDispatcher_FetchAccessToken(t *testing.T) {
 	dispatcher, _ := NewReceivingDispatcher(WithPlugin(types.Oid4vci, mock))
 
 	t.Run("Happy path", func(t *testing.T) {
-		_, err := dispatcher.FetchAccessToken(types.Oid4vci, common.URIField{}, "test-code")
+		_, err := dispatcher.FetchAccessToken(types.Oid4vci, common.URIField{}, "test-code", "")
 		if err != nil {
 			t.Errorf("FetchAccessToken() on happy path should not return error: %v", err)
 		}
 	})
 
 	t.Run("Empty authzCode", func(t *testing.T) {
-		_, err := dispatcher.FetchAccessToken(types.Oid4vci, common.URIField{}, "")
+		_, err := dispatcher.FetchAccessToken(types.Oid4vci, common.URIField{}, "", "")
 		if err == nil {
 			t.Fatal("Expected error for empty authzCode")
 		}
@@ -152,7 +152,7 @@ func TestReceivingDispatcher_FetchAccessToken(t *testing.T) {
 
 	t.Run("Unsupported receiving type", func(t *testing.T) {
 		invalidType := types.SupportedReceivingTypes(999)
-		_, err := dispatcher.FetchAccessToken(invalidType, common.URIField{}, "test-code")
+		_, err := dispatcher.FetchAccessToken(invalidType, common.URIField{}, "test-code", "")
 		if err == nil {
 			t.Fatal("Expected error for unsupported receiving type")
 		}

--- a/wallet/receiver/plugins/mock/mock.go
+++ b/wallet/receiver/plugins/mock/mock.go
@@ -67,7 +67,7 @@ func (m *MockReceiver) FetchAuthorizationServerMetadata(endpoint common.URIField
 
 // FetchAccessToken returns a mock access token
 // For mock implementation, this returns a static mock token
-func (m *MockReceiver) FetchAccessToken(receivingType types.SupportedReceivingTypes, endpoint common.URIField, authzCode string) (*types.CredentialIssuanceAccessToken, error) {
+func (m *MockReceiver) FetchAccessToken(receivingType types.SupportedReceivingTypes, endpoint common.URIField, authzCode string, txCode string) (*types.CredentialIssuanceAccessToken, error) {
 	if receivingType != types.Mock {
 		return nil, types.NewReceiverError(receivingType, endpoint.String(), "FetchAccessToken", fmt.Errorf("unsupported receiving type for mock receiver"))
 	}

--- a/wallet/receiver/plugins/mock/mock_test.go
+++ b/wallet/receiver/plugins/mock/mock_test.go
@@ -48,7 +48,7 @@ func TestMockReceiver_FetchAccessToken(t *testing.T) {
 	endpoint, _ := common.ParseURIField("mock://test")
 
 	// Test with correct receiving type
-	token, err := receiver.FetchAccessToken(types.Mock, *endpoint, "test_code")
+	token, err := receiver.FetchAccessToken(types.Mock, *endpoint, "test_code", "")
 	require.NoError(t, err)
 	assert.NotNil(t, token)
 	assert.Equal(t, "mock_access_token", token.Token)
@@ -56,7 +56,7 @@ func TestMockReceiver_FetchAccessToken(t *testing.T) {
 	assert.Equal(t, 3600, token.ExpiresIn)
 
 	// Test with incorrect receiving type
-	_, err = receiver.FetchAccessToken(types.Oid4vci, *endpoint, "test_code")
+	_, err = receiver.FetchAccessToken(types.Oid4vci, *endpoint, "test_code", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported receiving type")
 }

--- a/wallet/receiver/plugins/oid4vci/oid4vci.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci.go
@@ -107,7 +107,7 @@ func (o *Oid4vciReceiver) FetchAuthorizationServerMetadata(endpoint common.URIFi
 	return &metadata, nil
 }
 
-func (o *Oid4vciReceiver) FetchAccessToken(receivingTypes types.SupportedReceivingTypes, endpoint common.URIField, authzCode string) (*types.CredentialIssuanceAccessToken, error) {
+func (o *Oid4vciReceiver) FetchAccessToken(receivingTypes types.SupportedReceivingTypes, endpoint common.URIField, authzCode string, txCode string) (*types.CredentialIssuanceAccessToken, error) {
 	if receivingTypes != types.Oid4vci {
 		return nil, fmt.Errorf("unsupported flavor: %v", receivingTypes)
 	}
@@ -116,6 +116,9 @@ func (o *Oid4vciReceiver) FetchAccessToken(receivingTypes types.SupportedReceivi
 	formData := url.Values{}
 	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:pre-authorized_code")
 	formData.Set("pre-authorized_code", authzCode)
+	if txCode != "" {
+		formData.Set("tx_code", txCode)
+	}
 
 	var accessToken types.CredentialIssuanceAccessToken
 	if err := o.doRequest("POST", endpoint, "/token", strings.NewReader(formData.Encode()), &accessToken); err != nil {

--- a/wallet/receiver/plugins/oid4vci/oid4vci_test.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci_test.go
@@ -292,7 +292,7 @@ func TestOid4vciReceiver_FetchAccessToken(t *testing.T) {
 		env.SetDebugMode(false)
 		env.SetHTTPAllowed(false)
 
-		_, err := receiver.FetchAccessToken(types.Oid4vci, endpoint, "test-code")
+		_, err := receiver.FetchAccessToken(types.Oid4vci, endpoint, "test-code", "")
 		if err == nil {
 			t.Fatal("FetchAccessToken should be error when issuer's schema is http")
 		}
@@ -303,7 +303,7 @@ func TestOid4vciReceiver_FetchAccessToken(t *testing.T) {
 		defer env.SetHTTPAllowed(http_allowed)
 		env.SetHTTPAllowed(true)
 
-		token, err := receiver.FetchAccessToken(types.Oid4vci, endpoint, "test-code")
+		token, err := receiver.FetchAccessToken(types.Oid4vci, endpoint, "test-code", "")
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -319,6 +319,50 @@ func TestOid4vciReceiver_FetchAccessToken(t *testing.T) {
 			t.Errorf("Expected TokenType 'Bearer', got %s", token.TokenType)
 		}
 	})
+	t.Run("Request includes tx_code when provided", func(t *testing.T) {
+		http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
+		defer env.SetHTTPAllowed(http_allowed)
+		env.SetHTTPAllowed(true)
+
+		captureServer := mockserver.NewMockServer()
+		defer captureServer.Close()
+
+		handlerErrCh := make(chan error, 1)
+		captureServer.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				handlerErrCh <- fmt.Errorf("failed to parse request form: %w", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if got := r.Form.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:pre-authorized_code" {
+				handlerErrCh <- fmt.Errorf("expected pre-authorized_code to be test-code,got %s", got)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if got := r.Form.Get("pre-authorized_code"); got != "test-code" {
+
+				handlerErrCh <- fmt.Errorf("expected pre-authorized_code to be test-code, got %s", got)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if got := r.Form.Get("tx_code"); got != "123456" {
+				handlerErrCh <- fmt.Errorf("expected tx_code to be 123456, got %s", got)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			handlerErrCh <- nil
+
+			mockserver.JSONResponse(w, http.StatusOK, map[string]string{
+				"access_token": "mock-access-token",
+				"token_type":   "Bearer",
+			})
+		})
+		captureURL, _ := url.Parse(captureServer.URL())
+		token, err := receiver.FetchAccessToken(types.Oid4vci, common.URIField(*captureURL), "test-code", "123456")
+		require.NoError(t, err)
+		require.NotNil(t, token)
+		require.NoError(t, <-handlerErrCh)
+	})
 
 	t.Run("Server error", func(t *testing.T) {
 		http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
@@ -332,7 +376,7 @@ func TestOid4vciReceiver_FetchAccessToken(t *testing.T) {
 		errorServer.SetErrorResponse("/token", http.StatusInternalServerError)
 
 		errorURL, _ := url.Parse(errorServer.URL())
-		_, err := receiver.FetchAccessToken(types.Oid4vci, common.URIField(*errorURL), "test-code")
+		_, err := receiver.FetchAccessToken(types.Oid4vci, common.URIField(*errorURL), "test-code", "")
 		if err == nil {
 			t.Fatal("Expected error for server error")
 		}
@@ -349,7 +393,7 @@ func TestOid4vciReceiver_FetchAccessToken(t *testing.T) {
 		invalidJSONServer.SetTextResponse("/token", http.StatusOK, "{invalid-json")
 
 		invalidJSONURL, _ := url.Parse(invalidJSONServer.URL())
-		_, err := receiver.FetchAccessToken(types.Oid4vci, common.URIField(*invalidJSONURL), "test-code")
+		_, err := receiver.FetchAccessToken(types.Oid4vci, common.URIField(*invalidJSONURL), "test-code", "")
 		if err == nil {
 			t.Fatal("Expected error for invalid JSON response")
 		}

--- a/wallet/receiver/plugins/oid4vci/oid4vci_test.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci_test.go
@@ -335,7 +335,7 @@ func TestOid4vciReceiver_FetchAccessToken(t *testing.T) {
 				return
 			}
 			if got := r.Form.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:pre-authorized_code" {
-				handlerErrCh <- fmt.Errorf("expected pre-authorized_code to be test-code,got %s", got)
+				handlerErrCh <- fmt.Errorf("expected grant_type to be urn:ietf:params:oauth:grant-type:pre-authorized_code, got %s", got)
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}

--- a/wallet/receiver/types/types.go
+++ b/wallet/receiver/types/types.go
@@ -223,7 +223,7 @@ type Receiver interface {
 	FetchAuthorizationServerMetadata(endpoint common.URIField, receivingType SupportedReceivingTypes) (*AuthorizationServerMetadata, error)
 
 	// FetchAccessToken fetches access token through OID4VCI
-	FetchAccessToken(receivingType SupportedReceivingTypes, endpoint common.URIField, authzCode string) (*CredentialIssuanceAccessToken, error)
+	FetchAccessToken(receivingType SupportedReceivingTypes, endpoint common.URIField, authzCode string, txCode string) (*CredentialIssuanceAccessToken, error)
 
 	// ReceiveCredential receives credential through OID4VCI
 	ReceiveCredential(

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -266,7 +266,14 @@ type CredentialOffer struct {
 
 // CredentialOfferGrant represents a grant in a credential offer.
 type CredentialOfferGrant struct {
-	PreAuthorizedCode string `json:"pre-authorized_code"`
+	PreAuthorizedCode string  `json:"pre-authorized_code"`
+	TxCode            *TxCode `json:"tx_code,omitempty"`
+}
+
+type TxCode struct {
+	InputMode   string `json:"input_mode,omitempty"`
+	Length      int    `json:"length,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 // GetCredentialEntriesRequest holds parameters for querying credential entries.
@@ -562,7 +569,7 @@ func (w *Wallet) fetchCredentialMetadata(req ReceiveCredentialRequest) (*receive
 
 // obtainAccessToken obtains an access token using pre-authorization code.
 func (w *Wallet) obtainAccessToken(receivingType receiverTypes.SupportedReceivingTypes, authMetadata *receiverTypes.AuthorizationServerMetadata, preAuthCode string) (*receiverTypes.CredentialIssuanceAccessToken, error) {
-	accessToken, err := w.receiver.FetchAccessToken(receivingType, *authMetadata.TokenEndpoint, preAuthCode)
+	accessToken, err := w.receiver.FetchAccessToken(receivingType, *authMetadata.TokenEndpoint, preAuthCode, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch access token: %w", err)
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -461,10 +461,10 @@ func (w *Wallet) ReceiveCredential(req ReceiveCredentialRequest) (*SavedCredenti
 
 	preAuthGrant := req.CredentialOffer.Grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"]
 
-	if preAuthGrant.TxCode != nil && req.TxCode == "" {
+	if preAuthGrant.TxCode != nil && strings.TrimSpace(req.TxCode) == "" {
 		return nil, fmt.Errorf("tx_code is required by credential offer")
 	}
-	
+
 	issuerMetadata, authMetadata, err := w.fetchCredentialMetadata(req)
 	if err != nil {
 		return nil, err

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -255,6 +255,7 @@ type ReceiveCredentialRequest struct {
 	Type                 receiverTypes.SupportedReceivingTypes
 	Key                  IKeyEntry
 	CachedIssuerMetadata *receiverTypes.CredentialIssuerMetadata
+	TxCode               string
 }
 
 // CredentialOffer represents a credential offer from an issuer.
@@ -458,12 +459,18 @@ func (w *Wallet) ReceiveCredential(req ReceiveCredentialRequest) (*SavedCredenti
 		return nil, err
 	}
 
+	preAuthGrant := req.CredentialOffer.Grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"]
+
+	if preAuthGrant.TxCode != nil && req.TxCode == "" {
+		return nil, fmt.Errorf("tx_code is required by credential offer")
+	}
+	
 	issuerMetadata, authMetadata, err := w.fetchCredentialMetadata(req)
 	if err != nil {
 		return nil, err
 	}
 
-	accessToken, err := w.obtainAccessToken(req.Type, authMetadata, preAuthCode)
+	accessToken, err := w.obtainAccessToken(req.Type, authMetadata, preAuthCode, req.TxCode)
 	if err != nil {
 		return nil, err
 	}
@@ -568,8 +575,8 @@ func (w *Wallet) fetchCredentialMetadata(req ReceiveCredentialRequest) (*receive
 }
 
 // obtainAccessToken obtains an access token using pre-authorization code.
-func (w *Wallet) obtainAccessToken(receivingType receiverTypes.SupportedReceivingTypes, authMetadata *receiverTypes.AuthorizationServerMetadata, preAuthCode string) (*receiverTypes.CredentialIssuanceAccessToken, error) {
-	accessToken, err := w.receiver.FetchAccessToken(receivingType, *authMetadata.TokenEndpoint, preAuthCode, "")
+func (w *Wallet) obtainAccessToken(receivingType receiverTypes.SupportedReceivingTypes, authMetadata *receiverTypes.AuthorizationServerMetadata, preAuthCode string, txCode string) (*receiverTypes.CredentialIssuanceAccessToken, error) {
+	accessToken, err := w.receiver.FetchAccessToken(receivingType, *authMetadata.TokenEndpoint, preAuthCode, txCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch access token: %w", err)
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -307,7 +307,25 @@ func TestController_ReceiveCredential_TxCodeProvided_Integration(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	const defaultCredentialJWT = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lzc3Vlci5leGFtcGxlLmNvbSIsInN1YiI6ImRpZDprZXk6ejZNa2lvNFdEbWR0Z0VvNGY5SHE2aTZ0blc4V0Z3a25RUTRLSFVZOTlCR1k0RVZyIiwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCJdLCJpYXQiOjE2MjAyMzk4MDB9.mockSignature"
+	issuerKeyPair := mockserver.MustGenerateKeyPair("issuer-key-id")
+	jwtBuilder := mockserver.MustNewJWTBuilder(issuerKeyPair)
+	defaultCredentialJWT, err := jwtBuilder.CreateSignedJWT(server.URL, map[string]interface{}{
+		"sub": "did:key:z6Mkio4WDmdtgEo4f9Hq6i6tnW8WFwknQQ4KHUY99BGY4EVr",
+		"vc": map[string]interface{}{
+			"@context": []string{
+				"https://www.w3.org/2018/credentials/v1",
+			},
+			"id":           "http://example.com/credential/1",
+			"type":         []string{"VerifiableCredential"},
+			"issuer":       server.URL,
+			"issuanceDate": "2023-01-01T00:00:00Z",
+			"credentialSubject": map[string]interface{}{
+				"id":   "http://example.com/subject",
+				"name": "John Doe",
+			},
+		},
+	})
+	require.NoError(t, err)
 
 	mux.HandleFunc("/.well-known/openid-credential-issuer", func(w http.ResponseWriter, r *http.Request) {
 		mockserver.JSONResponse(w, http.StatusOK, map[string]interface{}{
@@ -381,15 +399,13 @@ func TestController_ReceiveCredential_TxCodeProvided_Integration(t *testing.T) {
 	}
 
 	_, err = controller.ReceiveCredential(req)
-	if err != nil {
-		require.NotContains(t, err.Error(), "tx_code is required by credential offer")
-	}
+	require.NoError(t, err)
 
 	select {
 	case got := <-txCodeCh:
 		require.Equal(t, "123456", got)
 	case <-time.After(2 * time.Second):
-		t.Fatal("tx_code was not received at token endpoint")
+		require.FailNow(t, "tx_code was not received at token endpoint")
 	}
 }
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -293,8 +293,33 @@ func TestController_ReceiveCredential_TxCodeRequired_Integration(t *testing.T) {
 	_, err := controller.ReceiveCredential(req)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "tx_code is required by credential offer")
-
 }
+
+func TestController_ReceiveCredential_TxCodeProvided_Integration(t *testing.T) {
+	controller := createTestControllerWithDefaults(t)
+	credentialIssuer, _ := url.Parse("https://issuer.example.com")
+	req := ReceiveCredentialRequest{
+		CredentialOffer: &CredentialOffer{
+			CredentialIssuer:           credentialIssuer,
+			CredentialConfigurationIDs: []string{"test-config"},
+			Grants: map[string]*CredentialOfferGrant{
+				"urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+					PreAuthorizedCode: "test-code",
+					TxCode:            &TxCode{},
+				},
+			},
+		},
+		Type:   receiverTypes.Oid4vci,
+		Key:    newMockKeyEntry(),
+		TxCode: "123456",
+	}
+
+	_, err := controller.ReceiveCredential(req)
+	if err != nil {
+		require.NotContains(t, err.Error(), "tx_code is required by credential offer")
+	}
+}
+
 func TestController_GetCredentialEntries_Integration(t *testing.T) {
 	controller := createTestControllerWithDefaults(t)
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
@@ -297,7 +298,72 @@ func TestController_ReceiveCredential_TxCodeRequired_Integration(t *testing.T) {
 
 func TestController_ReceiveCredential_TxCodeProvided_Integration(t *testing.T) {
 	controller := createTestControllerWithDefaults(t)
-	credentialIssuer, _ := url.Parse("https://issuer.example.com")
+	httpAllowed := env.IsHTTPAllowed()
+	defer env.SetHTTPAllowed(httpAllowed)
+	env.SetHTTPAllowed(true)
+
+	txCodeCh := make(chan string, 1)
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	const defaultCredentialJWT = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lzc3Vlci5leGFtcGxlLmNvbSIsInN1YiI6ImRpZDprZXk6ejZNa2lvNFdEbWR0Z0VvNGY5SHE2aTZ0blc4V0Z3a25RUTRLSFVZOTlCR1k0RVZyIiwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCJdLCJpYXQiOjE2MjAyMzk4MDB9.mockSignature"
+
+	mux.HandleFunc("/.well-known/openid-credential-issuer", func(w http.ResponseWriter, r *http.Request) {
+		mockserver.JSONResponse(w, http.StatusOK, map[string]interface{}{
+			"credential_issuer":     server.URL,
+			"credential_endpoint":   server.URL + "/credential",
+			"nonce_endpoint":        server.URL + "/nonce",
+			"authorization_servers": []string{server.URL},
+			"credential_configurations_supported": map[string]interface{}{
+				"test-config": map[string]interface{}{
+					"format": "jwt_vc_json",
+					"credential_definition": map[string]interface{}{
+						"type": []string{"VerifiableCredential"},
+					},
+				},
+			},
+		})
+	})
+
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		mockserver.JSONResponse(w, http.StatusOK, map[string]interface{}{
+			"issuer":                                          server.URL,
+			"token_endpoint":                                  server.URL + "/token",
+			"pre-authorized_grant_anonymous_access_supported": true,
+			"response_types_supported":                        []string{"code"},
+		})
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		txCodeCh <- r.Form.Get("tx_code")
+
+		mockserver.JSONResponse(w, http.StatusOK, map[string]interface{}{
+			"access_token": "test-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"c_nonce":      "test-nonce",
+		})
+	})
+
+	mux.HandleFunc("/nonce", func(w http.ResponseWriter, r *http.Request) {
+		mockserver.JSONResponse(w, http.StatusOK, map[string]interface{}{
+			"c_nonce": "test-nonce",
+		})
+	})
+
+	mux.HandleFunc("/credential", func(w http.ResponseWriter, r *http.Request) {
+		mockserver.JSONResponse(w, http.StatusOK, map[string]interface{}{
+			"credentials": []map[string]string{{
+				"credential": defaultCredentialJWT,
+			}},
+		})
+	})
+
+	credentialIssuer, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
 	req := ReceiveCredentialRequest{
 		CredentialOffer: &CredentialOffer{
 			CredentialIssuer:           credentialIssuer,
@@ -314,9 +380,16 @@ func TestController_ReceiveCredential_TxCodeProvided_Integration(t *testing.T) {
 		TxCode: "123456",
 	}
 
-	_, err := controller.ReceiveCredential(req)
+	_, err = controller.ReceiveCredential(req)
 	if err != nil {
 		require.NotContains(t, err.Error(), "tx_code is required by credential offer")
+	}
+
+	select {
+	case got := <-txCodeCh:
+		require.Equal(t, "123456", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("tx_code was not received at token endpoint")
 	}
 }
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -272,6 +272,29 @@ func TestController_ReceiveCredential_EmptyConfigurationIDs_Integration(t *testi
 	}
 }
 
+func TestController_ReceiveCredential_TxCodeRequired_Integration(t *testing.T) {
+
+	controller := createTestControllerWithDefaults(t)
+	credentialIssuer, _ := url.Parse("https://issuer.example.com")
+	req := ReceiveCredentialRequest{
+		CredentialOffer: &CredentialOffer{
+			CredentialIssuer:           credentialIssuer,
+			CredentialConfigurationIDs: []string{"test-config"},
+			Grants: map[string]*CredentialOfferGrant{
+				"urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+					PreAuthorizedCode: "test-code",
+					TxCode:            &TxCode{},
+				},
+			},
+		},
+		Type: receiverTypes.Oid4vci,
+		Key:  newMockKeyEntry(),
+	}
+	_, err := controller.ReceiveCredential(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tx_code is required by credential offer")
+
+}
 func TestController_GetCredentialEntries_Integration(t *testing.T) {
 	controller := createTestControllerWithDefaults(t)
 


### PR DESCRIPTION
baseを間違えたのでPRを作り直しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * トランザクションコード（tx_code）を使ったアクセストークン取得と資格付与フローのサポートを追加しました。

* **Behavior**
  * 事前承認グラントにtx_codeが含まれる場合、リクエストでの提供を必須化。未提供時はエラーになります。
  * 受信フローでtx_codeが渡されると、トークン取得リクエストにtx_codeが含まれます。

* **Tests**
  * tx_codeの必須/提供時挙動と、トークンエンドポイントへのtx_code送信を検証するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->