### PR TITLE
feat: support new OID4VCI credentials response format and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 GEMINI.md
+
+.reviews/

--- a/issuer+verifier/src/credential-request.types.ts
+++ b/issuer+verifier/src/credential-request.types.ts
@@ -5,6 +5,7 @@ export enum CredentialFormats {
   JWT_VC_JSON = 'jwt_vc_json',
   JWT_VC_JSON_LD = 'jwt_vc_json-ld',
   LDP_VC = 'ldp_vc',
+  DC_SD_JWT = 'dc+sd-jwt',
 }
 
 export enum ProofTypes {

--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -1,4 +1,4 @@
-import { base64url, exportJWK } from 'jose'
+import { base64url, calculateJwkThumbprint, exportJWK } from 'jose'
 import { Cnonce } from './cnonce.types'
 import {
   CredentialConfigurationId,
@@ -6,13 +6,14 @@ import {
   CredentialIssuerMetadata,
 } from './credential-issuer.types'
 import { CredentialOffer } from './credential-offer.types'
-import { CredentialRequest, ProofTypes } from './credential-request.types'
+import { CredentialFormats, CredentialRequest, ProofTypes } from './credential-request.types'
 import { CredentialResponse } from './credential-response.types'
 import { err, raise } from './errors/vcknots.error'
+import { jwkSchema } from './jwk.type'
+import { JwtVcIssuerResponse } from './jwt-vc-issuer.types'
+import { buildSdJwtCredential } from './providers/issue-credential-sd-jwt.provider'
 import { selectProvider } from './providers/provider.utils'
 import { VcknotsContext } from './vcknots.context'
-import { JwtVcIssuerResponse } from './jwt-vc-issuer.types'
-import { jwkSchema } from './jwk.type'
 
 type OfferOptions =
   | {
@@ -61,6 +62,7 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
   const cnonceStore$ = context.providers.get('cnonce-store-provider')
   const keyStore$ = context.providers.get('issuer-signature-key-store-provider')
   const credentialProof$ = context.providers.get('credential-proof-provider')
+  const did$ = context.providers.get('did-provider')
 
   return {
     async findIssuerMetadata(id) {
@@ -91,7 +93,11 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
             if (!issuerKey) {
               return null
             }
-            return jwkSchema.parse(await exportJWK(issuerKey))
+            // Publish a `kid` so SD-JWT VCs (whose header carries a `kid`) can be
+            // matched to the right key during verification.
+            const jwk = await exportJWK(issuerKey)
+            const kid = await calculateJwkThumbprint(jwk)
+            return jwkSchema.parse({ ...jwk, kid })
           })
         )
       ).filter((key) => key !== null)
@@ -168,7 +174,6 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
           message: 'Credential request format is not specified.',
         })
       }
-      const issueCredentialProvider = selectProvider(issueCredential$, format)
 
       // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#name-credential-request-2
       const credentialConfiguration = metadata.credential_configurations_supported
@@ -236,12 +241,6 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
         }
       }
 
-      const verifiableCredential = issueCredentialProvider.createCredential(
-        issuer,
-        configuration,
-        verifyProof,
-        options?.claims
-      )
       const keyAlg = options?.alg ?? 'ES256'
       if (
         !configuration.credential_signing_alg_values_supported ||
@@ -251,6 +250,84 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
           message: 'Unsupported key algorithm.',
         })
       }
