### PR TITLE
feat(aws): DynamoDBベースのリクエストオブジェクトストアプロバイダを追加

### DIFF
--- a/aws/src/index.ts
+++ b/aws/src/index.ts
@@ -14,3 +14,7 @@ export {
   DynamoDbVerifierMetadataStoreOptions,
   dynamodbVerifierMetadataStore,
 } from './providers/dynamodb-verifier-metadata-store.provider'
+export {
+  DynamoDbRequestObjectStoreOptions,
+  dynamodbRequestObjectStore,
+} from './providers/dynamodb-request-object-store.provider'

--- a/aws/src/providers/dynamodb-request-object-store.provider.ts
+++ b/aws/src/providers/dynamodb-request-object-store.provider.ts
@@ -40,7 +40,7 @@ export const dynamodbRequestObjectStore = (
       }
 
       // DynamoDB TTL deletion is eventually consistent — check expiry manually.
-      if (Math.floor(Date.now() / 1000) > expires_at) {
+      if (typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) > expires_at) {
         return null
       }
 

--- a/aws/src/providers/dynamodb-request-object-store.provider.ts
+++ b/aws/src/providers/dynamodb-request-object-store.provider.ts
@@ -1,0 +1,69 @@
+import { DeleteCommand, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { RequestObject } from '@trustknots/vcknots'
+import { RequestObjectStoreProvider } from '@trustknots/vcknots/providers'
+import { DynamoDbProviderOptions, resolveDynamoDbDocumentClient } from './dynamodb'
+
+export type DynamoDbRequestObjectStoreOptions = DynamoDbProviderOptions & {
+  tableName: string
+  /** TTL in milliseconds. Defaults to 5 minutes. */
+  expiresIn?: number
+}
+
+const DEFAULT_EXPIRES_IN_MS = 60 * 5 * 1000
+
+export const dynamodbRequestObjectStore = (
+  options: DynamoDbRequestObjectStoreOptions
+): RequestObjectStoreProvider => {
+  const client = resolveDynamoDbDocumentClient(options)
+  const { tableName, expiresIn = DEFAULT_EXPIRES_IN_MS } = options
+
+  return {
+    kind: 'request-object-store-provider',
+    name: 'dynamodb-request-object-store-provider',
+    single: true,
+
+    async fetch(id) {
+      const result = await client.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: { id },
+        })
+      )
+
+      if (!result.Item) {
+        return null
+      }
+
+      const { expires_at, requestObject } = result.Item as {
+        expires_at: number
+        requestObject: RequestObject
+      }
+
+      // DynamoDB TTL deletion is eventually consistent — check expiry manually.
+      if (Math.floor(Date.now() / 1000) > expires_at) {
+        return null
+      }
+
+      return requestObject
+    },
+
+    async save(id, requestObject) {
+      const expires_at = Math.floor((Date.now() + expiresIn) / 1000)
+      await client.send(
+        new PutCommand({
+          TableName: tableName,
+          Item: { id, requestObject, expires_at },
+        })
+      )
+    },
+
+    async delete(id) {
+      await client.send(
+        new DeleteCommand({
+          TableName: tableName,
+          Key: { id },
+        })
+      )
+    },
+  }
+}

--- a/aws/src/providers/dynamodb.ts
+++ b/aws/src/providers/dynamodb.ts
@@ -13,5 +13,7 @@ export const resolveDynamoDbDocumentClient = (
   }
 
   const dynamoDbClient = new DynamoDBClient({})
-  return DynamoDBDocumentClient.from(dynamoDbClient)
+  return DynamoDBDocumentClient.from(dynamoDbClient, {
+    marshallOptions: { removeUndefinedValues: true },
+  })
 }

