### PR TITLE
fix(wallet): accept raw ecdsa signatures with der tag byte

### DIFF
--- a/wallet/common/jose/signer.go
+++ b/wallet/common/jose/signer.go
@@ -95,13 +95,14 @@ func ConvertDERToRaw(derSig []byte, keySize int) ([]byte, error) {
 		return nil, fmt.Errorf("DER signature too short: %d bytes", len(derSig))
 	}
 
+	// Raw IEEE P1363 signatures have a fixed length and can begin with 0x30 by
+	// chance, so accept the raw length before using the DER sequence-tag heuristic.
+	if len(derSig) == keySize*2 {
+		return derSig, nil
+	}
+
 	// Check if it's DER format (starts with 0x30)
 	if derSig[0] != 0x30 {
-		// Not DER format - might already be raw format
-		// Check if it's the expected raw format length
-		if len(derSig) == keySize*2 {
-			return derSig, nil
-		}
 		return nil, fmt.Errorf("signature is not in DER format and length (%d) doesn't match expected raw format (%d)", len(derSig), keySize*2)
 	}
 

--- a/wallet/common/jose/signer_test.go
+++ b/wallet/common/jose/signer_test.go
@@ -193,6 +193,21 @@ func TestConvertDERToRaw(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			name: "ES256 raw signature starting with DER sequence tag",
+			input: func() []byte {
+				sig := make([]byte, 64)
+				sig[0] = 0x30
+				sig[1] = 0x01
+				sig[2] = 0x7f
+				sig[32] = 0x20
+				sig[63] = 0x01
+				return sig
+			}(),
+			keySize:     32,
+			expectedLen: 64,
+			wantErr:     false,
+		},
+		{
 			name:        "invalid DER signature too short",
 			input:       []byte{0x30, 0x05},
 			keySize:     32,


### PR DESCRIPTION

## Summary

This updates `wallet/common/jose.ConvertDERToRaw` to accept fixed-length raw IEEE P1363 ECDSA signatures before applying the DER sequence-tag heuristic.

A regression test is added for an ES256 raw signature whose first byte is `0x30`.

## Root Cause

`ConvertDERToRaw` already accepts raw signatures when their length is `keySize * 2`, but it only checked that after testing whether the first byte was `0x30`.

Raw ECDSA signatures are arbitrary bytes, so a valid raw signature can begin with `0x30` by chance. In that case the function attempted to parse the raw signature as DER and failed with errors such as:

`invalid DER format: expected integer tag for R at offset 2`

## Fix

Accept the unambiguous raw signature length first:

- `len(sig) == keySize * 2` => return as raw
- otherwise, fall back to the existing DER parsing path

## Validation

- `go test ./common/jose`

<!-- If an upstream issue exists before opening this PR, add: Fixes #<issue-number> -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ECDSA署名の形式検出ロジックを改善し、より堅牢な処理を実現しました。

* **Tests**
  * 署名変換処理の追加テストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trustknots/vcknots/pull/261)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->