### PR TITLE
ci(vcknots): update publish workflow for npm trusted publish

### DIFF
--- a/.github/workflows/ci-create-tag-and-publish.yaml
+++ b/.github/workflows/ci-create-tag-and-publish.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -33,27 +34,28 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: |
+          # care npm Trusted Publish Auth
+          npm install -g npm@latest
+          pnpm install
 
       - name: Build
         run: |
           pnpm build
-    
-      - name: Check npm auth
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-          npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Print publish config
+        run: |
+          npm --version
+          npm pkg get name
+          npm pkg get version
+          npm config get registry
+          echo "OIDC_REQUEST_TOKEN=${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+SET}"
 
       - name: Publish
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           pnpm changeset publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Push release tags
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * パッケージ公開プロセスのセキュリティを強化しました。OIDC ベースの Trusted Publishing を採用し、従来のトークン認証から移行しました。ユーザーへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->