### PR TITLE
fix(wallet): validate unique credential configuration ids

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -326,7 +326,7 @@ func resolveCredentialRequestProofBindingMethod(
 		if strings.HasPrefix(normalized, "did:") {
 			return credentialRequestProofBindingMethodKID
 		}
-	
+
 		if strings.EqualFold(strings.TrimSpace(method), string(credentialRequestProofBindingMethodJWK)) {
 			return credentialRequestProofBindingMethodJWK
 		}
@@ -527,7 +527,6 @@ func (w *Wallet) ReceiveCredential(req ReceiveCredentialRequest) (*SavedCredenti
 		return nil, err
 	}
 
-
 	credentialConfigurationID, credentialConfiguration, serializationFlavor, err := w.selectCredentialConfiguration(req, issuerMetadata)
 	if err != nil {
 		return nil, err
@@ -564,6 +563,13 @@ func (w *Wallet) validateCredentialOffer(offer *CredentialOffer) (string, error)
 
 	if len(offer.CredentialConfigurationIDs) == 0 {
 		return "", fmt.Errorf("credential configuration IDs are empty")
+	}
+	seen := make(map[string]struct{}, len(offer.CredentialConfigurationIDs))
+	for _, id := range offer.CredentialConfigurationIDs {
+		if _, dup := seen[id]; dup {
+			return "", fmt.Errorf("credential configuration IDs must be unique: %q is duplicated", id)
+		}
+		seen[id] = struct{}{}
 	}
 
 	preAuthCode := preAuthGrant.PreAuthorizedCode
@@ -664,7 +670,7 @@ func ensureJWTProofSupported(credentialConfiguration *receiverTypes.CredentialCo
 
 	return fmt.Errorf("unsupported proof type: jwt proof is required")
 }
-  
+
 func (w *Wallet) validateCredentialConfigurationIDs(offer *CredentialOffer, issuerMetadata *receiverTypes.CredentialIssuerMetadata) error {
 	if offer == nil {
 		return fmt.Errorf("credential offer is required")

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -365,8 +365,8 @@ func TestController_ReceiveCredential_TxCodeProvided_Integration(t *testing.T) {
 
 	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
 		mockserver.JSONResponse(w, http.StatusOK, map[string]interface{}{
-			"issuer":                                          server.URL,
-			"token_endpoint":                                  server.URL + "/token",
+			"issuer":         server.URL,
+			"token_endpoint": server.URL + "/token",
 			"pre-authorized_grant_anonymous_access_supported": true,
 			"response_types_supported":                        []string{"code"},
 		})
@@ -1446,9 +1446,9 @@ func newCredentialIssuanceMockServer(t *testing.T, opts credentialIssuanceMockSe
 		switch r.URL.Path {
 		case "/.well-known/openid-credential-issuer":
 			issuerResponse := map[string]interface{}{
-				"credential_issuer":                    baseURL,
-				"credential_endpoint":                  baseURL + "/credential",
-				"authorization_servers":                []string{baseURL},
+				"credential_issuer":                   baseURL,
+				"credential_endpoint":                 baseURL + "/credential",
+				"authorization_servers":               []string{baseURL},
 				"credential_configurations_supported": opts.credentialConfigurationsSupported,
 			}
 			if opts.includeNonceEndpoint {
@@ -2499,6 +2499,18 @@ func TestWallet_validateCredentialOffer(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "duplicated credential configuration IDs",
+			offer: &CredentialOffer{
+				CredentialIssuer:           issuerURL,
+				CredentialConfigurationIDs: []string{"Degree", "VerifiableCredential", "Degree"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "credential configuration IDs must be unique",
+		},
+		{
 			name: "empty pre-authorization code",
 			offer: &CredentialOffer{
 				CredentialIssuer:           issuerURL,
@@ -2514,6 +2526,17 @@ func TestWallet_validateCredentialOffer(t *testing.T) {
 			offer: &CredentialOffer{
 				CredentialIssuer:           issuerURL,
 				CredentialConfigurationIDs: []string{"test-credential"},
+				Grants: map[string]*CredentialOfferGrant{
+					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
+				},
+			},
+			want: "pre-auth-code",
+		},
+		{
+			name: "valid offer with multiple unique credential configuration IDs",
+			offer: &CredentialOffer{
+				CredentialIssuer:           issuerURL,
+				CredentialConfigurationIDs: []string{"Degree", "VerifiableCredential"},
 				Grants: map[string]*CredentialOfferGrant{
 					preAuthGrantType: {PreAuthorizedCode: "pre-auth-code"},
 				},


### PR DESCRIPTION
## 変更内容

- `validateCredentialOffer` に `credential_configuration_ids` の重複チェックを追加
- 同じ credential configuration ID が複数含まれている場合はエラーにする
- 以下のテストケースを追加
  - 重複した `credential_configuration_ids` を拒否すること
  - 複数の unique な `credential_configuration_ids` を許可すること

## 対象範囲

- wallet 側のみ
- issuer 側の schema / flow は変更なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * クレデンシャルオファーの検証機能を改善し、重複したクレデンシャル設定IDを検出して処理を中断するようにしました。
  * 対応するテストケースを追加し、正常系および異常系での動作を確認しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->