### PR TITLE
fix(wallet): validate credential configuration IDs against issuer metadata

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -533,7 +533,7 @@ func (w *Wallet) fetchCredentialMetadata(req ReceiveCredentialRequest) (*receive
 		}
 	}
 
-	if err := validateCredentialConfigurationIDs(req.CredentialOffer, issuerMetadata); err != nil {
+	if err := w.validateCredentialConfigurationIDs(req.CredentialOffer, issuerMetadata); err != nil {
 		return nil, nil, err
 	}
 
@@ -564,17 +564,20 @@ func (w *Wallet) fetchCredentialMetadata(req ReceiveCredentialRequest) (*receive
 	return issuerMetadata, authMetadata, nil
 }
 
-func validateCredentialConfigurationIDs(offer *CredentialOffer, issuerMetadata *receiverTypes.CredentialIssuerMetadata) error {
+func (w *Wallet) validateCredentialConfigurationIDs(offer *CredentialOffer, issuerMetadata *receiverTypes.CredentialIssuerMetadata) error {
 	if offer == nil {
 		return fmt.Errorf("credential offer is required")
 	}
 	if issuerMetadata == nil {
-		return fmt.Errorf("credential issuer metadata is nil")
+		return fmt.Errorf("issuer metadata is required")
+	}
+	if len(issuerMetadata.CredentialConfigurationSupported) == 0 {
+		return fmt.Errorf("credential configurations supported are missing in issuer metadata")
 	}
 
 	for _, configID := range offer.CredentialConfigurationIDs {
-		if _, ok := issuerMetadata.CredentialConfigurationSupported[configID]; !ok {
-			return fmt.Errorf("credential configuration %s is not supported by issuer metadata", configID)
+		if _, exists := issuerMetadata.CredentialConfigurationSupported[configID]; !exists {
+			return fmt.Errorf("credential configuration %q is not supported by issuer metadata", configID)
 		}
 	}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -496,6 +496,26 @@ func (w *Wallet) validateCredentialOffer(offer *CredentialOffer) (string, error)
 	return preAuthCode, nil
 }
 
+func (w *Wallet) validateCredentialConfigurationIDs(offer *CredentialOffer, issuerMetadata *receiverTypes.CredentialIssuerMetadata) error {
+	if offer == nil {
+		return fmt.Errorf("credential offer is required")
+	}
+	if issuerMetadata == nil {
+		return fmt.Errorf("issuer metadata is required")
+	}
+	if len(issuerMetadata.CredentialConfigurationSupported) == 0 {
+		return fmt.Errorf("credential configurations supported are missing in issuer metadata")
+	}
+
+	for _, configID := range offer.CredentialConfigurationIDs {
+		if _, exists := issuerMetadata.CredentialConfigurationSupported[configID]; !exists {
+			return fmt.Errorf("credential configuration %q is not supported by issuer metadata", configID)
+		}
+	}
+
+	return nil
+}
+
 func validateCredentialIssuerIdentifier(issuer *url.URL) error {
 	if issuer == nil {
 		return fmt.Errorf("credential issuer is not included in the offer")
@@ -562,26 +582,6 @@ func (w *Wallet) fetchCredentialMetadata(req ReceiveCredentialRequest) (*receive
 	}
 
 	return issuerMetadata, authMetadata, nil
-}
-
-func (w *Wallet) validateCredentialConfigurationIDs(offer *CredentialOffer, issuerMetadata *receiverTypes.CredentialIssuerMetadata) error {
-	if offer == nil {
-		return fmt.Errorf("credential offer is required")
-	}
-	if issuerMetadata == nil {
-		return fmt.Errorf("issuer metadata is required")
-	}
-	if len(issuerMetadata.CredentialConfigurationSupported) == 0 {
-		return fmt.Errorf("credential configurations supported are missing in issuer metadata")
-	}
-
-	for _, configID := range offer.CredentialConfigurationIDs {
-		if _, exists := issuerMetadata.CredentialConfigurationSupported[configID]; !exists {
-			return fmt.Errorf("credential configuration %q is not supported by issuer metadata", configID)
-		}
-	}
-
-	return nil
 }
 
 // obtainAccessToken obtains an access token using pre-authorization code.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -533,6 +533,10 @@ func (w *Wallet) fetchCredentialMetadata(req ReceiveCredentialRequest) (*receive
 		}
 	}
 
+	if err := validateCredentialConfigurationIDs(req.CredentialOffer, issuerMetadata); err != nil {
+		return nil, nil, err
+	}
+
 	if len(issuerMetadata.AuthorizationServers) == 0 {
 		return nil, nil, fmt.Errorf("no authorization servers found in issuer metadata")
 	}
@@ -558,6 +562,23 @@ func (w *Wallet) fetchCredentialMetadata(req ReceiveCredentialRequest) (*receive
 	}
 
 	return issuerMetadata, authMetadata, nil
+}
+
+func validateCredentialConfigurationIDs(offer *CredentialOffer, issuerMetadata *receiverTypes.CredentialIssuerMetadata) error {
+	if offer == nil {
+		return fmt.Errorf("credential offer is required")
+	}
+	if issuerMetadata == nil {
+		return fmt.Errorf("credential issuer metadata is nil")
+	}
+
+	for _, configID := range offer.CredentialConfigurationIDs {
+		if _, ok := issuerMetadata.CredentialConfigurationSupported[configID]; !ok {
+			return fmt.Errorf("credential configuration %s is not supported by issuer metadata", configID)
+		}
+	}
+
+	return nil
 }
 
 // obtainAccessToken obtains an access token using pre-authorization code.

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1110,6 +1110,30 @@ func TestController_FetchCredentialIssuerMetadata_WithMockServer(t *testing.T) {
 	t.Logf("Successfully fetched metadata: %+v", metadata)
 }
 
+func TestWallet_fetchCredentialMetadata_RejectsUnsupportedCredentialConfigurationID(t *testing.T) {
+	controller := createTestControllerWithDefaults(t)
+	issuerURL := mustParseURL(t, "https://issuer.example.com")
+
+	req := ReceiveCredentialRequest{
+		CredentialOffer: &CredentialOffer{
+			CredentialIssuer:           issuerURL,
+			CredentialConfigurationIDs: []string{"supported-config", "missing-config"},
+		},
+		Type: receiverTypes.Oid4vci,
+		CachedIssuerMetadata: &receiverTypes.CredentialIssuerMetadata{
+			CredentialConfigurationSupported: map[string]receiverTypes.CredentialConfiguration{
+				"supported-config": {
+					Format: "jwt_vc_json",
+				},
+			},
+		},
+	}
+
+	_, _, err := controller.fetchCredentialMetadata(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "credential configuration missing-config is not supported by issuer metadata")
+}
+
 func TestController_PresentCredential_WithMockServer_Integration(t *testing.T) {
 	// First, create a mock OID4VCI server to get a credential
 	vciServer := createMockOID4VCIServer()

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1110,28 +1110,37 @@ func TestController_FetchCredentialIssuerMetadata_WithMockServer(t *testing.T) {
 	t.Logf("Successfully fetched metadata: %+v", metadata)
 }
 
-func TestWallet_fetchCredentialMetadata_RejectsUnsupportedCredentialConfigurationID(t *testing.T) {
+func TestController_ReceiveCredential_RejectsUnsupportedCredentialConfigurationID(t *testing.T) {
+	server := createMockOID4VCIServer()
+	defer server.Close()
+
 	controller := createTestControllerWithDefaults(t)
-	issuerURL := mustParseURL(t, "https://issuer.example.com")
+
+	serverURL, err := url.Parse(server.URL())
+	require.NoError(t, err)
+
+	httpAllowed := env.IsHTTPAllowed()
+	defer env.SetHTTPAllowed(httpAllowed)
+	env.SetHTTPAllowed(true)
 
 	req := ReceiveCredentialRequest{
 		CredentialOffer: &CredentialOffer{
-			CredentialIssuer:           issuerURL,
-			CredentialConfigurationIDs: []string{"supported-config", "missing-config"},
-		},
-		Type: receiverTypes.Oid4vci,
-		CachedIssuerMetadata: &receiverTypes.CredentialIssuerMetadata{
-			CredentialConfigurationSupported: map[string]receiverTypes.CredentialConfiguration{
-				"supported-config": {
-					Format: "jwt_vc_json",
+			CredentialIssuer:           serverURL,
+			CredentialConfigurationIDs: []string{"unsupported-config"},
+			Grants: map[string]*CredentialOfferGrant{
+				"urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+					PreAuthorizedCode: "test-code",
 				},
 			},
 		},
+		Type: receiverTypes.Oid4vci,
+		Key:  newMockKeyEntry(),
 	}
 
-	_, _, err := controller.fetchCredentialMetadata(req)
+	credential, err := controller.ReceiveCredential(req)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "credential configuration missing-config is not supported by issuer metadata")
+	require.Nil(t, credential)
+	require.Contains(t, err.Error(), `credential configuration "unsupported-config" is not supported by issuer metadata`)
 }
 
 func TestController_PresentCredential_WithMockServer_Integration(t *testing.T) {
@@ -1820,6 +1829,71 @@ func TestWallet_validateCredentialOffer(t *testing.T) {
 
 			require.NoError(t, gotErr)
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWallet_validateCredentialConfigurationIDs(t *testing.T) {
+	tests := []struct {
+		name            string
+		offer           *CredentialOffer
+		issuerMetadata  *receiverTypes.CredentialIssuerMetadata
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:    "all offered configuration IDs are supported",
+			offer:   &CredentialOffer{CredentialConfigurationIDs: []string{"EmployeeID_jwt_vc_json", "StudentID_jwt_vc_json"}},
+			wantErr: false,
+			issuerMetadata: &receiverTypes.CredentialIssuerMetadata{
+				CredentialConfigurationSupported: map[string]receiverTypes.CredentialConfiguration{
+					"EmployeeID_jwt_vc_json": {Format: "jwt_vc_json"},
+					"StudentID_jwt_vc_json":  {Format: "jwt_vc_json"},
+				},
+			},
+		},
+		{
+			name:  "unsupported offered configuration ID is rejected",
+			offer: &CredentialOffer{CredentialConfigurationIDs: []string{"EmployeeID_jwt_vc_json", "UnknownID_jwt_vc_json"}},
+			issuerMetadata: &receiverTypes.CredentialIssuerMetadata{
+				CredentialConfigurationSupported: map[string]receiverTypes.CredentialConfiguration{
+					"EmployeeID_jwt_vc_json": {Format: "jwt_vc_json"},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: `credential configuration "UnknownID_jwt_vc_json" is not supported by issuer metadata`,
+		},
+		{
+			name:            "missing issuer metadata is rejected",
+			offer:           &CredentialOffer{CredentialConfigurationIDs: []string{"EmployeeID_jwt_vc_json"}},
+			issuerMetadata:  nil,
+			wantErr:         true,
+			wantErrContains: "issuer metadata is required",
+		},
+		{
+			name:  "missing supported configurations in metadata is rejected",
+			offer: &CredentialOffer{CredentialConfigurationIDs: []string{"EmployeeID_jwt_vc_json"}},
+			issuerMetadata: &receiverTypes.CredentialIssuerMetadata{
+				CredentialConfigurationSupported: map[string]receiverTypes.CredentialConfiguration{},
+			},
+			wantErr:         true,
+			wantErrContains: "credential configurations supported are missing in issuer metadata",
+		},
+	}
+
+	w, err := NewWallet()
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := w.validateCredentialConfigurationIDs(tt.offer, tt.issuerMetadata)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Validate each `credential_configuration_ids` value from a Credential Offer against `credential_configurations_supported` in Issuer Metadata
- Return a descriptive error before continuing the OID4VCI receive flow when an unsupported configuration ID is included
- Add a regression test for unsupported credential configuration IDs

## Testing

- `gofmt -w wallet.go wallet_test.go`
- `go test ./...` in `wallet/`

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 資格情報オファーの受領前に、オファー内の設定識別子が発行者メタデータでサポートされているかを事前検証するようになりました。未サポートの識別子を含むオファーは受信フロー前にエラーになります。
* **テスト**
  * サポート有無やメタデータ欠如などの各ケースを検証する自動テストを追加し、早期エラー検出の動作を担保しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->