+
+      // SD-JWT VC keeps claim values out of the signed body and binds them to the
+      // holder key, so it follows a dedicated assembly path instead of the W3C
+      // JWT VC one below.
+      if (format === CredentialFormats.DC_SD_JWT) {
+        const holderKid = verifyProof.header.kid
+        const didSplit = holderKid.split(':')
+        const didProvider = selectProvider(did$, didSplit[1])
+        const holderDidDoc = await didProvider.resolveDid(holderKid)
+        const holderJwk = holderDidDoc?.verificationMethod?.[0]?.publicKeyJwk
+        if (!holderJwk) {
+          throw err('INVALID_PROOF', {
+            message: 'Cannot resolve holder key for SD-JWT key binding.',
+          })
+        }
+
+        // The SD-JWT `vct` is the configuration's specific (non-base) type.
+        const types = configuration.credential_definition.type
+        const vct = types.find((it) => it !== 'VerifiableCredential') ?? types[0]
+
+        // Collect the disclosable claims declared by the configuration.
+        const subject = configuration.credential_definition.credentialSubject ?? {}
+        const claims: Record<string, unknown> = {}
+        for (const [key, definition] of Object.entries(subject)) {
+          if (options?.claims && key in options.claims) {
+            const value = options.claims[key]
+            claims[key] =
+              definition.value_type === 'number'
+                ? Number(value)
+                : definition.value_type === 'string'
+                  ? String(value)
+                  : value
+          } else if (definition.mandatory === true) {
+            throw err('INVALID_CLAIMS', {
+              message: `Claim ${key} is defined as mandatory but was not provided.`,
+            })
+          }
+        }
+
+        const issuerKey = await keyStore$.fetch(issuer, keyAlg)
+        if (!issuerKey) {
+          throw err('AUTHZ_ISSUER_KEY_NOT_FOUND', {
+            message: 'Issuer key not found.',
+          })
+        }
+        // Must match the `kid` published in the issuer JWKS (see jwt-vc-issuer).
+        const issuerKid = await calculateJwkThumbprint(await exportJWK(issuerKey))
+
+        const credential = await buildSdJwtCredential({
+          issuer,
+          vct,
+          alg: keyAlg,
+          kid: issuerKid,
+          holderJwk,
+          claims,
+          sign: (payload, header) =>
+            keyStore$.sign(
+              issuer,
+              keyAlg,
+              payload as Parameters<typeof keyStore$.sign>[2],
+              header as Parameters<typeof keyStore$.sign>[3]
+            ),
+        })
+
+        return {
+          credential,
+          c_nonce: nonce,
+          c_nonce_expires_in: options?.cnonce?.c_nonce_expires_in ?? 86400,
+        }
+      }
+
+      const issueCredentialProvider = selectProvider(issueCredential$, format)
+      const verifiableCredential = issueCredentialProvider.createCredential(
+        issuer,
+        configuration,
+        verifyProof,
+        options?.claims
+      )
       const jwtHeader = {
         alg: keyAlg,
         typ: 'JWT',

--- a/issuer+verifier/src/providers/issue-credential-sd-jwt.provider.ts
+++ b/issuer+verifier/src/providers/issue-credential-sd-jwt.provider.ts
@@ -1,0 +1,101 @@
+import { pack } from '@sd-jwt/core'
+import { digest, generateSalt } from '@sd-jwt/crypto-nodejs'
+import { base64url } from 'jose'
+import type { JWK } from 'jose'
+import { raise } from '../errors/vcknots.error'
+
+// SD-JWT VC issuance.
+//
+// Unlike the W3C JWT VC path, an SD-JWT VC keeps the actual claim values out of
+// the signed JWT body. Each selectively-disclosable claim becomes a "disclosure"
+// (`base64url(JSON([salt, key, value]))`) and only its salted hash digest is kept
+// in the signed payload under `_sd`. The encoded form is:
+//
+//   <issuer-signed JWT>~<disclosure>~<disclosure>~...~
+//
+// Disclosure framing and digest calculation are delegated to `@sd-jwt`'s `pack`
+// with the very same `digest` hasher the verifier uses, so the credential we emit
+// round-trips through `verify-presentation-dc-sd-jwt.provider`. Signing reuses the
+// issuer key store (`sign`) exactly like the JWT VC path, so no private key
+// material leaves the key store.
+
+// SD-JWT VC header `typ` as expected by the verifier (`dc+sd-jwt`).
+export const SD_JWT_VC_TYP = 'dc+sd-jwt'
+
+// Digest algorithm advertised in `_sd_alg`. Must match the hasher used below.
+const SD_ALG = 'sha-256'
+
+// signSdJwt signs the issuer JWT part and returns its base64url signature.
+// It mirrors `IssuerSignatureKeyStoreProvider.sign`, so the caller can pass that
+// method directly.
+export type SignSdJwt = (
+  payload: Record<string, unknown>,
+  header: Record<string, unknown>
+) => Promise<string | null>
+
+export type BuildSdJwtCredentialArgs = {
+  /** Credential Issuer identifier, used as `iss`. */
+  issuer: string
+  /** SD-JWT VC type, used as `vct`. */
+  vct: string
+  /** Signing algorithm, e.g. `ES256`. */
+  alg: string
+  /** Key id placed in the JWT header; must match a key in the issuer JWKS. */
+  kid: string
+  /** Holder public key for key binding, placed in `cnf.jwk`. */
+  holderJwk: JWK
+  /** Selectively-disclosable claims (each becomes a disclosure). */
+  claims: Record<string, unknown>
+  /** Issued-at, in seconds since epoch. Defaults to now. */
+  iat?: number
+  /** Signing callback, typically the issuer key store's `sign`. */
+  sign: SignSdJwt
+}
+
+// buildSdJwtCredential assembles a signed SD-JWT VC in combined issuance format.
+export const buildSdJwtCredential = async (args: BuildSdJwtCredentialArgs): Promise<string> => {
+  const disclosableKeys = Object.keys(args.claims)
+
+  // `pack` replaces each disclosable claim with a salted-hash digest under `_sd`
+  // and returns the corresponding disclosures. Using the verifier's `digest`
+  // hasher guarantees the digests it later recomputes match.
+  // `{ _sd: [...] }` marks the top-level claims as selectively disclosable. The
+  // cast keeps us off `@sd-jwt/types` (not a direct dependency) while matching the
+  // runtime shape `pack` expects.
+  const disclosureFrame = { _sd: disclosableKeys } as Parameters<typeof pack>[1]
+  const { packedClaims, disclosures } = await pack(
+    { ...args.claims },
+    disclosureFrame,
+    { alg: SD_ALG, hasher: digest },
+    generateSalt
+  )
+
+  const iat = args.iat ?? Math.floor(Date.now() / 1000)
+  const payload = {
+    ...(packedClaims as Record<string, unknown>),
+    vct: args.vct,
+    iss: args.issuer,
+    iat,
+    cnf: { jwk: args.holderJwk },
+    _sd_alg: SD_ALG,
+  }
+  const header = {
+    alg: args.alg,
+    typ: SD_JWT_VC_TYP,
+    kid: args.kid,
+  }
+
+  const signature = await args.sign(payload, header)
+  if (!signature) {
+    throw raise('INTERNAL_SERVER_ERROR', {
+      message: 'Cannot sign SD-JWT credential.',
+    })
+  }
+
+  const encode = (x: unknown) => base64url.encode(JSON.stringify(x))
+  const issuerJwt = `${encode(header)}.${encode(payload)}.${signature}`
+
+  // Combined issuance format always terminates with `~` (no key binding JWT yet).
+  const encodedDisclosures = disclosures.map((d) => d.encode())
+  return [issuerJwt, ...encodedDisclosures, ''].join('~')
+}

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { before, describe, it, mock } from 'node:test'
-import { exportJWK, generateKeyPair } from 'jose'
+import { calculateJwkThumbprint, exportJWK, generateKeyPair } from 'jose'
 import {
   CredentialConfigurationId,
   CredentialIssuer,
@@ -159,7 +159,10 @@ describe('IssuerFlow', () => {
       credential_configurations_supported: {},
     }
     const keys = await generateKeyPair('ES256', { extractable: true })
-    const expectedJwk = await exportJWK(keys.publicKey)
+    const baseJwk = await exportJWK(keys.publicKey)
+    // The published JWK now carries a thumbprint `kid` so SD-JWT VCs can be
+    // matched to the issuer key during verification.
+    const expectedJwk = { ...baseJwk, kid: await calculateJwkThumbprint(baseJwk) }
     mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
     mock.method(mockIssuerKeyStoreProvider, 'fetch', async () => keys.publicKey)
 

--- a/issuer+verifier/test/providers/issue-credential-sd-jwt.provider.spec.ts
+++ b/issuer+verifier/test/providers/issue-credential-sd-jwt.provider.spec.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { CompactSign, exportJWK, generateKeyPair } from 'jose'
+import { decodeSdJwt } from '@sd-jwt/decode'
+import { ES256, digest } from '@sd-jwt/crypto-nodejs'
+import { buildSdJwtCredential, SD_JWT_VC_TYP } from '../../src/providers/issue-credential-sd-jwt.provider'
+
+const { SDJwtInstance } = require('@sd-jwt/core')
+
+describe('buildSdJwtCredential', () => {
+  const issuer = 'https://issuer.example.com'
+  const vct = 'IdentityCredential'
+  const claims = {
+    given_name: 'John',
+    family_name: 'Doe',
+  }
+
+  // Builds an SD-JWT VC signed by a fresh issuer key, returning everything a test
+  // needs to verify the round-trip.
+  const issue = async () => {
+    const issuerKeys = await generateKeyPair('ES256', { extractable: true })
+    const issuerPublicJwk = await exportJWK(issuerKeys.publicKey)
+    const holderKeys = await generateKeyPair('ES256', { extractable: true })
+    const holderJwk = await exportJWK(holderKeys.publicKey)
+
+    // Mirror IssuerSignatureKeyStoreProvider.sign: sign JSON(payload) under the
+    // protected header and return only the signature component.
+    const sign = async (payload: Record<string, unknown>, header: Record<string, unknown>) => {
+      const jws = await new CompactSign(new TextEncoder().encode(JSON.stringify(payload)))
+        .setProtectedHeader(header as Parameters<CompactSign['setProtectedHeader']>[0])
+        .sign(issuerKeys.privateKey)
+      return jws.split('.')[2]
+    }
+
+    const sdJwt = await buildSdJwtCredential({
+      issuer,
+      vct,
+      alg: 'ES256',
+      kid: 'issuer-key-1',
+      holderJwk,
+      claims,
+      sign,
+    })
+
+    return { sdJwt, issuerPublicJwk, holderJwk }
+  }
+
+  it('emits combined issuance format terminated with ~', async () => {
+    const { sdJwt } = await issue()
+    assert.ok(sdJwt.endsWith('~'), 'SD-JWT must end with ~')
+    // <jwt>~<disclosure>~<disclosure>~  => 3 parts before trailing empty segment.
+    const parts = sdJwt.split('~')
+    assert.equal(parts.at(-1), '')
+    assert.equal(parts.length, 2 + Object.keys(claims).length)
+  })
+
+  it('keeps disclosable claim values out of the signed body', async () => {
+    const { sdJwt } = await issue()
+    const decoded = await decodeSdJwt(sdJwt, digest)
+
+    assert.equal(decoded.jwt.header.typ, SD_JWT_VC_TYP)
+    assert.equal(decoded.jwt.payload.vct, vct)
+    assert.equal(decoded.jwt.payload.iss, issuer)
+    assert.equal(decoded.jwt.payload._sd_alg, 'sha-256')
+    assert.ok(Array.isArray(decoded.jwt.payload._sd))
+    // The raw claim values must not appear in the signed JWT body.
+    assert.equal(decoded.jwt.payload.given_name, undefined)
+    assert.equal(decoded.jwt.payload.family_name, undefined)
+  })
+
+  it('binds the holder key via cnf.jwk', async () => {
+    const { sdJwt, holderJwk } = await issue()
+    const decoded = await decodeSdJwt(sdJwt, digest)
+    const cnf = decoded.jwt.payload.cnf as { jwk: { x: string; y: string } }
+    assert.ok(cnf?.jwk)
+    assert.equal(cnf.jwk.x, holderJwk.x)
+    assert.equal(cnf.jwk.y, holderJwk.y)
+  })
+
+  it('verifies against the issuer key and recovers disclosed claims', async () => {
+    const { sdJwt, issuerPublicJwk } = await issue()
+
+    const verifier = await ES256.getVerifier(issuerPublicJwk)
+    const sdjwt = new SDJwtInstance({ verifier, hasher: digest })
+
+    await assert.doesNotReject(() => sdjwt.validate(sdJwt))
+
+    const { payload } = await sdjwt.verify(sdJwt)
+    assert.equal(payload.given_name, 'John')
+    assert.equal(payload.family_name, 'Doe')
+    assert.equal(payload.vct, vct)
+  })
+})

--- a/server/samples/issuer_metadata.json
+++ b/server/samples/issuer_metadata.json
@@ -73,6 +73,46 @@
 					"text_color": "#FFFFFF"
 				}
 			]
+		},
+		"IdentityCredential": {
+			"format": "dc+sd-jwt",
+			"scope": "Identity",
+			"cryptographic_binding_methods_supported": ["jwk"],
+			"credential_signing_alg_values_supported": ["ES256"],
+			"credential_definition": {
+				"type": ["VerifiableCredential", "IdentityCredential"],
+				"credentialSubject": {
+					"given_name": {
+						"display": [
+							{
+								"name": "Given Name",
+								"locale": "en-US"
+							}
+						],
+						"value_type": "string"
+					},
+					"family_name": {
+						"display": [
+							{
+								"name": "Surname",
+								"locale": "en-US"
+							}
+						],
+						"value_type": "string"
+					}
+				}
+			},
+			"proof_types_supported": {
+				"jwt": {
+					"proof_signing_alg_values_supported": ["ES256"]
+				}
+			},
+			"display": [
+				{
+					"name": "Identity Credential",
+					"locale": "en-US"
+				}
+			]
 		}
 	}
 }

