### PR TITLE
chore: add authz server hint to offer

### DIFF
--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -624,7 +624,7 @@ curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/off
 **Response**
 
 ```raw
-openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredential%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%224a5f42719f49402ba2322e7cd410491e%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%7D%7D%2C%22authorization_server%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%7D
+openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredential%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22496d5305a74c4af2a4eb9d90fe445da5%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%2C%22authorization_server%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%7D%7D%7D
 ```
 
 
@@ -1413,6 +1413,7 @@ type OfferOptions =
   | {
       usePreAuth: false
       state?: unknown
+      authorizationServer?: string
     }
   | {
       usePreAuth: true
@@ -1422,6 +1423,7 @@ type OfferOptions =
         description?: string
       }
       ttlSec?: number
+      authorizationServer?: string
     }
 ```
 

--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -465,6 +465,7 @@ app.post('/configurations/:configuration/offer', async (c) => {
       const { offer, tx_code } = await issuerFlow.offerCredential(issuer, configurations, {
         usePreAuth: true,
         txCode: options?.tx_code,
+        authorizationServer: c.req.query('authorization_server'),
       })
 
       console.log('offer:', offer)

--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -624,7 +624,7 @@ curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/off
 **Response**
 
 ```raw
-openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredential%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22496d5305a74c4af2a4eb9d90fe445da5%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%2C%22authorization_server%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%7D%7D%7D
+openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredentialSdJwt%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%2268baf35e74ae430684662d85ea87160e%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%7D%7D%7D
 ```
 
 

--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -585,7 +585,7 @@ app.post('/configurations/:configuration/offer', async (c) => {
       const { offer, tx_code } = await issuerFlow.offerCredential(issuer, configurations, {
         usePreAuth: true,
         txCode: options?.tx_code,
-        authorizationServer: c.req.query('authorization_server'),
+        authorizationServer: options?.authorization_server,
       })
 
       console.log('offer:', offer)

--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -616,14 +616,15 @@ curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/off
       "input_mode": "numeric",
       "length": 6,
       "description": "Please enter the one-time code."
-    }
+    },
+    "authorization_server":"http://localhost:8080"
   }'
 ```
 
 **Response**
 
 ```raw
-openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredentialSdJwt%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%2268baf35e74ae430684662d85ea87160e%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%7D%7D%7D
+openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredential%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%224a5f42719f49402ba2322e7cd410491e%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%7D%7D%2C%22authorization_server%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%7D
 ```
 
 

--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -606,8 +606,10 @@ app.post('/configurations/:configuration/offer', async (c) => {
 
 **Request**
 
-Include a request body (JSON) only when specifying `tx_code` or `authorization_server`.
-`authorization_server` can be included only when the Issuer Metadata contains multiple entries in `authorization_servers`.
+Include a request body (JSON) only when specifying optional parameters.
+
+- `tx_code` can be used to include a transaction code in the Credential Offer.
+- `authorization_server` can be included only when the Issuer Metadata contains multiple entries in `authorization_servers`.
 
 ```bash
 curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/offer \

--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -606,7 +606,8 @@ app.post('/configurations/:configuration/offer', async (c) => {
 
 **Request**
 
-Include a request body (JSON) only when specifying `tx_code`.
+Include a request body (JSON) only when specifying `tx_code` or `authorization_server`.
+`authorization_server` can be included only when the Issuer Metadata contains multiple entries in `authorization_servers`.
 
 ```bash
 curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/offer \
@@ -616,8 +617,7 @@ curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/off
       "input_mode": "numeric",
       "length": 6,
       "description": "Please enter the one-time code."
-    },
-    "authorization_server":"http://localhost:8080"
+    }
   }'
 ```
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -622,7 +622,7 @@ curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/off
 **レスポンス**
 
 ```raw
-openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredential%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22496d5305a74c4af2a4eb9d90fe445da5%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%2C%22authorization_server%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%7D%7D%7D
+openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredentialSdJwt%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%2268baf35e74ae430684662d85ea87160e%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%7D%7D%7D
 ```
 
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -614,14 +614,15 @@ curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/off
       "input_mode": "numeric",
       "length": 6,
       "description": "Please enter the one-time code."
-    }
+    },
+    "authorization_server":"http://localhost:8080"
   }'
 ```
 
 **レスポンス**
 
 ```raw
-openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredentialSdJwt%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%2268baf35e74ae430684662d85ea87160e%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%7D%7D%7D
+openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredential%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%224a5f42719f49402ba2322e7cd410491e%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%7D%7D%2C%22authorization_server%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%7D
 ```
 
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -584,7 +584,7 @@ app.post('/configurations/:configuration/offer', async (c) => {
       const { offer, tx_code } = await issuerFlow.offerCredential(issuer, configurations, {
         usePreAuth: true,
         txCode: options?.tx_code,
-        authorizationServer: c.req.query('authorization_server'),
+        authorizationServer: options?.authorization_server,
       })
       console.log('offer:', offer)
       console.log('tx_code:', tx_code)

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -622,7 +622,7 @@ curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/off
 **レスポンス**
 
 ```raw
-openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredential%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%224a5f42719f49402ba2322e7cd410491e%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%7D%7D%2C%22authorization_server%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%7D
+openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredential%22%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22496d5305a74c4af2a4eb9d90fe445da5%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22numeric%22%2C%22length%22%3A6%2C%22description%22%3A%22Please%20enter%20the%20one-time%20code.%22%7D%2C%22authorization_server%22%3A%22http%3A%2F%2Flocalhost%3A8080%22%7D%7D%7D
 ```
 
 
@@ -1412,6 +1412,7 @@ type OfferOptions =
   | {
       usePreAuth: false
       state?: unknown
+      authorizationServer?: string
     }
   | {
       usePreAuth: true
@@ -1421,6 +1422,7 @@ type OfferOptions =
         description?: string
       }
       ttlSec?: number
+      authorizationServer?: string
     }
 ```
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -604,8 +604,10 @@ app.post('/configurations/:configuration/offer', async (c) => {
 
 **リクエスト**
 
-`tx_code` や `authorization_server` 指定する場合のみ、リクエストボディ（JSON）を付けて送信します。
-`authorization_server` は、Issuer Metadata の `authorization_servers` に複数のエントリーが含まれる場合にのみ指定できます。
+任意パラメータを指定する場合のみ、リクエストボディ（JSON）を含めてください。
+
+- tx_code は、Credential Offer にトランザクションコードを含めるために使用できます。
+- authorization_server は、Issuer Metadata の authorization_servers に複数のエントリーが含まれる場合にのみ指定できます。
 
 ```bash
 curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/offer \

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -465,6 +465,7 @@ app.post('/configurations/:configuration/offer', async (c) => {
       const { offer, tx_code } = await issuerFlow.offerCredential(issuer, configurations, {
         usePreAuth: true,
         txCode: options?.tx_code,
+        authorizationServer: c.req.query('authorization_server'),
       })
       console.log('offer:', offer)
       console.log('tx_code:', tx_code)

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -604,7 +604,8 @@ app.post('/configurations/:configuration/offer', async (c) => {
 
 **リクエスト**
 
-`tx_code` を指定する場合のみ、リクエストボディ（JSON）を付けて送信します。
+`tx_code` や `authorization_server` 指定する場合のみ、リクエストボディ（JSON）を付けて送信します。
+`authorization_server` は、Issuer Metadata の `authorization_servers` に複数のエントリーが含まれる場合にのみ指定できます。
 
 ```bash
 curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/offer \
@@ -614,8 +615,7 @@ curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/off
       "input_mode": "numeric",
       "length": 6,
       "description": "Please enter the one-time code."
-    },
-    "authorization_server":"http://localhost:8080"
+    }
   }'
 ```
 

--- a/issuer+verifier/src/credential-offer.types.ts
+++ b/issuer+verifier/src/credential-offer.types.ts
@@ -13,12 +13,14 @@ const preAuthorizedCodeGrantSchema = z
   .object({
     'pre-authorized_code': z.string(),
     tx_code: txCodeSchema,
+    authorization_server: z.string().optional(),
   })
   .optional()
 
 const authorizationCodeGrantSchema = z
   .object({
     issuer_state: z.string().optional(),
+    authorization_server: z.string().optional(),
   })
   .optional()
 
@@ -32,7 +34,6 @@ const grantsSchema = z
 export const credentialOfferSchema = z.object({
   credential_issuer: CredentialIssuer.schema,
   grants: grantsSchema,
-  authorization_server: z.string().optional(),
   credential_configuration_ids: z.array(CredentialConfigurationId.schema),
 })
 
@@ -45,7 +46,6 @@ export type TxCode = z.infer<typeof txCodeSchema>
 export const CredentialOffer = (value?: {
   credential_issuer?: string
   grants?: unknown // TODO: Define the appropriate type
-  authorization_server?: string
   credential_configuration_ids: string[]
 }) => credentialOfferSchema.parse(value)
 CredentialOffer.schema = credentialOfferSchema

--- a/issuer+verifier/src/credential-offer.types.ts
+++ b/issuer+verifier/src/credential-offer.types.ts
@@ -33,6 +33,7 @@ export const credentialOfferSchema = z.object({
   credential_issuer: CredentialIssuer.schema,
   grants: grantsSchema,
   credential_configuration_ids: z.array(CredentialConfigurationId.schema).optional(),
+  authorization_server: z.string().optional(),
 })
 
 export type CredentialOffer = z.infer<typeof credentialOfferSchema>
@@ -45,6 +46,7 @@ export const CredentialOffer = (value?: {
   credential_issuer?: string
   grants?: unknown // TODO: Define the appropriate type
   credential_configuration_ids?: string[]
+  authorization_server?: string
 }) => credentialOfferSchema.parse(value)
 CredentialOffer.schema = credentialOfferSchema
 

--- a/issuer+verifier/src/credential-offer.types.ts
+++ b/issuer+verifier/src/credential-offer.types.ts
@@ -13,14 +13,14 @@ const preAuthorizedCodeGrantSchema = z
   .object({
     'pre-authorized_code': z.string(),
     tx_code: txCodeSchema,
-    authorization_server: z.string().optional(),
+    authorization_server: z.string().url().optional(),
   })
   .optional()
 
 const authorizationCodeGrantSchema = z
   .object({
     issuer_state: z.string().optional(),
-    authorization_server: z.string().optional(),
+    authorization_server: z.string().url().optional(),
   })
   .optional()
 

--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -242,13 +242,16 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
         })
       }
 
-      if (
-        options?.authorizationServer &&
-        !metadata.authorization_servers?.includes(options?.authorizationServer)
-      ) {
-        throw err('invalid_credential_request', {
-          message: `Authorization server ${options?.authorizationServer} is not supported by issuer ${issuer}.`,
-        })
+      if (options?.authorizationServer) {
+        const supportedAuthorizationServers = metadata.authorization_servers ?? [
+          metadata.credential_issuer,
+        ]
+
+        if (!supportedAuthorizationServers.includes(options.authorizationServer)) {
+          throw err('invalid_credential_request', {
+            message: `Authorization server ${options.authorizationServer} is not supported by issuer ${issuer}.`,
+          })
+        }
       }
 
       for (const configId of configurations) {

--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -22,6 +22,7 @@ type OfferOptions =
   | {
       usePreAuth: false
       state?: unknown
+      authorizationServer?: string
     }
   | {
       usePreAuth: true
@@ -31,6 +32,7 @@ type OfferOptions =
         description?: string
       }
       ttlSec?: number
+      authorizationServer?: string
     }
 type IssueOptions = {
   alg: string
@@ -210,6 +212,15 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
           message: `Issuer metadata for ${issuer} not found.`,
         })
 
+      if (
+        options?.authorizationServer &&
+        !metadata.authorization_servers?.includes(options?.authorizationServer)
+      ) {
+        throw err('invalid_credential_request', {
+          message: `Authorization server ${options?.authorizationServer} is not supported by issuer ${issuer}.`,
+        })
+      }
+
       for (const configId of configurations) {
         if (metadata.credential_configurations_supported[configId] === undefined) {
           throw err('unknown_credential_configuration', {
@@ -243,6 +254,7 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
             description: options.txCode.description,
           },
         }),
+        ...(options?.authorizationServer && { authorizationServer: options.authorizationServer }),
       })
       return {
         offer,

--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -243,11 +243,17 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
       }
 
       if (options?.authorizationServer) {
-        const supportedAuthorizationServers = metadata.authorization_servers ?? [
-          metadata.credential_issuer,
-        ]
+        if (
+          metadata.authorization_servers === undefined ||
+          metadata.authorization_servers.length <= 1
+        ) {
+          throw err('invalid_credential_request', {
+            message:
+              'authorization_server can only be used when authorization_servers has multiple entries.',
+          })
+        }
 
-        if (!supportedAuthorizationServers.includes(options.authorizationServer)) {
+        if (!metadata.authorization_servers.includes(options.authorizationServer)) {
           throw err('invalid_credential_request', {
             message: `Authorization server ${options.authorizationServer} is not supported by issuer ${issuer}.`,
           })

--- a/issuer+verifier/src/providers/credential-offer.provider.ts
+++ b/issuer+verifier/src/providers/credential-offer.provider.ts
@@ -34,6 +34,9 @@ export const credentialOffer = (): CredentialOfferProvider => {
         credential_issuer: issuer.credential_issuer,
         credential_configuration_ids: configurations,
         grants,
+        ...(options.authorizationServer && {
+          authorization_server: options.authorizationServer,
+        }),
       }
     },
   }

--- a/issuer+verifier/src/providers/credential-offer.provider.ts
+++ b/issuer+verifier/src/providers/credential-offer.provider.ts
@@ -22,11 +22,17 @@ export const credentialOffer = (): CredentialOfferProvider => {
             'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
               'pre-authorized_code': options.code,
               ...(txCode && { tx_code: txCode }),
+              ...(options.authorizationServer && {
+                authorization_server: options.authorizationServer,
+              }),
             },
           }
         : {
             authorization_code: {
               issuer_state: String(options.state),
+              ...(options.authorizationServer && {
+                authorization_server: options.authorizationServer,
+              }),
             },
           }
 
@@ -34,9 +40,6 @@ export const credentialOffer = (): CredentialOfferProvider => {
         credential_issuer: issuer.credential_issuer,
         credential_configuration_ids: configurations,
         grants,
-        ...(options.authorizationServer && {
-          authorization_server: options.authorizationServer,
-        }),
       }
     },
   }

