### PR TITLE
fix(wallet): enforce OID4VP draft 24 §5.11 request_uri requirements

### DIFF
--- a/wallet/presenter/plugins/oid4vp/oid4vp.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp.go
@@ -722,7 +722,9 @@ func (b *requestBuilder) WithRequestObjectURI(uri string, method RequestURIMetho
 		b.errValidation = fmt.Errorf("failed to parse request_uri %q: %w", uri, err)
 		return b
 	}
-	if !env.IsHTTPAllowed() && !strings.EqualFold(parsedURI.Scheme, "https") {
+	schemeOK := strings.EqualFold(parsedURI.Scheme, "https") ||
+		(env.IsHTTPAllowed() && strings.EqualFold(parsedURI.Scheme, "http"))
+	if !schemeOK {
 		b.errValidation = fmt.Errorf("unsupported URL scheme for request_uri: %q (https required; set VCKNOTS_WALLET_HTTP_ALLOWED=true to allow http for testing)", parsedURI.Scheme)
 		return b
 	}

--- a/wallet/presenter/plugins/oid4vp/oid4vp.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp.go
@@ -704,19 +704,41 @@ func (b *requestBuilder) WithRequestObject(obj string) *requestBuilder {
 // WithRequestObjectURI constructs the CredentialPresentationRequest
 // with fetching the request object from the given URI using the specified method,
 // and validates its claims and signature as per OID4VP and RFC9101.
+//
+// Per OID4VP draft 24 §5.11, when method is POST the request MUST use the
+// https scheme, set Content-Type: application/x-www-form-urlencoded and
+// Accept: application/oauth-authz-req+jwt. The https requirement is also
+// applied to the GET method for project-wide consistency with the same
+// guard in wallet/receiver/plugins/oid4vci/oid4vci.go (Issue #29).
+// It can be relaxed by setting the VCKNOTS_WALLET_HTTP_ALLOWED environment
+// variable for testing.
 func (b *requestBuilder) WithRequestObjectURI(uri string, method RequestURIMethod) *requestBuilder {
 	if b.errValidation != nil {
 		return b
 	}
 
+	parsedURI, err := url.Parse(uri)
+	if err != nil {
+		b.errValidation = fmt.Errorf("failed to parse request_uri %q: %w", uri, err)
+		return b
+	}
+	if !env.IsHTTPAllowed() && !strings.EqualFold(parsedURI.Scheme, "https") {
+		b.errValidation = fmt.Errorf("unsupported URL scheme for request_uri: %q (https required; set VCKNOTS_WALLET_HTTP_ALLOWED=true to allow http for testing)", parsedURI.Scheme)
+		return b
+	}
+
 	var req *http.Request
-	var err error
 
 	switch method {
 	case RequestURIMethodGET:
-		req, err = http.NewRequest(http.MethodGet, uri, nil)
+		req, err = http.NewRequest(http.MethodGet, parsedURI.String(), nil)
 	case RequestURIMethodPOST:
-		req, err = http.NewRequest(http.MethodPost, uri, nil)
+		req, err = http.NewRequest(http.MethodPost, parsedURI.String(), nil)
+		if err == nil {
+			// OID4VP draft 24 §5.11: Request URI Method post
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("Accept", "application/oauth-authz-req+jwt")
+		}
 	default:
 		b.errValidation = fmt.Errorf("unsupported request_uri_method: %s", method)
 		return b

--- a/wallet/presenter/plugins/oid4vp/oid4vp_test.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp_test.go
@@ -987,4 +987,21 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 			t.Fatalf("expected https-required error, got: %v", rb.errValidation)
 		}
 	})
+
+	// Non-http(s) schemes must be rejected regardless of HTTP_ALLOWED.
+	t.Run("rejects non-http(s) scheme even when HTTP_ALLOWED is true", func(t *testing.T) {
+		t.Setenv(env.HTTP_ALLOWED.String(), "true")
+
+		for _, badURI := range []string{
+			"ftp://example.com/request-object",
+			"file:///etc/passwd",
+			"data:text/plain,foo",
+		} {
+			rb := requestBuilder{}
+			rb.WithRequestObjectURI(badURI, RequestURIMethodGET)
+			if rb.errValidation == nil || !strings.Contains(rb.errValidation.Error(), "https required") {
+				t.Errorf("uri=%q: expected https-required error, got: %v", badURI, rb.errValidation)
+			}
+		}
+	})
 }