--- a/wallet/examples/common/common.go
+++ b/wallet/examples/common/common.go
@@ -7,9 +7,14 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
+	"net/http"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/trustknots/vcknots/wallet"
@@ -18,6 +23,7 @@ import (
 	"github.com/trustknots/vcknots/wallet/presenter"
 	"github.com/trustknots/vcknots/wallet/presenter/plugins/oid4vp"
 	"github.com/trustknots/vcknots/wallet/receiver"
+	receiverTypes "github.com/trustknots/vcknots/wallet/receiver/types"
 	"github.com/trustknots/vcknots/wallet/serializer"
 	"github.com/trustknots/vcknots/wallet/verifier"
 )
@@ -154,5 +160,82 @@ func NewOID4VPRuntime(certPath string) (*Runtime, error) {
 		CredStore:  credStore,
 		Serializer: serializerDispatcher,
 		Wallet:     w,
+	}, nil
+}
+
+const credentialOfferURIPrefix = "openid-credential-offer://?credential_offer="
+
+// ReceiveCredentialFromOffer fetches a credential offer from the issuer's offer
+// endpoint, then runs the OID4VCI pre-authorized-code flow to receive and store
+// the credential. format is the OID4VCI credential format to request, e.g.
+// "jwt_vc_json" or "dc+sd-jwt".
+func ReceiveCredentialFromOffer(
+	w *wallet.Wallet,
+	key *MockKeyEntry,
+	offerEndpoint string,
+	format string,
+) (*wallet.SavedCredential, error) {
+	resp, err := http.Post(offerEndpoint, "application/json", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch credential offer: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read offer response: %w", err)
+	}
+
+	offer, err := parseCredentialOffer(string(body))
+	if err != nil {
+		return nil, err
+	}
+
+	return w.ReceiveCredential(wallet.ReceiveCredentialRequest{
+		CredentialOffer: offer,
+		Type:            receiverTypes.Oid4vci,
+		Key:             key,
+		Format:          format,
+	})
+}
+
+// parseCredentialOffer parses an "openid-credential-offer://" URI into a
+// wallet.CredentialOffer.
+func parseCredentialOffer(offerURI string) (*wallet.CredentialOffer, error) {
+	offerURI = strings.TrimSpace(offerURI)
+	if !strings.HasPrefix(offerURI, credentialOfferURIPrefix) {
+		return nil, fmt.Errorf("invalid offer URI format: %q", offerURI)
+	}
+
+	decodedOffer, err := url.QueryUnescape(strings.TrimPrefix(offerURI, credentialOfferURIPrefix))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode offer: %w", err)
+	}
+
+	var offerData struct {
+		CredentialIssuer           string   `json:"credential_issuer"`
+		CredentialConfigurationIDs []string `json:"credential_configuration_ids"`
+		Grants                     map[string]struct {
+			PreAuthorizedCode string `json:"pre-authorized_code"`
+		} `json:"grants"`
+	}
+	if err := json.Unmarshal([]byte(decodedOffer), &offerData); err != nil {
+		return nil, fmt.Errorf("failed to parse offer JSON: %w", err)
+	}
+
+	issuerURL, err := url.Parse(offerData.CredentialIssuer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse credential issuer URL: %w", err)
+	}
+
+	grants := make(map[string]*wallet.CredentialOfferGrant, len(offerData.Grants))
+	for grantType, grant := range offerData.Grants {
+		grants[grantType] = &wallet.CredentialOfferGrant{PreAuthorizedCode: grant.PreAuthorizedCode}
+	}
+
+	return &wallet.CredentialOffer{
+		CredentialIssuer:           issuerURL,
+		CredentialConfigurationIDs: offerData.CredentialConfigurationIDs,
+		Grants:                     grants,
 	}, nil
 }