--- a/issuer+verifier/src/providers/provider.types.ts
+++ b/issuer+verifier/src/providers/provider.types.ts
@@ -379,10 +379,12 @@ export type CredentialOfferProvider = {
             length?: number
             description?: string
           }
+          authorizationServer?: string
         }
       | {
           usePreAuth: false
           state: unknown
+          authorizationServer?: string
         }
   ): Promise<CredentialOffer>
 }

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -356,6 +356,75 @@ describe('IssuerFlow', () => {
     assert.equal(mockPreAuthCodeStoreProvider.save.mock.callCount(), 1)
     assert.equal(mockCredentialOfferProvider.create.mock.callCount(), 1)
   })
+  it('should create a credential offer with pre-authorized code with authz server', async () => {
+    const metadata = CredentialIssuerMetadata({
+      credential_issuer: issuer,
+      credential_endpoint: 'https://example.com/credentials',
+      authorization_servers: ['https://example.com/auth'],
+      credential_configurations_supported: {
+        VerifiableId: {
+          format: 'jwt_vc_json',
+          credential_definition: {
+            type: ['VCKnots'],
+            credentialSubject: {},
+          },
+          credential_signing_alg_values_supported: ['ES256'],
+        },
+      },
+    })
+    const options = {
+      usePreAuth: true,
+      authorization_server: 'https://example.com/auth',
+    }
+    const code = 'PREAUTHCODE'
+    const offer = CredentialOffer({
+      credential_issuer: issuer,
+      authorization_server: 'https://example.com/auth',
+    })
+    mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
+    mock.method(mockPreAuthCodeProvider, 'generate', async () => code)
+    mock.method(mockPreAuthCodeStoreProvider, 'save', async () => {})
+    mock.method(mockCredentialOfferProvider, 'create', async () => offer)
+
+    const result = await issuerFlow.offerCredential(issuer, configurations, options)
+
+    assert.ok(result)
+    assert.equal(mockIssuerMetadataProvider.fetch.mock.callCount(), 1)
+    assert.equal(mockPreAuthCodeProvider.generate.mock.callCount(), 1)
+    assert.equal(mockPreAuthCodeStoreProvider.save.mock.callCount(), 1)
+    assert.equal(mockCredentialOfferProvider.create.mock.callCount(), 1)
+  })
+  it(`should throw 'invalid_credential_request'  error when the provided authorization server is not found in the issuer metadata`, async () => {
+    const metadata = CredentialIssuerMetadata({
+      credential_issuer: issuer,
+      credential_endpoint: 'https://example.com/credentials',
+      authorization_servers: ['https://example.com/auth'],
+      credential_configurations_supported: {
+        VerifiableId: {
+          format: 'jwt_vc_json',
+          credential_definition: {
+            type: ['VCKnots'],
+            credentialSubject: {},
+          },
+          credential_signing_alg_values_supported: ['ES256'],
+        },
+      },
+    })
+
+    mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
+
+    const suspects = async () => {
+      return await issuerFlow.offerCredential(issuer, configurations, {
+        usePreAuth: true,
+        authorizationServer: 'https://example.com/failed',
+      })
+    }
+
+    await assert.rejects(suspects, {
+      name: 'invalid_credential_request',
+      message: `Authorization server https://example.com/failed is not supported by issuer ${issuer}.`,
+    })
+  })
 
   it('should create a credential offer with txCode when txCode options are provided', async () => {
     const metadata: CredentialIssuerMetadata = {

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -388,6 +388,7 @@ describe('IssuerFlow', () => {
     assert.equal(mockPreAuthCodeStoreProvider.save.mock.callCount(), 1)
     assert.equal(mockCredentialOfferProvider.create.mock.callCount(), 1)
   })
+
   it('should create a credential offer with pre-authorized code with authz server', async () => {
     const metadata = CredentialIssuerMetadata({
       credential_issuer: issuer,
@@ -427,7 +428,49 @@ describe('IssuerFlow', () => {
     assert.equal(mockPreAuthCodeStoreProvider.save.mock.callCount(), 1)
     assert.equal(mockCredentialOfferProvider.create.mock.callCount(), 1)
   })
-  it(`should throw 'invalid_credential_request'  error when the provided authorization server is not found in the issuer metadata`, async () => {
+
+  it('should create a credential offer when authorizationServer equals credential_issuer and authorization_servers is undefined', async () => {
+    const metadata = CredentialIssuerMetadata({
+      credential_issuer: issuer,
+      credential_endpoint: 'https://example.com/credentials',
+      credential_configurations_supported: {
+        VerifiableId: {
+          format: 'jwt_vc_json',
+          credential_definition: {
+            type: ['VCKnots'],
+            credentialSubject: {},
+          },
+          credential_signing_alg_values_supported: ['ES256'],
+        },
+      },
+    })
+    const options = {
+      usePreAuth: true,
+      authorizationServer: issuer,
+    }
+    const code = 'PREAUTHCODE'
+    const offer = CredentialOffer({
+      credential_issuer: issuer,
+      authorization_server: issuer,
+      credential_configuration_ids: [CredentialConfigurationId('VerifiableId')],
+    })
+    mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
+    mock.method(mockPreAuthCodeProvider, 'generate', async () => code)
+    mock.method(mockPreAuthCodeStoreProvider, 'save', async () => {})
+    mock.method(mockCredentialOfferProvider, 'create', async () => offer)
+
+    const result = await issuerFlow.offerCredential(issuer, configurations, options)
+
+    assert.ok(result)
+    assert.equal(mockCredentialOfferProvider.create.mock.callCount(), 1)
+    assert.deepStrictEqual(mockCredentialOfferProvider.create.mock.calls[0].arguments[2], {
+      usePreAuth: true,
+      authorizationServer: issuer,
+      code,
+    })
+  })
+
+  it(`should throw 'invalid_credential_request' error when the provided authorization server is not found in the issuer metadata`, async () => {
     const metadata = CredentialIssuerMetadata({
       credential_issuer: issuer,
       credential_endpoint: 'https://example.com/credentials',

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -412,8 +412,13 @@ describe('IssuerFlow', () => {
     const code = 'PREAUTHCODE'
     const offer = CredentialOffer({
       credential_issuer: issuer,
-      authorization_server: 'https://example.com/auth',
       credential_configuration_ids: [CredentialConfigurationId('VerifiableId')],
+      grants: {
+        'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
+          'pre-authorized_code': code,
+          authorization_server: 'https://example.com/auth',
+        },
+      },
     })
     mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
     mock.method(mockPreAuthCodeProvider, 'generate', async () => code)
@@ -451,8 +456,13 @@ describe('IssuerFlow', () => {
     const code = 'PREAUTHCODE'
     const offer = CredentialOffer({
       credential_issuer: issuer,
-      authorization_server: issuer,
       credential_configuration_ids: [CredentialConfigurationId('VerifiableId')],
+      grants: {
+        'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
+          'pre-authorized_code': code,
+          authorization_server: 'https://example.com/auth',
+        },
+      },
     })
     mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
     mock.method(mockPreAuthCodeProvider, 'generate', async () => code)

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -473,7 +473,7 @@ describe('IssuerFlow', () => {
       return await issuerFlow.offerCredential(issuer, configurations, options)
     }
 
-    assert.rejects(suspects, {
+    await assert.rejects(suspects, {
       name: 'invalid_credential_request',
       message:
         'authorization_server can only be used when authorization_servers has multiple entries.',
@@ -520,7 +520,7 @@ describe('IssuerFlow', () => {
       return await issuerFlow.offerCredential(issuer, configurations, options)
     }
 
-    assert.rejects(suspects, {
+    await assert.rejects(suspects, {
       name: 'invalid_credential_request',
       message:
         'authorization_server can only be used when authorization_servers has multiple entries.',

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -412,6 +412,7 @@ describe('IssuerFlow', () => {
     const offer = CredentialOffer({
       credential_issuer: issuer,
       authorization_server: 'https://example.com/auth',
+      credential_configuration_ids: [CredentialConfigurationId('VerifiableId')],
     })
     mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
     mock.method(mockPreAuthCodeProvider, 'generate', async () => code)

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -406,7 +406,7 @@ describe('IssuerFlow', () => {
     })
     const options = {
       usePreAuth: true,
-      authorization_server: 'https://example.com/auth',
+      authorizationServer: 'https://example.com/auth',
     }
     const code = 'PREAUTHCODE'
     const offer = CredentialOffer({

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -393,7 +393,7 @@ describe('IssuerFlow', () => {
     const metadata = CredentialIssuerMetadata({
       credential_issuer: issuer,
       credential_endpoint: 'https://example.com/credentials',
-      authorization_servers: ['https://example.com/auth'],
+      authorization_servers: ['https://example.com/auth', 'https://example.com/auth2'],
       credential_configurations_supported: {
         VerifiableId: {
           format: 'jwt_vc_json',
@@ -434,7 +434,7 @@ describe('IssuerFlow', () => {
     assert.equal(mockCredentialOfferProvider.create.mock.callCount(), 1)
   })
 
-  it('should create a credential offer when authorizationServer equals credential_issuer and authorization_servers is undefined', async () => {
+  it(`should throw 'invalid_credential_request' when authorization_servers is undefined`, async () => {
     const metadata = CredentialIssuerMetadata({
       credential_issuer: issuer,
       credential_endpoint: 'https://example.com/credentials',
@@ -469,14 +469,61 @@ describe('IssuerFlow', () => {
     mock.method(mockPreAuthCodeStoreProvider, 'save', async () => {})
     mock.method(mockCredentialOfferProvider, 'create', async () => offer)
 
-    const result = await issuerFlow.offerCredential(issuer, configurations, options)
+    const suspects = async () => {
+      return await issuerFlow.offerCredential(issuer, configurations, options)
+    }
 
-    assert.ok(result)
-    assert.equal(mockCredentialOfferProvider.create.mock.callCount(), 1)
-    assert.deepStrictEqual(mockCredentialOfferProvider.create.mock.calls[0].arguments[2], {
+    assert.rejects(suspects, {
+      name: 'invalid_credential_request',
+      message:
+        'authorization_server can only be used when authorization_servers has multiple entries.',
+    })
+  })
+
+  it(`should throw 'invalid_credential_request' when authorization_servers is only one entry`, async () => {
+    const metadata = CredentialIssuerMetadata({
+      credential_issuer: issuer,
+      authorization_servers: ['https://example.com/auth'],
+      credential_endpoint: 'https://example.com/credentials',
+      credential_configurations_supported: {
+        VerifiableId: {
+          format: 'jwt_vc_json',
+          credential_definition: {
+            type: ['VCKnots'],
+            credentialSubject: {},
+          },
+          credential_signing_alg_values_supported: ['ES256'],
+        },
+      },
+    })
+    const options = {
       usePreAuth: true,
       authorizationServer: issuer,
-      code,
+    }
+    const code = 'PREAUTHCODE'
+    const offer = CredentialOffer({
+      credential_issuer: issuer,
+      credential_configuration_ids: [CredentialConfigurationId('VerifiableId')],
+      grants: {
+        'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
+          'pre-authorized_code': code,
+          authorization_server: 'https://example.com/auth',
+        },
+      },
+    })
+    mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
+    mock.method(mockPreAuthCodeProvider, 'generate', async () => code)
+    mock.method(mockPreAuthCodeStoreProvider, 'save', async () => {})
+    mock.method(mockCredentialOfferProvider, 'create', async () => offer)
+
+    const suspects = async () => {
+      return await issuerFlow.offerCredential(issuer, configurations, options)
+    }
+
+    assert.rejects(suspects, {
+      name: 'invalid_credential_request',
+      message:
+        'authorization_server can only be used when authorization_servers has multiple entries.',
     })
   })
 
@@ -484,7 +531,7 @@ describe('IssuerFlow', () => {
     const metadata = CredentialIssuerMetadata({
       credential_issuer: issuer,
       credential_endpoint: 'https://example.com/credentials',
-      authorization_servers: ['https://example.com/auth'],
+      authorization_servers: ['https://example.com/auth', 'https://example.com/auth2'],
       credential_configurations_supported: {
         VerifiableId: {
           format: 'jwt_vc_json',

--- a/issuer+verifier/test/providers/credential-offer.provider.spec.ts
+++ b/issuer+verifier/test/providers/credential-offer.provider.spec.ts
@@ -53,6 +53,23 @@ describe('CredentialOfferProvider', () => {
     })
   })
 
+  it('should create a credential offer using pre-authorized code with authorization server', async () => {
+    const offer = await provider.create(issuer, configurations, {
+      usePreAuth: true,
+      code: PreAuthorizedCode('pre-auth-code-123'),
+      authorizationServer: 'https://example.com/auth',
+    })
+
+    assert.equal(offer.credential_issuer, issuer.credential_issuer)
+    assert.deepEqual(offer.credential_configuration_ids, configurations)
+    assert.deepEqual(offer.grants, {
+      'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
+        'pre-authorized_code': 'pre-auth-code-123',
+      },
+    })
+    assert.equal(offer.authorization_server, 'https://example.com/auth')
+  })
+
   it('should create a credential offer using pre-authorized code with txCode', async () => {
     const txCodeInput = {
       inputMode: 'numeric' as const,

--- a/issuer+verifier/test/providers/credential-offer.provider.spec.ts
+++ b/issuer+verifier/test/providers/credential-offer.provider.spec.ts
@@ -65,9 +65,9 @@ describe('CredentialOfferProvider', () => {
     assert.deepEqual(offer.grants, {
       'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
         'pre-authorized_code': 'pre-auth-code-123',
+        authorization_server: 'https://example.com/auth',
       },
     })
-    assert.equal(offer.authorization_server, 'https://example.com/auth')
   })
 
   it('should create a credential offer using pre-authorized code with txCode', async () => {

--- a/server/core/src/routes/issue.ts
+++ b/server/core/src/routes/issue.ts
@@ -63,6 +63,7 @@ export const createIssueRouter = (context: VcknotsContext, baseUrl: string) => {
       length?: number
       description?: string
     }
+    authorization_server?: string
   }
   const dpopNonceResponse = async (c: Context) => {
     const dpopNonce = await authzFlow.createDpopNonceChallenge(DPOP_NONCE_TTL_MS)
@@ -154,7 +155,7 @@ export const createIssueRouter = (context: VcknotsContext, baseUrl: string) => {
         usePreAuth: true,
         txCode: options?.tx_code,
         ttlSec: PRE_CODE_TTL_SEC,
-        authorizationServer: c.req.query('authorization_server'),
+        authorizationServer: options?.authorization_server,
       })
       // TODO: Share tx_code with user (e.g., display on issuance screen or send via email)
       console.log('tx_code:', tx_code)

--- a/server/core/src/routes/issue.ts
+++ b/server/core/src/routes/issue.ts
@@ -154,6 +154,7 @@ export const createIssueRouter = (context: VcknotsContext, baseUrl: string) => {
         usePreAuth: true,
         txCode: options?.tx_code,
         ttlSec: PRE_CODE_TTL_SEC,
+        authorizationServer: c.req.query('authorization_server'),
       })
       // TODO: Share tx_code with user (e.g., display on issuance screen or send via email)
       console.log('tx_code:', tx_code)

--- a/server/core/src/server.ts
+++ b/server/core/src/server.ts
@@ -56,8 +56,7 @@ export const createServer = (options?: VcknotsOptions) => {
     }
 
     issuerMetadataConfig.credential_issuer = CredentialIssuer(baseUrl)
-    // Add a second authorization server entry to avoid validation errors when testing authorization_server hint handling.
-    issuerMetadataConfig.authorization_servers = [baseUrl, 'https://authz.example.com']
+    issuerMetadataConfig.authorization_servers = [baseUrl]
     issuerMetadataConfig.credential_endpoint = `${baseUrl}/credentials`
     issuerMetadataConfig.deferred_credential_endpoint = `${baseUrl}/deferred_credential`
     issuerMetadataConfig.nonce_endpoint = `${baseUrl}/nonce`

--- a/server/core/src/server.ts
+++ b/server/core/src/server.ts
@@ -56,7 +56,8 @@ export const createServer = (options?: VcknotsOptions) => {
     }
 
     issuerMetadataConfig.credential_issuer = CredentialIssuer(baseUrl)
-    issuerMetadataConfig.authorization_servers = [baseUrl]
+    // Add a second authorization server entry to avoid validation errors when testing authorization_server hint handling.
+    issuerMetadataConfig.authorization_servers = [baseUrl, 'https://authz.example.com']
     issuerMetadataConfig.credential_endpoint = `${baseUrl}/credentials`
     issuerMetadataConfig.deferred_credential_endpoint = `${baseUrl}/deferred_credential`
     issuerMetadataConfig.nonce_endpoint = `${baseUrl}/nonce`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credential Offer で特定の認可サーバー（authorization_server）を指定できるようになりました。

* **Documentation**
  * Issuer ドキュメントとサンプルを更新し、authorization_server の指定条件と送信タイミングを明記しました。

* **Bug Fixes / Behavior**
  * 指定が不正な場合や条件を満たさない場合に明確なエラー応答を返すようになりました。

* **Tests**
  * authorization_server 指定時の成功／失敗ケースを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->