### PR TITLE
feat(wallet): add validation for credential configuration IDs in credential offers

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -496,6 +496,26 @@ func (w *Wallet) validateCredentialOffer(offer *CredentialOffer) (string, error)
 	return preAuthCode, nil
 }
 
+func (w *Wallet) validateCredentialConfigurationIDs(offer *CredentialOffer, issuerMetadata *receiverTypes.CredentialIssuerMetadata) error {
+	if offer == nil {
+		return fmt.Errorf("credential offer is required")
+	}
+	if issuerMetadata == nil {
+		return fmt.Errorf("issuer metadata is required")
+	}
+	if len(issuerMetadata.CredentialConfigurationSupported) == 0 {
+		return fmt.Errorf("credential configurations supported are missing in issuer metadata")
+	}
+
+	for _, configID := range offer.CredentialConfigurationIDs {
+		if _, exists := issuerMetadata.CredentialConfigurationSupported[configID]; !exists {
+			return fmt.Errorf("credential configuration %q is not supported by issuer metadata", configID)
+		}
+	}
+
+	return nil
+}
+
 func validateCredentialIssuerIdentifier(issuer *url.URL) error {
 	if issuer == nil {
 		return fmt.Errorf("credential issuer is not included in the offer")
@@ -531,6 +551,10 @@ func (w *Wallet) fetchCredentialMetadata(req ReceiveCredentialRequest) (*receive
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to fetch issuer metadata: %w", err)
 		}
+	}
+
+	if err := w.validateCredentialConfigurationIDs(req.CredentialOffer, issuerMetadata); err != nil {
+		return nil, nil, err
 	}
 
 	if len(issuerMetadata.AuthorizationServers) == 0 {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1110,6 +1110,39 @@ func TestController_FetchCredentialIssuerMetadata_WithMockServer(t *testing.T) {
 	t.Logf("Successfully fetched metadata: %+v", metadata)
 }
 
+func TestController_ReceiveCredential_RejectsUnsupportedCredentialConfigurationID(t *testing.T) {
+	server := createMockOID4VCIServer()
+	defer server.Close()
+
+	controller := createTestControllerWithDefaults(t)
+
+	serverURL, err := url.Parse(server.URL())
+	require.NoError(t, err)
+
+	httpAllowed := env.IsHTTPAllowed()
+	defer env.SetHTTPAllowed(httpAllowed)
+	env.SetHTTPAllowed(true)
+
+	req := ReceiveCredentialRequest{
+		CredentialOffer: &CredentialOffer{
+			CredentialIssuer:           serverURL,
+			CredentialConfigurationIDs: []string{"unsupported-config"},
+			Grants: map[string]*CredentialOfferGrant{
+				"urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+					PreAuthorizedCode: "test-code",
+				},
+			},
+		},
+		Type: receiverTypes.Oid4vci,
+		Key:  newMockKeyEntry(),
+	}
+
+	credential, err := controller.ReceiveCredential(req)
+	require.Error(t, err)
+	require.Nil(t, credential)
+	require.Contains(t, err.Error(), `credential configuration "unsupported-config" is not supported by issuer metadata`)
+}
+
 func TestController_PresentCredential_WithMockServer_Integration(t *testing.T) {
 	// First, create a mock OID4VCI server to get a credential
 	vciServer := createMockOID4VCIServer()
@@ -1796,6 +1829,71 @@ func TestWallet_validateCredentialOffer(t *testing.T) {
 
 			require.NoError(t, gotErr)
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWallet_validateCredentialConfigurationIDs(t *testing.T) {
+	tests := []struct {
+		name            string
+		offer           *CredentialOffer
+		issuerMetadata  *receiverTypes.CredentialIssuerMetadata
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:    "all offered configuration IDs are supported",
+			offer:   &CredentialOffer{CredentialConfigurationIDs: []string{"EmployeeID_jwt_vc_json", "StudentID_jwt_vc_json"}},
+			wantErr: false,
+			issuerMetadata: &receiverTypes.CredentialIssuerMetadata{
+				CredentialConfigurationSupported: map[string]receiverTypes.CredentialConfiguration{
+					"EmployeeID_jwt_vc_json": {Format: "jwt_vc_json"},
+					"StudentID_jwt_vc_json":  {Format: "jwt_vc_json"},
+				},
+			},
+		},
+		{
+			name:  "unsupported offered configuration ID is rejected",
+			offer: &CredentialOffer{CredentialConfigurationIDs: []string{"EmployeeID_jwt_vc_json", "UnknownID_jwt_vc_json"}},
+			issuerMetadata: &receiverTypes.CredentialIssuerMetadata{
+				CredentialConfigurationSupported: map[string]receiverTypes.CredentialConfiguration{
+					"EmployeeID_jwt_vc_json": {Format: "jwt_vc_json"},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: `credential configuration "UnknownID_jwt_vc_json" is not supported by issuer metadata`,
+		},
+		{
+			name:            "missing issuer metadata is rejected",
+			offer:           &CredentialOffer{CredentialConfigurationIDs: []string{"EmployeeID_jwt_vc_json"}},
+			issuerMetadata:  nil,
+			wantErr:         true,
+			wantErrContains: "issuer metadata is required",
+		},
+		{
+			name:  "missing supported configurations in metadata is rejected",
+			offer: &CredentialOffer{CredentialConfigurationIDs: []string{"EmployeeID_jwt_vc_json"}},
+			issuerMetadata: &receiverTypes.CredentialIssuerMetadata{
+				CredentialConfigurationSupported: map[string]receiverTypes.CredentialConfiguration{},
+			},
+			wantErr:         true,
+			wantErrContains: "credential configurations supported are missing in issuer metadata",
+		},
+	}
+
+	w, err := NewWallet()
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := w.validateCredentialConfigurationIDs(tt.offer, tt.issuerMetadata)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 認証情報オファーの検証を強化し、発行者メタデータでサポートされていない設定IDが含まれている場合にエラーを返すようになりました。

* **テスト**
  * 検証ロジックのテストケースを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trustknots/vcknots/pull/259)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->