--- a/wallet/examples/server_integration_sdjwt+kbjwt/server_integration_sdjwt_kbjwt.go
+++ b/wallet/examples/server_integration_sdjwt+kbjwt/server_integration_sdjwt_kbjwt.go
@@ -23,11 +23,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/trustknots/vcknots/wallet"
-	"github.com/trustknots/vcknots/wallet/credential"
-	"github.com/trustknots/vcknots/wallet/credstore"
 	"github.com/trustknots/vcknots/wallet/examples/common"
 	"github.com/trustknots/vcknots/wallet/serializer/plugins/sdjwtvc"
 )
@@ -248,49 +245,36 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	credStore := runtime.CredStore
-	serializer := runtime.Serializer
 	w := runtime.Wallet
-
-	sdJwtCredFile, err := os.ReadFile("example_sd_jwt.txt")
-	if err != nil {
-		panic(err)
-	}
-	sdJwtCredFile = []byte(strings.TrimRight(string(sdJwtCredFile), "\r\n"))
-	err = credStore.SaveCredentialEntry(credstore.CredentialEntry{
-		Id:         "sample-sdjwt-kbjwt",
-		ReceivedAt: time.Now(),
-		Raw:        sdJwtCredFile,
-		MimeType:   string(credential.SDJwtVC),
-	}, credstore.SupportedCredStoreTypes(0))
-	if err != nil {
-		panic(err)
-	}
-
-	savedSdJwtCredEntry, err := credStore.GetCredentialEntry("sample-sdjwt-kbjwt", credstore.SupportedCredStoreTypes(0))
-	if err != nil {
-		panic(err)
-	}
 
 	logger.Info("Starting SD-JWT + KB-JWT server integration check...")
 
 	mockKey := common.NewMockKeyEntry()
 