--- a/aws/test/dynamodb-request-object-store.provider.spec.ts
+++ b/aws/test/dynamodb-request-object-store.provider.spec.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { mockClient } from 'aws-sdk-client-mock'
+import { RequestObject, RequestObjectId } from '@trustknots/vcknots'
+import { dynamodbRequestObjectStore } from '../src/providers/dynamodb-request-object-store.provider'
+
+const TABLE_NAME = 'RequestObjectsTable'
+const ddbMock = mockClient(DynamoDBDocumentClient)
+
+describe('dynamodbRequestObjectStore', () => {
+  const requestObjectId = RequestObjectId('test-request-object-id')
+  const requestObject: RequestObject = {
+    client_id: 'https://verifier.example.com',
+    response_type: 'vp_token',
+    response_mode: 'direct_post',
+    nonce: 'test-nonce',
+    presentation_definition: {
+      id: 'test-pd',
+      input_descriptors: [],
+    },
+  }
+
+  afterEach(() => {
+    ddbMock.reset()
+  })
+
+  const createProvider = (expiresIn?: number) =>
+    dynamodbRequestObjectStore({
+      client: ddbMock as unknown as DynamoDBDocumentClient,
+      tableName: TABLE_NAME,
+      ...(expiresIn !== undefined && { expiresIn }),
+    })
+
+  it('should have correct provider metadata', () => {
+    const provider = createProvider()
+    assert.equal(provider.kind, 'request-object-store-provider')
+    assert.equal(provider.name, 'dynamodb-request-object-store-provider')
+    assert.equal(provider.single, true)
+  })
+
+  it('should save and fetch a request object', async () => {
+    const futureExpiry = Math.floor(Date.now() / 1000) + 300
+    ddbMock.on(PutCommand).resolves({})
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: requestObjectId, requestObject, expires_at: futureExpiry },
+    })
+
+    const provider = createProvider()
+    await provider.save(requestObjectId, requestObject)
+    const fetched = await provider.fetch(requestObjectId)
+
+    assert.deepEqual(fetched, requestObject)
+    assert.equal(ddbMock.commandCalls(PutCommand).length, 1)
+    assert.equal(ddbMock.commandCalls(GetCommand).length, 1)
+  })
+
+  it('should return null when fetching an unknown id', async () => {
+    ddbMock.on(GetCommand).resolves({})
+
+    const provider = createProvider()
+    const fetched = await provider.fetch(RequestObjectId('unknown-id'))
+
+    assert.equal(fetched, null)
+  })
+
+  it('should return null when the item is expired', async () => {
+    const pastExpiry = Math.floor(Date.now() / 1000) - 1
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: requestObjectId, requestObject, expires_at: pastExpiry },
+    })
+
+    const provider = createProvider()
+    const fetched = await provider.fetch(requestObjectId)
+
+    assert.equal(fetched, null)
+  })
+
+  it('should save with correct table name and expires_at', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Math.floor(Date.now() / 1000)
+
+    const provider = createProvider()
+    await provider.save(requestObjectId, requestObject)
+
+    const after = Math.floor(Date.now() / 1000)
+    const putCall = ddbMock.commandCalls(PutCommand)[0]
+    const item = putCall?.args[0].input.Item
+
+    assert.equal(putCall?.args[0].input.TableName, TABLE_NAME)
+    assert.equal(item?.id, requestObjectId)
+    assert.deepEqual(item?.requestObject, requestObject)
+    assert.ok(item?.expires_at >= before + 300)
+    assert.ok(item?.expires_at <= after + 300)
+  })
+
+  it('should delete a request object', async () => {
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.delete(requestObjectId)
+
+    const deleteCall = ddbMock.commandCalls(DeleteCommand)[0]
+    assert.equal(deleteCall?.args[0].input.TableName, TABLE_NAME)
+    assert.deepEqual(deleteCall?.args[0].input.Key, { id: requestObjectId })
+  })
+})

--- a/aws/test/dynamodb-request-object-store.provider.spec.ts
+++ b/aws/test/dynamodb-request-object-store.provider.spec.ts
@@ -76,6 +76,17 @@ describe('dynamodbRequestObjectStore', () => {
     assert.equal(fetched, null)
   })
 