--- a/wallet/presenter/plugins/oid4vp/oid4vp_test.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp_test.go
@@ -132,6 +132,9 @@ func mustParseURL(t *testing.T, rawURL string) *url.URL {
 }
 
 func TestOid4vpPresenter_ParsePresentationRequest(t *testing.T) {
+	// mockserver / httptest.NewServer use http; allow it for these tests.
+	t.Setenv(env.HTTP_ALLOWED.String(), "true")
+
 	// Setup mock verifier server with proper JWT signing
 	verifierServer := mockserver.NewOID4VPVerifierServer(nil)
 	defer verifierServer.Close()
@@ -886,6 +889,9 @@ func TestOid4vpPresenter_RequestObject_WithX5C_X509SanDNS_SuccessAndFailures(t *
 }
 
 func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
+	// mockserver is HTTP-only; allow http scheme for these tests.
+	t.Setenv(env.HTTP_ALLOWED.String(), "true")
+
 	t.Run("Delete default User-Agent header (GET)", func(t *testing.T) {
 		m := mockserver.NewMockServer()
 		defer m.Close()
@@ -929,6 +935,56 @@ func Test_requestBuilder_WithRequestObjectURI(t *testing.T) {
 		rb.WithRequestObjectURI(requestObjectURI.String(), RequestURIMethodPOST)
 		if !called {
 			t.Fatal("handler was not invoked")
+		}
+	})
+
+	// OID4VP draft 24 §5.11: POST request must set the prescribed
+	// Content-Type and Accept headers.
+	t.Run("POST sets Content-Type and Accept headers", func(t *testing.T) {
+		m := mockserver.NewMockServer()
+		defer m.Close()
+
+		var gotContentType, gotAccept string
+		m.HandleFunc("/request-object", func(w http.ResponseWriter, r *http.Request) {
+			gotContentType = r.Header.Get("Content-Type")
+			gotAccept = r.Header.Get("Accept")
+			w.WriteHeader(http.StatusOK)
+		})
+
+		requestObjectURI, _ := url.Parse(m.URL() + "/request-object")
+
+		rb := requestBuilder{}
+		rb.WithRequestObjectURI(requestObjectURI.String(), RequestURIMethodPOST)
+
+		if gotContentType != "application/x-www-form-urlencoded" {
+			t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", gotContentType)
+		}
+		if gotAccept != "application/oauth-authz-req+jwt" {
+			t.Errorf("Accept = %q, want application/oauth-authz-req+jwt", gotAccept)
+		}
+	})
+
+	// OID4VP draft 24 §5.11: request_uri must use the https scheme.
+	// IsHTTPAllowed() short-circuits on DEBUG, so clear both env vars.
+	t.Run("rejects http scheme when HTTP_ALLOWED is false (GET)", func(t *testing.T) {
+		t.Setenv(env.HTTP_ALLOWED.String(), "")
+		t.Setenv(env.DEBUG.String(), "")
+
+		rb := requestBuilder{}
+		rb.WithRequestObjectURI("http://example.com/request-object", RequestURIMethodGET)
+		if rb.errValidation == nil || !strings.Contains(rb.errValidation.Error(), "https required") {
+			t.Fatalf("expected https-required error, got: %v", rb.errValidation)
+		}
+	})
+
+	t.Run("rejects http scheme when HTTP_ALLOWED is false (POST)", func(t *testing.T) {
+		t.Setenv(env.HTTP_ALLOWED.String(), "")
+		t.Setenv(env.DEBUG.String(), "")
+
+		rb := requestBuilder{}
+		rb.WithRequestObjectURI("http://example.com/request-object", RequestURIMethodPOST)
+		if rb.errValidation == nil || !strings.Contains(rb.errValidation.Error(), "https required") {
+			t.Fatalf("expected https-required error, got: %v", rb.errValidation)
 		}
 	})
 }


### PR DESCRIPTION
WithRequestObjectURI now sets Content-Type: application/x-www-form-urlencoded and Accept: application/oauth-authz-req+jwt for POST, and validates the request_uri uses https (gated by VCKNOTS_WALLET_HTTP_ALLOWED for testing, matching the oid4vci.go pattern from #29).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OID4VPリクエストURIの検証を強化し、原則としてHTTPSを要求。限定的な環境設定でのみHTTPを許可する挙動を追加。
  * POST時に適切なContent-Type/Acceptヘッダを確実に設定するよう改善。パース失敗や未対応スキーム時のエラーメッセージを明確化。

* **Tests**
  * セキュリティ検証、HTTP許可フラグ挙動、およびPOSTヘッダ設定の動作確認テストを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trustknots/vcknots/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->