### PR TITLE
feat(wallet): add DPoP support for token requests

### DIFF
--- a/wallet/receiver/plugins/oid4vci/oid4vci.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci.go
@@ -160,7 +160,6 @@ func (o *Oid4vciReceiver) FetchAccessToken(
 	if !env.IsHTTPAllowed() && !strings.EqualFold(endpointURL.Scheme, "https") {
 		return nil, fmt.Errorf("unsupported URL scheme for OID4VCI endpoint: %q (https required)", endpointURL.Scheme)
 	}
-
 	req, err := http.NewRequest(
 		http.MethodPost,
 		endpointURL.String(),

--- a/wallet/receiver/plugins/oid4vci/oid4vci_test.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci_test.go
@@ -388,7 +388,6 @@ func TestOid4vciReceiver_FetchAccessToken(t *testing.T) {
 	})
 
 	t.Run("DPoP header is absent when proof is nil", func(t *testing.T) {
-
 		httpAllowed := env.IsHTTPAllowed()
 		defer env.SetHTTPAllowed(httpAllowed)
 		env.SetHTTPAllowed(true)
@@ -414,7 +413,6 @@ func TestOid4vciReceiver_FetchAccessToken(t *testing.T) {
 	})
 
 	t.Run("DPoP header is absent when proof is empty string", func(t *testing.T) {
-
 		httpAllowed := env.IsHTTPAllowed()
 		defer env.SetHTTPAllowed(httpAllowed)
 		env.SetHTTPAllowed(true)

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -280,6 +280,16 @@ func TestNewWalletWithConfig_MissingComponents(t *testing.T) {
 	}
 }
 
+func TestNewInMemoryECKeyEntry(t *testing.T) {
+	key, err := newInMemoryECKeyEntry()
+	require.NoError(t, err)
+	require.NotEmpty(t, key.ID())
+
+	pub, ok := key.PublicKey().Key.(*ecdsa.PublicKey)
+	require.True(t, ok)
+	require.Equal(t, elliptic.P256(), pub.Curve)
+}
+
 func TestController_GenerateDID_Integration(t *testing.T) {
 	controller := createTestControllerWithDefaults(t)
 
@@ -1093,6 +1103,24 @@ func extractHeaderField(t *testing.T, compactJWT string, field string) any {
 	value, ok := header[field]
 	require.True(t, ok, "field %q not found in header", field)
 	return value
+}
+
+func TestWallet_generateDPoPProof_SignatureVerifies(t *testing.T) {
+	key, err := newInMemoryECKeyEntry()
+	require.NoError(t, err)
+
+	w := &Wallet{}
+	proof, err := w.generateDPoPProof(key, http.MethodPost, "https://server.example.com/token", "", nil)
+	require.NoError(t, err)
+
+	parsed, err := jose.ParseSigned(proof, []jose.SignatureAlgorithm{jose.ES256})
+	require.NoError(t, err)
+
+	embeddedJWK := parsed.Signatures[0].Header.JSONWebKey
+	require.NotNil(t, embeddedJWK)
+
+	_, err = parsed.Verify(embeddedJWK.Key)
+	require.NoError(t, err)
 }
 
 func TestController_generateJWTProof_AnonymousPreAuthorizedFlow_OmitsIss(t *testing.T) {


### PR DESCRIPTION
## 概要

OID4VCI の token request に対して、wallet の DPoP 対応を追加しました。

今回の変更で wallet は以下を行えるようになります。

- DPoP の ON/OFF を設定できる
- DPoP 用鍵が未指定なら自動生成して保持できる
- token request 用の DPoP proof JWT を生成できる
- token request に `DPoP` HTTP ヘッダを付与できる

## 変更内容

- `DPoPConfig` を wallet config に追加
- DPoP 用 in-memory EC 鍵生成を追加
- 以下を含む DPoP proof JWT の生成を追加
  - `typ: dpop+jwt`
  - `alg`
  - `jwk`（公開鍵のみ）
  - `jti`
  - `htm`
  - `htu`
  - `iat`
- wallet -> dispatcher -> receiver plugin の経路で DPoP proof を渡せるように修正
- OID4VCI token request で `DPoP` ヘッダ付与を追加

## テスト

以下を確認するテストを追加しました。

- DPoP proof の header / payload 構造
- `jti` の一意性
- nil key 時のエラー
- wallet レベルの DPoP ON/OFF 挙動
- DPoP 鍵の自動生成
- token request における `DPoP` ヘッダの有無

#補足

今回のスコープは token request の DPoP 対応までです。  
DPoP-bound access token を用いた後続リクエストの扱いは含んでいません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * トークンエンドポイントへのリクエスト処理を整理し、一貫したHTTPクライアントを使用するよう変更しました。
  * DPoP（Demonstration of Proof-of-Possession）ヘッダの処理を改善し、適切な認証メカニズムに対応しました。
  * エラーハンドリングを明示化し、より詳細なエラー情報を返すようにしました。

* **テスト**
  * DPoPヘッダの動作確認テストを追加しました。
  * 暗号鍵生成と署名検証のテストカバレッジを拡大しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->