+  it('should return null when expires_at is missing', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: requestObjectId, requestObject },
+    })
+
+    const provider = createProvider()
+    const fetched = await provider.fetch(requestObjectId)
+
+    assert.equal(fetched, null)
+  })
+
   it('should save with correct table name and expires_at', async () => {
     ddbMock.on(PutCommand).resolves({})
     const before = Math.floor(Date.now() / 1000)

--- a/server/aws/README.ja.md
+++ b/server/aws/README.ja.md
@@ -81,7 +81,7 @@ cp .env.example .env
 | `AUTH_SERVERS_TABLE_NAME` | Authz **必須** | DynamoDB テーブル名（スタック出力: `AuthServersTableName`） |
 | `PRE_CODES_TABLE_NAME` | Authz（任意） | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
 | `VERIFIERS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `VerifiersTableName`） |
-| `REQUEST_OBJECTS_TABLE_NAME` | Verifier（任意） | DynamoDB テーブル名（スタック出力: `RequestObjectsTableName`） |
+| `REQUEST_OBJECTS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `RequestObjectsTableName`） |
 | `NONCES_TABLE_NAME` | Verifier（任意） | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
 | `ISSUER_PORT` | Issuer（任意） | Issuer のリッスンポートを上書き（デフォルト: `8081`） |
 | `ISSUER_BASE_URL` | Issuer（任意） | Issuer メタデータで使用するベース URL を上書き（デフォルト: `http://localhost:{ISSUER_PORT}`） |
@@ -90,7 +90,7 @@ cp .env.example .env
 | `VERIFIER_PORT` | Verifier（任意） | Verifier のリッスンポートを上書き（デフォルト: `8083`） |
 | `VERIFIER_BASE_URL` | Verifier（任意） | Verifier メタデータで使用するベース URL を上書き（デフォルト: `http://localhost:{VERIFIER_PORT}`） |
 
-**`ISSUERS_TABLE_NAME`・`AUTH_SERVERS_TABLE_NAME`・`VERIFIERS_TABLE_NAME` は必須**です。未設定の場合、該当サーバーは起動時に終了します。
+**`ISSUERS_TABLE_NAME`・`AUTH_SERVERS_TABLE_NAME`・`VERIFIERS_TABLE_NAME`・`REQUEST_OBJECTS_TABLE_NAME` は必須**です。未設定の場合、該当サーバーは起動時に終了します。
 
 ## サーバーの起動
 

--- a/server/aws/README.md
+++ b/server/aws/README.md
@@ -81,7 +81,7 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 | `AUTH_SERVERS_TABLE_NAME` | Authz **required** | DynamoDB table name (stack output: `AuthServersTableName`) |
 | `PRE_CODES_TABLE_NAME` | Authz (optional) | DynamoDB table name (stack output: `PreCodesTableName`) |
 | `VERIFIERS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `VerifiersTableName`) |
-| `REQUEST_OBJECTS_TABLE_NAME` | Verifier (optional) | DynamoDB table name (stack output: `RequestObjectsTableName`) |
+| `REQUEST_OBJECTS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `RequestObjectsTableName`) |
 | `NONCES_TABLE_NAME` | Verifier (optional) | DynamoDB table name (stack output: `NoncesTableName`) |
 | `ISSUER_PORT` | Issuer (optional) | Override the Issuer listening port (default: `8081`) |
 | `ISSUER_BASE_URL` | Issuer (optional) | Override the base URL used in Issuer metadata (default: `http://localhost:{ISSUER_PORT}`) |
@@ -90,7 +90,7 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 | `VERIFIER_PORT` | Verifier (optional) | Override the Verifier listening port (default: `8083`) |
 | `VERIFIER_BASE_URL` | Verifier (optional) | Override the base URL used in Verifier metadata (default: `http://localhost:{VERIFIER_PORT}`) |
 
-**`ISSUERS_TABLE_NAME`, `AUTH_SERVERS_TABLE_NAME`, and `VERIFIERS_TABLE_NAME` are required** — each server exits at startup if its table name is missing.
+**`ISSUERS_TABLE_NAME`, `AUTH_SERVERS_TABLE_NAME`, `VERIFIERS_TABLE_NAME`, and `REQUEST_OBJECTS_TABLE_NAME` are required** — each server exits at startup if its table name is missing.
 
 ## Start the Servers
 

--- a/server/aws/src/.env.example
+++ b/server/aws/src/.env.example
@@ -22,5 +22,6 @@ AUTH_SERVERS_TABLE_NAME=ResourcesStack-DataStoresAuthServersTableXXXXXXXX-XXXXXX
 # VERIFIER_BASE_URL=http://localhost:8083
 # Required for DynamoDB verifier metadata store (deploy output: VerifiersTableName)
 VERIFIERS_TABLE_NAME=ResourcesStack-DataStoresVerifiersTableXXXXXXXX-XXXXXXXXXXXX
-# REQUEST_OBJECTS_TABLE_NAME=ResourcesStack-...
+# Required for DynamoDB request object store (deploy output: RequestObjectsTableName)
+REQUEST_OBJECTS_TABLE_NAME=ResourcesStack-DataStoresRequestObjectsTableXXXXXXXX-XXXXXXXXXXXX
 # NONCES_TABLE_NAME=ResourcesStack-...

--- a/server/aws/src/apps/create-authz-app.ts
+++ b/server/aws/src/apps/create-authz-app.ts
@@ -6,7 +6,6 @@ import { createAuthzRouter } from '@trustknots/server-core/routes/authz'
 import { AuthorizationServerIssuer, AuthorizationServerMetadata, initializeAuthzFlow } from '@trustknots/vcknots/authz'
 import type { VcknotsOptions } from '@trustknots/vcknots'
 import { createBaseApp } from './create-base-app.js'
-import { createVcknotsContext } from '../context/vcknots-context.js'
 
 export function createAuthzApp(options?: VcknotsOptions) {
   const tableName = process.env.AUTH_SERVERS_TABLE_NAME
@@ -19,14 +18,13 @@ export function createAuthzApp(options?: VcknotsOptions) {
   if (!Number.isFinite(port)) throw new Error(`Invalid AUTHZ_PORT: "${rawPort}"`)
 
   const store = dynamodbAuthzServerMetadataStore({ tableName })
-  const { app } = createBaseApp(
+  const { app, context } = createBaseApp(
     createAuthzRouter,
     { port, baseUrl: process.env.AUTHZ_BASE_URL },
     { ...options, providers: [store, ...(options?.providers ?? [])] },
   )
 
   async function initialize(baseUrl: string) {
-    const context = createVcknotsContext({ ...options, providers: [store, ...(options?.providers ?? [])] })
     const authzFlow = initializeAuthzFlow(context)
 
     const existing = await authzFlow.findAuthzServerMetadata(AuthorizationServerIssuer(baseUrl))

--- a/server/aws/src/apps/create-base-app.ts
+++ b/server/aws/src/apps/create-base-app.ts
@@ -23,5 +23,5 @@ export function createBaseApp(
     return c.json({ error: 'internal_server_error' }, 500)
   })
 
-  return { app }
+  return { app, context }
 }

--- a/server/aws/src/apps/create-issuer-app.ts
+++ b/server/aws/src/apps/create-issuer-app.ts
@@ -6,7 +6,6 @@ import { createIssueRouter } from '@trustknots/server-core/routes/issue'
 import { CredentialIssuer, CredentialIssuerMetadata, initializeIssuerFlow } from '@trustknots/vcknots/issuer'
 import type { VcknotsOptions } from '@trustknots/vcknots'
 import { createBaseApp } from './create-base-app.js'
-import { createVcknotsContext } from '../context/vcknots-context.js'
 
 export function createIssuerApp(options?: VcknotsOptions) {
   const tableName = process.env.ISSUERS_TABLE_NAME
@@ -19,14 +18,13 @@ export function createIssuerApp(options?: VcknotsOptions) {
   if (!Number.isFinite(port)) throw new Error(`Invalid ISSUER_PORT: "${rawPort}"`)
 
   const store = dynamodbIssuerMetadataStore({ tableName })
-  const { app } = createBaseApp(
+  const { app, context } = createBaseApp(
     createIssueRouter,
     { port, baseUrl: process.env.ISSUER_BASE_URL },
     { ...options, providers: [store, ...(options?.providers ?? [])] },
   )
 
   async function initialize(baseUrl: string) {
-    const context = createVcknotsContext({ ...options, providers: [store, ...(options?.providers ?? [])] })
     const issuerFlow = initializeIssuerFlow(context)
 
     const existing = await issuerFlow.findIssuerMetadata(CredentialIssuer(baseUrl))

--- a/server/aws/src/apps/create-verifier-app.ts
+++ b/server/aws/src/apps/create-verifier-app.ts
@@ -6,7 +6,6 @@ import { createVerifierRouter } from '@trustknots/server-core/routes/verify'
 import { VerifierClientId, VerifierMetadata, initializeVerifierFlow } from '@trustknots/vcknots/verifier'
 import type { VcknotsOptions } from '@trustknots/vcknots'
 import { createBaseApp } from './create-base-app.js'
-import { createVcknotsContext } from '../context/vcknots-context.js'
 
 export function createVerifierApp(options?: VcknotsOptions) {
   const verifiersTableName = process.env.VERIFIERS_TABLE_NAME
@@ -25,7 +24,7 @@ export function createVerifierApp(options?: VcknotsOptions) {
 
   const verifierMetadataStore = dynamodbVerifierMetadataStore({ tableName: verifiersTableName })
   const requestObjectStore = dynamodbRequestObjectStore({ tableName: requestObjectsTableName })
-  const { app } = createBaseApp(
+  const { app, context } = createBaseApp(
     createVerifierRouter,
     { port, baseUrl: process.env.VERIFIER_BASE_URL },
     { ...options, providers: [verifierMetadataStore, requestObjectStore, ...(options?.providers ?? [])] },
@@ -33,7 +32,6 @@ export function createVerifierApp(options?: VcknotsOptions) {
 
   async function initialize(baseUrl: string) {
     const verifierId = VerifierClientId(baseUrl)
-    const context = createVcknotsContext({ ...options, providers: [verifierMetadataStore, requestObjectStore, ...(options?.providers ?? [])] })
     const verifierFlow = initializeVerifierFlow(context)
 
     const existing = await verifierFlow.findVerifierMetadata(verifierId)

--- a/server/aws/src/apps/create-verifier-app.ts
+++ b/server/aws/src/apps/create-verifier-app.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { dynamodbVerifierMetadataStore } from '@trustknots/aws'
+import { dynamodbRequestObjectStore, dynamodbVerifierMetadataStore } from '@trustknots/aws'
 import { createVerifierRouter } from '@trustknots/server-core/routes/verify'
 import { VerifierClientId, VerifierMetadata, initializeVerifierFlow } from '@trustknots/vcknots/verifier'
 import type { VcknotsOptions } from '@trustknots/vcknots'
@@ -9,25 +9,31 @@ import { createBaseApp } from './create-base-app.js'
 import { createVcknotsContext } from '../context/vcknots-context.js'
 
 export function createVerifierApp(options?: VcknotsOptions) {
-  const tableName = process.env.VERIFIERS_TABLE_NAME
-  if (!tableName) {
+  const verifiersTableName = process.env.VERIFIERS_TABLE_NAME
+  if (!verifiersTableName) {
     throw new Error('VERIFIERS_TABLE_NAME is required')
+  }
+
+  const requestObjectsTableName = process.env.REQUEST_OBJECTS_TABLE_NAME
+  if (!requestObjectsTableName) {
+    throw new Error('REQUEST_OBJECTS_TABLE_NAME is required')
   }
 
   const rawPort = process.env.VERIFIER_PORT ?? '8083'
   const port = Number.parseInt(rawPort, 10)
   if (!Number.isFinite(port)) throw new Error(`Invalid VERIFIER_PORT: "${rawPort}"`)
 
-  const store = dynamodbVerifierMetadataStore({ tableName })
+  const verifierMetadataStore = dynamodbVerifierMetadataStore({ tableName: verifiersTableName })
+  const requestObjectStore = dynamodbRequestObjectStore({ tableName: requestObjectsTableName })
   const { app } = createBaseApp(
     createVerifierRouter,
     { port, baseUrl: process.env.VERIFIER_BASE_URL },
-    { ...options, providers: [store, ...(options?.providers ?? [])] },
+    { ...options, providers: [verifierMetadataStore, requestObjectStore, ...(options?.providers ?? [])] },
   )
 
   async function initialize(baseUrl: string) {
     const verifierId = VerifierClientId(baseUrl)
-    const context = createVcknotsContext({ ...options, providers: [store, ...(options?.providers ?? [])] })
+    const context = createVcknotsContext({ ...options, providers: [verifierMetadataStore, requestObjectStore, ...(options?.providers ?? [])] })
     const verifierFlow = initializeVerifierFlow(context)
 
     const existing = await verifierFlow.findVerifierMetadata(verifierId)


### PR DESCRIPTION
## 概要
- 既存のDynamoDBメタデータストアプロバイダと同様のパターンで、verifierサーバー向けにDynamoDBベースのリクエストオブジェクトストアプロバイダ（`DynamoDbRequestObjectStoreProvider`）を追加
- undefinedなフィールドがあってもmarshallingエラーにならないよう、共通の`DynamoDBDocumentClient`設定で`removeUndefinedValues`を有効化
- `server/aws/README.md`で`REQUEST_OBJECTS_TABLE_NAME`を必須環境変数として明記し、`.env.example`も合わせて更新

## テスト計画
- [ ] `aws/`ディレクトリで`pnpm test`が通ること（新規追加の`dynamodb-request-object-store.provider.spec.ts`を含む）
- [ ] `REQUEST_OBJECTS_TABLE_NAME`をローカルDynamoDBに向けて設定し、verifierサーバーが起動することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * DynamoDB を使ったリクエストオブジェクトの保存・取得・削除（有効期限付き）に対応
  * Verifier 初期化でリクエストオブジェクト用の保存先を利用するよう拡張
* **不具合修正**
  * DynamoDB 送信時に `undefined` 値を除外するよう改善
* **ドキュメント**
  * `REQUEST_OBJECTS_TABLE_NAME` を必須として案内（README/.env.example/起動要件）
* **テスト**
  * DynamoDB 経由の保存・取得・期限切れ・削除の挙動を検証するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->