-	deserializedSdJwtCred, err := serializer.DeserializeCredential(credential.SDJwtVC, savedSdJwtCredEntry.Raw)
+	// Issue and receive a fresh SD-JWT VC from the local server via the OID4VCI
+	// pre-authorized-code flow, then present it with a Key-Binding JWT.
+	logger.Info("Requesting SD-JWT credential from issuer...")
+	savedSdJwtCred, err := common.ReceiveCredentialFromOffer(
+		w,
+		mockKey,
+		verifierURL+"/configurations/IdentityCredential/offer",
+		"dc+sd-jwt",
+	)
 	if err != nil {
-		panic(err)
+		logger.Error("Failed to receive credential", "error", err)
+		os.Exit(1)
 	}
-
-	savedSdJwtCred := wallet.SavedCredential{
-		Credential: deserializedSdJwtCred,
-		Entry:      savedSdJwtCredEntry,
-	}
-	logger.Info("Deserialized credential", "credential.issuer", deserializedSdJwtCred.Issuer, "credential.claims", deserializedSdJwtCred.Claims)
+	logger.Info(
+		"Received SD-JWT credential",
+		"id", savedSdJwtCred.Entry.Id,
+		"issuer", savedSdJwtCred.Credential.Issuer,
+		"claims", savedSdJwtCred.Credential.Claims,
+	)
 
 	options := sdjwtvc.SdJwtVcPresentationOptions{
 		SelectedClaims:    []string{"given_name"},
 		RequireKeyBinding: true,
 	}
 
-	presentation(w, mockKey, &savedSdJwtCred, &options, logger)
+	presentation(w, mockKey, savedSdJwtCred, &options, logger)
 }

--- a/wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go
+++ b/wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go
@@ -16,8 +16,8 @@ package main
 //   - Usage: go run server_integration_sdjwt.go "<OID4VP_URI>"
 //   - Example: go run server_integration_sdjwt.go "openid4vp://authorize?client_id=...&request_uri=..."
 //
-// Both modes follow the same flow: seed credential -> build wallet -> get OID4VP request URI -> present.
-// The only differences are runtime inputs (request URI source, certificate pool, selected claims).
+// In server integration mode the credential is issued and received from the local
+// server (OID4VCI); in conformance mode it is loaded from a pre-issued sample file.
 
 import (
 	"crypto/x509"
@@ -216,6 +216,43 @@ func buildCertPool(isConformanceMode bool) *x509.CertPool {
 	return certPool
 }
 
+// seedSdJwtFromFile loads a pre-issued SD-JWT credential from example_sd_jwt.txt
+// into the credential store and returns it. Used for conformance mode, where no
+// local issuer is available to issue a credential.
+func seedSdJwtFromFile(
+	credStore *credstore.CredStoreDispatcher,
+	serializerDisp *serializer.SerializationDispatcher,
+	logger *slog.Logger,
+) *wallet.SavedCredential {
+	sdJwtCredFile, err := os.ReadFile("example_sd_jwt.txt")
+	if err != nil {
+		panic(err)
+	}
+
+	credID := "sample-sdjwt"
+	if err := credStore.SaveCredentialEntry(credstore.CredentialEntry{
+		Id:         credID,
+		ReceivedAt: time.Now(),
+		Raw:        sdJwtCredFile,
+		MimeType:   string(credential.SDJwtVC),
+	}, credstore.SupportedCredStoreTypes(0)); err != nil {
+		panic(err)
+	}
+
+	entry, err := credStore.GetCredentialEntry(credID, credstore.SupportedCredStoreTypes(0))
+	if err != nil {
+		panic(err)
+	}
+
+	deserialized, err := serializerDisp.DeserializeCredential(credential.SDJwtVC, entry.Raw)
+	if err != nil {
+		panic(err)
+	}
+	logger.Info("Seeded credential from file", "issuer", deserialized.Issuer, "claims", deserialized.Claims)
+
+	return &wallet.SavedCredential{Credential: deserialized, Entry: entry}
+}
+
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
@@ -249,28 +286,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
-	sdJwtCredFile, err := os.ReadFile("example_sd_jwt.txt")
-	if err != nil {
-		panic(err)
-	}
-
-	credID := "sample-sdjwt"
-	err = credStore.SaveCredentialEntry(credstore.CredentialEntry{
-		Id:         credID,
-		ReceivedAt: time.Now(),
-		Raw:        sdJwtCredFile,
-		MimeType:   string(credential.SDJwtVC),
-	}, credstore.SupportedCredStoreTypes(0))
-	if err != nil {
-		panic(err)
-	}
-
-	savedSdJwtCredEntry, err := credStore.GetCredentialEntry(credID, credstore.SupportedCredStoreTypes(0))
-	if err != nil {
-		panic(err)
-	}
-	logger.Info("Retrieved credential entry", "mime_type", savedSdJwtCredEntry.MimeType)
 
 	certPool := buildCertPool(isConformanceMode)
 	p := &oid4vp.Oid4vpPresenter{
@@ -318,15 +333,32 @@ func main() {
 
 	mockKey := common.NewMockKeyEntry()
 
-	deserializedCred, err := serializerDisp.DeserializeCredential(credential.SDJwtVC, savedSdJwtCredEntry.Raw)
-	if err != nil {
-		panic(err)
+	var savedCred *wallet.SavedCredential
+	if isConformanceMode {
+		// Conformance mode runs against external services with no local issuer,
+		// so the credential to present is loaded from a pre-issued sample file.
+		savedCred = seedSdJwtFromFile(credStore, serializerDisp, logger)
+	} else {
+		// Server integration mode issues and receives a fresh SD-JWT VC from the
+		// local server via the OID4VCI pre-authorized-code flow.
+		logger.Info("Requesting SD-JWT credential from issuer...")
+		savedCred, err = common.ReceiveCredentialFromOffer(
+			w,
+			mockKey,
+			"http://localhost:8080/configurations/IdentityCredential/offer",
+			"dc+sd-jwt",
+		)
+		if err != nil {
+			logger.Error("Failed to receive credential", "error", err)
+			os.Exit(1)
+		}
+		logger.Info(
+			"Received SD-JWT credential",
+			"id", savedCred.Entry.Id,
+			"issuer", savedCred.Credential.Issuer,
+			"claims", savedCred.Credential.Claims,
+		)
 	}
-	savedCred := &wallet.SavedCredential{
-		Credential: deserializedCred,
-		Entry:      savedSdJwtCredEntry,
-	}
-	logger.Info("Deserialized credential", "issuer", deserializedCred.Issuer, "claims", deserializedCred.Claims)
 
 	var oid4vpURI string
 	var options *sdjwtvc.SdJwtVcPresentationOptions

--- a/wallet/receiver/plugins/oid4vci/oid4vci.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci.go
@@ -197,26 +197,56 @@ func (o *Oid4vciReceiver) ReceiveCredential(
 		return nil, fmt.Errorf("credential response is empty")
 	}
 
-	// Extract credential from response
-	var credentialResponse map[string]interface{}
+	// Extract credential from response.
+	//
+	// OID4VCI (the current draft, see issuer #394) returns the credential nested
+	// under a "credentials" array, where each entry carries a "credential" field:
+	//
+	//	{ "credentials": [ { "credential": "<credential>" } ] }
+	//
+	// Earlier drafts returned it as a flat top-level "credential" field:
+	//
+	//	{ "credential": "<credential>" }
+	//
+	// We prefer the new array form and fall back to the legacy flat form so that
+	// issuers that have not migrated yet keep working.
+	var credentialResponse struct {
+		Credentials []struct {
+			Credential json.RawMessage `json:"credential"`
+		} `json:"credentials"`
+		Credential json.RawMessage `json:"credential"`
+	}
 	if err := json.Unmarshal(bodyBytes, &credentialResponse); err != nil {
 		return nil, err
 	}
 
-	credential, ok := credentialResponse["credential"]
-	if !ok {
+	var rawCredential json.RawMessage
+	switch {
+	case len(credentialResponse.Credentials) > 0 && len(credentialResponse.Credentials[0].Credential) > 0:
+		// New format: take the first credential in the array.
+		rawCredential = credentialResponse.Credentials[0].Credential
+	case len(credentialResponse.Credential) > 0:
+		// Legacy format: flat top-level credential.
+		rawCredential = credentialResponse.Credential
+	default:
 		return nil, fmt.Errorf("no credential found in response")
 	}
 
-	credentialStr, ok := credential.(string)
-	if !ok {
-		// If credential is not a string, marshal it back to JSON
-		credentialBytes, err := json.Marshal(credential)
-		if err != nil {
-			return nil, err
-		}
-		credentialStr = string(credentialBytes)
+	credentialStr, err := credentialRawToString(rawCredential)
+	if err != nil {
+		return nil, err
 	}
 
 	return &credentialStr, nil
+}
+
+// credentialRawToString converts a raw JSON credential value into a string.
+// When the credential is a JSON string (e.g. a compact JWT or SD-JWT) it is
+// unquoted; otherwise (e.g. a JSON-LD object) the raw JSON is returned as-is.
+func credentialRawToString(raw json.RawMessage) (string, error) {
+	var credentialStr string
+	if err := json.Unmarshal(raw, &credentialStr); err == nil {
+		return credentialStr, nil
+	}
+	return string(raw), nil
 }

--- a/wallet/receiver/plugins/oid4vci/oid4vci_test.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci_test.go
@@ -37,7 +37,8 @@ func TestOid4vciReceiver_FetchIssuerMetadata(t *testing.T) {
 		http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
 		defer env.SetDebugMode(dbg_mode)
 		defer env.SetHTTPAllowed(http_allowed)
-		env.SetDebugMode(false); env.SetHTTPAllowed(false)
+		env.SetDebugMode(false)
+		env.SetHTTPAllowed(false)
 
 		_, err := receiver.FetchIssuerMetadata(endpoint, types.Oid4vci)
 		if err == nil {
@@ -202,7 +203,8 @@ func TestOid4vciReceiver_FetchAuthorizationServerMetadata(t *testing.T) {
 		http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
 		defer env.SetDebugMode(dbg_mode)
 		defer env.SetHTTPAllowed(http_allowed)
-		env.SetDebugMode(false); env.SetHTTPAllowed(false)
+		env.SetDebugMode(false)
+		env.SetHTTPAllowed(false)
 
 		_, err := receiver.FetchAuthorizationServerMetadata(endpoint, types.Oid4vci)
 		if err == nil {
@@ -283,7 +285,8 @@ func TestOid4vciReceiver_FetchAccessToken(t *testing.T) {
 		http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
 		defer env.SetDebugMode(dbg_mode)
 		defer env.SetHTTPAllowed(http_allowed)
-		env.SetDebugMode(false); env.SetHTTPAllowed(false)
+		env.SetDebugMode(false)
+		env.SetHTTPAllowed(false)
 
 		_, err := receiver.FetchAccessToken(types.Oid4vci, endpoint, "test-code")
 		if err == nil {
@@ -365,7 +368,8 @@ func TestOid4vciReceiver_ReceiveCredential(t *testing.T) {
 		http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
 		defer env.SetDebugMode(dbg_mode)
 		defer env.SetHTTPAllowed(http_allowed)
-		env.SetDebugMode(false); env.SetHTTPAllowed(false)
+		env.SetDebugMode(false)
+		env.SetHTTPAllowed(false)
 
 		_, err := receiver.ReceiveCredential(types.Oid4vci, endpoint, "jwt_vc_json", accessToken, nil, nil)
 		if err == nil {
@@ -444,6 +448,81 @@ func TestOid4vciReceiver_ReceiveCredential(t *testing.T) {
 			t.Fatal("Expected error when no credential is in the response")
 		}
 	})
+
+	t.Run("New credentials array format", func(t *testing.T) {
+		http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
+		defer env.SetHTTPAllowed(http_allowed)
+		env.SetHTTPAllowed(true)
+
+		server := mockserver.NewMockServer()
+		defer server.Close()
+
+		// OID4VCI current format: credential nested under a "credentials" array.
+		server.SetJSONResponse("/credential", http.StatusOK, map[string]interface{}{
+			"credentials": []map[string]string{
+				{"credential": "new-format-credential"},
+			},
+		})
+
+		serverURL, _ := url.Parse(server.URL() + "/credential")
+		credential, err := receiver.ReceiveCredential(types.Oid4vci, common.URIField(*serverURL), "jwt_vc_json", accessToken, nil, nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if credential == nil || *credential != "new-format-credential" {
+			t.Fatalf("Expected 'new-format-credential', got %v", credential)
+		}
+	})
+
+	t.Run("Prefers credentials array over legacy flat field", func(t *testing.T) {
+		http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
+		defer env.SetHTTPAllowed(http_allowed)
+		env.SetHTTPAllowed(true)
+
+		server := mockserver.NewMockServer()
+		defer server.Close()
+
+		// When both forms are present, the new array form wins.
+		server.SetJSONResponse("/credential", http.StatusOK, map[string]interface{}{
+			"credentials": []map[string]string{
+				{"credential": "from-array"},
+			},
+			"credential": "from-flat",
+		})
+
+		serverURL, _ := url.Parse(server.URL() + "/credential")
+		credential, err := receiver.ReceiveCredential(types.Oid4vci, common.URIField(*serverURL), "jwt_vc_json", accessToken, nil, nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if credential == nil || *credential != "from-array" {
+			t.Fatalf("Expected 'from-array', got %v", credential)
+		}
+	})
+
+	t.Run("Empty credentials array falls back to legacy flat field", func(t *testing.T) {
+		http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
+		defer env.SetHTTPAllowed(http_allowed)
+		env.SetHTTPAllowed(true)
+
+		server := mockserver.NewMockServer()
+		defer server.Close()
+
+		// An empty array carries no credential, so the legacy field is used.
+		server.SetJSONResponse("/credential", http.StatusOK, map[string]interface{}{
+			"credentials": []map[string]string{},
+			"credential":  "from-flat",
+		})
+
+		serverURL, _ := url.Parse(server.URL() + "/credential")
+		credential, err := receiver.ReceiveCredential(types.Oid4vci, common.URIField(*serverURL), "jwt_vc_json", accessToken, nil, nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if credential == nil || *credential != "from-flat" {
+			t.Fatalf("Expected 'from-flat', got %v", credential)
+		}
+	})
 }
 
 func TestOid4vciReceiver_MetadataDiscovery_UrlPatterns(t *testing.T) {
@@ -514,7 +593,7 @@ func TestOid4vciReceiver_MetadataDiscovery_UrlPatterns(t *testing.T) {
 	http_allowed := strings.EqualFold(env.GetEnv(env.HTTP_ALLOWED), "true")
 	defer env.SetHTTPAllowed(http_allowed)
 	env.SetHTTPAllowed(true)
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -252,6 +252,27 @@ type ReceiveCredentialRequest struct {
 	Type                 receiverTypes.SupportedReceivingTypes
 	Key                  IKeyEntry
 	CachedIssuerMetadata *receiverTypes.CredentialIssuerMetadata
+	// Format is the OID4VCI credential format to request, e.g. "jwt_vc_json" or
+	// "dc+sd-jwt". When empty it defaults to "jwt_vc_json" for backward
+	// compatibility.
+	Format string
+}
+
+// OID4VCI credential request formats supported by the wallet.
+const (
+	formatJwtVcJson = "jwt_vc_json"
+	formatDcSdJwt   = "dc+sd-jwt"
+)
+
+// credentialFormatToMime maps an OID4VCI credential format to the MIME type used
+// to store and deserialize the received credential.
+func credentialFormatToMime(format string) string {
+	switch format {
+	case formatDcSdJwt:
+		return string(credential.SDJwtVC)
+	default:
+		return string(credential.JwtVc)
+	}
 }
 
 // CredentialOffer represents a credential offer from an issuer.
@@ -472,7 +493,7 @@ func (w *Wallet) ReceiveCredential(req ReceiveCredentialRequest) (*SavedCredenti
 		return nil, err
 	}
 
-	return w.storeAndParseCredential(credentialJWT)
+	return w.storeAndParseCredential(credentialJWT, credentialFormatToMime(req.Format))
 }
 
 // validateCredentialOffer validates the credential offer and extracts pre-authorization code.
@@ -563,10 +584,15 @@ func (w *Wallet) requestCredential(req ReceiveCredentialRequest, issuerMetadata 
 		return nil, fmt.Errorf("failed to generate JWT proof: %w", err)
 	}
 
+	format := req.Format
+	if format == "" {
+		format = formatJwtVcJson
+	}
+
 	credentialJWT, err := w.receiver.ReceiveCredential(
 		req.Type,
 		issuerMetadata.CredentialEndpoint,
-		"jwt_vc_json",
+		format,
 		*accessToken,
 		&receiverTypes.CredentialDefinition{
 			Type: append(req.CredentialOffer.CredentialConfigurationIDs, "VerifiableCredential"),
@@ -580,13 +606,14 @@ func (w *Wallet) requestCredential(req ReceiveCredentialRequest, issuerMetadata 
 	return credentialJWT, nil
 }
 
-// storeAndParseCredential stores the credential and parses it for return.
-func (w *Wallet) storeAndParseCredential(credentialJWT *string) (*SavedCredential, error) {
+// storeAndParseCredential stores the credential under the given MIME type and
+// parses it for return.
+func (w *Wallet) storeAndParseCredential(credentialJWT *string, mimeType string) (*SavedCredential, error) {
 	credentialEntry := types.CredentialEntry{
 		Id:         uuid.New().String(),
 		ReceivedAt: time.Now(),
 		Raw:        []byte(*credentialJWT),
-		MimeType:   "application/vc+jwt",
+		MimeType:   mimeType,
 	}
 
 	if err := w.credStore.SaveCredentialEntry(credentialEntry, types.SupportedCredStoreTypes(0)); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * SD-JWT VC（`dc+sd-jwt`）の発行フローに対応し、対応フォーマットをサンプルにも追加しました。
  * 資格情報の受領要求でフォーマット指定を反映できるようになり、受信側の保存・再パース挙動が指定に連動しました。
  * 受信を credential offer から行うサンプル用ユーティリティを追加しました。

* **Bug Fixes**
  * OID4VCI のクレデンシャル応答パースを改善し、複数形式に互換性を持たせました。

* **Tests**
  * 受信テストを拡充し、新旧レスポンス形式の優先・フォールバックを検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->