### PR TITLE
feat(aws): DynamoDBベースのnonce(c_nonce)ストアプロバイダを追加

### DIFF
--- a/aws/src/index.ts
+++ b/aws/src/index.ts
@@ -18,3 +18,7 @@ export {
   DynamoDbRequestObjectStoreOptions,
   dynamodbRequestObjectStore,
 } from './providers/dynamodb-request-object-store.provider'
+export {
+  DynamoDbNonceStoreOptions,
+  dynamodbNonceStore,
+} from './providers/dynamodb-nonce-store.provider'

--- a/aws/src/providers/dynamodb-nonce-store.provider.ts
+++ b/aws/src/providers/dynamodb-nonce-store.provider.ts
@@ -10,16 +10,19 @@ export type DynamoDbNonceStoreOptions = DynamoDbProviderOptions & {
 type NonceItem = {
   id: string
   nonce: Nonce
+  /** Epoch milliseconds — used for manual expiry checks (parity with Firestore / in-memory). */
   expires_at: number
+  /** Epoch seconds — DynamoDB TTL attribute (infra-only, see CDK `timeToLiveAttribute: 'ttl'`). */
+  ttl: number
 }
 
 export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceStoreProvider => {
   const client = resolveDynamoDbDocumentClient(options)
   const { tableName } = options
 
-  // Treat the boundary second as expired (>=) to avoid reusing a nonce at its exact expiry.
+  // Match the Firestore / in-memory providers: expires_at is epoch ms and the exact boundary is still valid (>).
   const isExpired = (expires_at: unknown): boolean =>
-    typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) >= expires_at
+    typeof expires_at !== 'number' || Date.now() > expires_at
 
   return {
     kind: 'nonce-store-provider',
@@ -31,12 +34,13 @@ export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceSto
       if (ttlMs == null) {
         throw new Error('nonce_expires_in is required when saving nonce')
       }
-      // DynamoDB TTL expects an epoch time in seconds.
-      const expires_at = Math.floor((Date.now() + ttlMs) / 1000)
+      const expires_at = Date.now() + ttlMs
+      // DynamoDB TTL expects epoch seconds; round up so TTL never deletes before the real (ms) expiry.
+      const ttl = Math.ceil(expires_at / 1000)
       await client.send(
         new PutCommand({
           TableName: tableName,
-          Item: { id: nonce.nonce, nonce, expires_at } satisfies NonceItem,
+          Item: { id: nonce.nonce, nonce, expires_at, ttl } satisfies NonceItem,
         })
       )
     },

--- a/aws/src/providers/dynamodb-nonce-store.provider.ts
+++ b/aws/src/providers/dynamodb-nonce-store.provider.ts
@@ -1,0 +1,89 @@
+import { DeleteCommand, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { Nonce } from '@trustknots/vcknots'
+import { NonceStoreProvider } from '@trustknots/vcknots/providers'
+import { DynamoDbProviderOptions, resolveDynamoDbDocumentClient } from './dynamodb'
+
+export type DynamoDbNonceStoreOptions = DynamoDbProviderOptions & {
+  tableName: string
+}
+
+type NonceItem = {
+  id: string
+  nonce: Nonce
+  expires_at: number
+}
+
+export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceStoreProvider => {
+  const client = resolveDynamoDbDocumentClient(options)
+  const { tableName } = options
+
+  const isExpired = (expires_at: unknown): boolean =>
+    typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) > expires_at
+
+  return {
+    kind: 'nonce-store-provider',
+    name: 'dynamodb-nonce-store-provider',
+    single: true,
+
+    async save(nonce): Promise<void> {
+      const ttlMs = nonce.nonce_expires_in
+      if (ttlMs == null) {
+        throw new Error('nonce_expires_in is required when saving nonce')
+      }
+      // DynamoDB TTL expects an epoch time in seconds.
+      const expires_at = Math.floor((Date.now() + ttlMs) / 1000)
+      await client.send(
+        new PutCommand({
+          TableName: tableName,
+          Item: { id: nonce.nonce, nonce, expires_at } satisfies NonceItem,
+        })
+      )
+    },
+
+    async validate(nonce): Promise<boolean> {
+      const result = await client.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: { id: nonce.nonce },
+        })
+      )
+
+      if (!result.Item) {
+        return false
+      }
+
+      // DynamoDB TTL deletion is eventually consistent — check expiry manually.
+      const { expires_at } = result.Item as NonceItem
+      return !isExpired(expires_at)
+    },
+
+    async revoke(nonce): Promise<boolean> {
+      const result = await client.send(
+        new DeleteCommand({
+          TableName: tableName,
+          Key: { id: nonce.nonce },
+          ReturnValues: 'ALL_OLD',
+        })
+      )
+      return result.Attributes != null
+    },
+
+    async consume(nonce): Promise<boolean> {
+      // Atomically remove and return the previous item so a nonce can be used only once.
+      const result = await client.send(
+        new DeleteCommand({
+          TableName: tableName,
+          Key: { id: nonce.nonce },
+          ReturnValues: 'ALL_OLD',
+        })
+      )
+
+      if (!result.Attributes) {
+        return false
+      }
+
+      const { expires_at } = result.Attributes as NonceItem
+      return !isExpired(expires_at)
+    },
+  }
+}

--- a/aws/src/providers/dynamodb-nonce-store.provider.ts
+++ b/aws/src/providers/dynamodb-nonce-store.provider.ts
@@ -55,7 +55,17 @@ export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceSto
 
       // DynamoDB TTL deletion is eventually consistent — check expiry manually.
       const { expires_at } = result.Item as NonceItem
-      return !isExpired(expires_at)
+      if (isExpired(expires_at)) {
+        // Match the Firestore provider: proactively delete expired nonces instead of waiting for TTL.
+        await client.send(
+          new DeleteCommand({
+            TableName: tableName,
+            Key: { id: nonce.nonce },
+          })
+        )
+        return false
+      }
+      return true
     },
 
     async revoke(nonce): Promise<boolean> {

--- a/aws/src/providers/dynamodb-nonce-store.provider.ts
+++ b/aws/src/providers/dynamodb-nonce-store.provider.ts
@@ -17,8 +17,9 @@ export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceSto
   const client = resolveDynamoDbDocumentClient(options)
   const { tableName } = options
 
+  // Treat the boundary second as expired (>=) to avoid reusing a nonce at its exact expiry.
   const isExpired = (expires_at: unknown): boolean =>
-    typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) > expires_at
+    typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) >= expires_at
 
   return {
     kind: 'nonce-store-provider',

--- a/aws/src/providers/dynamodb-request-object-store.provider.ts
+++ b/aws/src/providers/dynamodb-request-object-store.provider.ts
@@ -39,8 +39,8 @@ export const dynamodbRequestObjectStore = (
         requestObject: RequestObject
       }
 
-      // DynamoDB TTL deletion is eventually consistent — check expiry manually.
-      if (typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) > expires_at) {
+      // expires_at is epoch ms (parity with Firestore / in-memory). DynamoDB TTL is eventually consistent — check manually.
+      if (typeof expires_at !== 'number' || Date.now() > expires_at) {
         return null
       }
 
@@ -48,11 +48,13 @@ export const dynamodbRequestObjectStore = (
     },
 
     async save(id, requestObject) {
-      const expires_at = Math.floor((Date.now() + expiresIn) / 1000)
+      const expires_at = Date.now() + expiresIn
+      // DynamoDB TTL expects epoch seconds; round up so TTL never deletes before the real (ms) expiry.
+      const ttl = Math.ceil(expires_at / 1000)
       await client.send(
         new PutCommand({
           TableName: tableName,
-          Item: { id, requestObject, expires_at },
+          Item: { id, requestObject, expires_at, ttl },
         })
       )
     },

--- a/aws/test/dynamodb-nonce-store.provider.spec.ts
+++ b/aws/test/dynamodb-nonce-store.provider.spec.ts
@@ -28,22 +28,25 @@ describe('dynamodbNonceStore', () => {
     assert.equal(provider.single, true)
   })
 
-  it('should save with correct table name and epoch-seconds expires_at', async () => {
+  it('should save with epoch-ms expires_at and epoch-seconds ttl', async () => {
     ddbMock.on(PutCommand).resolves({})
-    const before = Math.floor(Date.now() / 1000)
+    const before = Date.now()
 
     const provider = createProvider()
     await provider.save(nonce)
 
-    const after = Math.floor(Date.now() / 1000)
+    const after = Date.now()
     const putCall = ddbMock.commandCalls(PutCommand)[0]
     const item = putCall?.args[0].input.Item
 
     assert.equal(putCall?.args[0].input.TableName, TABLE_NAME)
     assert.equal(item?.id, nonce.nonce)
     assert.deepEqual(item?.nonce, nonce)
-    assert.ok(item?.expires_at >= before + 300)
-    assert.ok(item?.expires_at <= after + 300)
+    // expires_at is epoch ms (parity with Firestore / in-memory).
+    assert.ok(item?.expires_at >= before + 300 * 1000)
+    assert.ok(item?.expires_at <= after + 300 * 1000)
+    // ttl is epoch seconds, rounded up so TTL never fires before the real (ms) expiry.
+    assert.equal(item?.ttl, Math.ceil(item?.expires_at / 1000))
   })
 
   it('should throw when nonce_expires_in is missing on save', async () => {
@@ -53,7 +56,7 @@ describe('dynamodbNonceStore', () => {
   })
 
   it('validate should return true for a valid nonce', async () => {
-    const futureExpiry = Math.floor(Date.now() / 1000) + 300
+    const futureExpiry = Date.now() + 300 * 1000
     ddbMock.on(GetCommand).resolves({
       Item: { id: nonce.nonce, nonce, expires_at: futureExpiry },
     })
@@ -73,7 +76,7 @@ describe('dynamodbNonceStore', () => {
   })
 
   it('validate should return false and delete an expired nonce', async () => {
-    const pastExpiry = Math.floor(Date.now() / 1000) - 1
+    const pastExpiry = Date.now() - 1000
     ddbMock.on(GetCommand).resolves({
       Item: { id: nonce.nonce, nonce, expires_at: pastExpiry },
     })
@@ -90,7 +93,7 @@ describe('dynamodbNonceStore', () => {
 
   it('revoke should return true when the nonce existed', async () => {
     ddbMock.on(DeleteCommand).resolves({
-      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) + 300 },
+      Attributes: { id: nonce.nonce, nonce, expires_at: Date.now() + 300 * 1000 },
     })
 
     const provider = createProvider()
@@ -110,7 +113,7 @@ describe('dynamodbNonceStore', () => {
 
   it('consume should return true and delete a valid nonce', async () => {
     ddbMock.on(DeleteCommand).resolves({
-      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) + 300 },
+      Attributes: { id: nonce.nonce, nonce, expires_at: Date.now() + 300 * 1000 },
     })
 
     const provider = createProvider()
@@ -128,7 +131,7 @@ describe('dynamodbNonceStore', () => {
 
   it('consume should return false for an expired nonce', async () => {
     ddbMock.on(DeleteCommand).resolves({
-      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) - 1 },
+      Attributes: { id: nonce.nonce, nonce, expires_at: Date.now() - 1000 },
     })
 
     const provider = createProvider()

--- a/aws/test/dynamodb-nonce-store.provider.spec.ts
+++ b/aws/test/dynamodb-nonce-store.provider.spec.ts
@@ -72,14 +72,20 @@ describe('dynamodbNonceStore', () => {
     assert.equal(await provider.validate(nonce), false)
   })
 
-  it('validate should return false for an expired nonce', async () => {
+  it('validate should return false and delete an expired nonce', async () => {
     const pastExpiry = Math.floor(Date.now() / 1000) - 1
     ddbMock.on(GetCommand).resolves({
       Item: { id: nonce.nonce, nonce, expires_at: pastExpiry },
     })
+    ddbMock.on(DeleteCommand).resolves({})
 
     const provider = createProvider()
     assert.equal(await provider.validate(nonce), false)
+
+    // Match the Firestore provider: expired nonces are proactively deleted, not left to TTL.
+    const deleteCall = ddbMock.commandCalls(DeleteCommand)[0]
+    assert.equal(deleteCall?.args[0].input.TableName, TABLE_NAME)
+    assert.deepEqual(deleteCall?.args[0].input.Key, { id: nonce.nonce })
   })
 
   it('revoke should return true when the nonce existed', async () => {

--- a/aws/test/dynamodb-nonce-store.provider.spec.ts
+++ b/aws/test/dynamodb-nonce-store.provider.spec.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { mockClient } from 'aws-sdk-client-mock'
+import { Nonce } from '@trustknots/vcknots'
+import { dynamodbNonceStore } from '../src/providers/dynamodb-nonce-store.provider'
+
+const TABLE_NAME = 'NoncesTable'
+const ddbMock = mockClient(DynamoDBDocumentClient)
+
+describe('dynamodbNonceStore', () => {
+  const nonce: Nonce = { nonce: 'test-nonce', nonce_expires_in: 300 * 1000 }
+
+  afterEach(() => {
+    ddbMock.reset()
+  })
+
+  const createProvider = () =>
+    dynamodbNonceStore({
+      client: ddbMock as unknown as DynamoDBDocumentClient,
+      tableName: TABLE_NAME,
+    })
+
+  it('should have correct provider metadata', () => {
+    const provider = createProvider()
+    assert.equal(provider.kind, 'nonce-store-provider')
+    assert.equal(provider.name, 'dynamodb-nonce-store-provider')
+    assert.equal(provider.single, true)
+  })
+
+  it('should save with correct table name and epoch-seconds expires_at', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Math.floor(Date.now() / 1000)
+
+    const provider = createProvider()
+    await provider.save(nonce)
+
+    const after = Math.floor(Date.now() / 1000)
+    const putCall = ddbMock.commandCalls(PutCommand)[0]
+    const item = putCall?.args[0].input.Item
+
+    assert.equal(putCall?.args[0].input.TableName, TABLE_NAME)
+    assert.equal(item?.id, nonce.nonce)
+    assert.deepEqual(item?.nonce, nonce)
+    assert.ok(item?.expires_at >= before + 300)
+    assert.ok(item?.expires_at <= after + 300)
+  })
+
+  it('should throw when nonce_expires_in is missing on save', async () => {
+    const provider = createProvider()
+    await assert.rejects(() => provider.save({ nonce: 'no-ttl' }), /nonce_expires_in is required/)
+    assert.equal(ddbMock.commandCalls(PutCommand).length, 0)
+  })
+
+  it('validate should return true for a valid nonce', async () => {
+    const futureExpiry = Math.floor(Date.now() / 1000) + 300
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: nonce.nonce, nonce, expires_at: futureExpiry },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.validate(nonce), true)
+    const getCall = ddbMock.commandCalls(GetCommand)[0]
+    assert.equal(getCall?.args[0].input.TableName, TABLE_NAME)
+    assert.deepEqual(getCall?.args[0].input.Key, { id: nonce.nonce })
+  })
+
+  it('validate should return false for an unknown nonce', async () => {
+    ddbMock.on(GetCommand).resolves({})
+
+    const provider = createProvider()
+    assert.equal(await provider.validate(nonce), false)
+  })
+
+  it('validate should return false for an expired nonce', async () => {
+    const pastExpiry = Math.floor(Date.now() / 1000) - 1
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: nonce.nonce, nonce, expires_at: pastExpiry },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.validate(nonce), false)
+  })
+
+  it('revoke should return true when the nonce existed', async () => {
+    ddbMock.on(DeleteCommand).resolves({
+      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) + 300 },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.revoke(nonce), true)
+    const deleteCall = ddbMock.commandCalls(DeleteCommand)[0]
+    assert.equal(deleteCall?.args[0].input.TableName, TABLE_NAME)
+    assert.deepEqual(deleteCall?.args[0].input.Key, { id: nonce.nonce })
+    assert.equal(deleteCall?.args[0].input.ReturnValues, 'ALL_OLD')
+  })
+
+  it('revoke should return false when the nonce did not exist', async () => {
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    assert.equal(await provider.revoke(nonce), false)
+  })
+
+  it('consume should return true and delete a valid nonce', async () => {
+    ddbMock.on(DeleteCommand).resolves({
+      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) + 300 },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.consume(nonce), true)
+    const deleteCall = ddbMock.commandCalls(DeleteCommand)[0]
+    assert.equal(deleteCall?.args[0].input.ReturnValues, 'ALL_OLD')
+  })
+
+  it('consume should return false for an unknown nonce', async () => {
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    assert.equal(await provider.consume(nonce), false)
+  })
+
+  it('consume should return false for an expired nonce', async () => {
+    ddbMock.on(DeleteCommand).resolves({
+      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) - 1 },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.consume(nonce), false)
+  })
+})

--- a/aws/test/dynamodb-request-object-store.provider.spec.ts
+++ b/aws/test/dynamodb-request-object-store.provider.spec.ts
@@ -40,7 +40,7 @@ describe('dynamodbRequestObjectStore', () => {
   })
 
   it('should save and fetch a request object', async () => {
-    const futureExpiry = Math.floor(Date.now() / 1000) + 300
+    const futureExpiry = Date.now() + 300 * 1000
     ddbMock.on(PutCommand).resolves({})
     ddbMock.on(GetCommand).resolves({
       Item: { id: requestObjectId, requestObject, expires_at: futureExpiry },
@@ -65,7 +65,7 @@ describe('dynamodbRequestObjectStore', () => {
   })
 
   it('should return null when the item is expired', async () => {
-    const pastExpiry = Math.floor(Date.now() / 1000) - 1
+    const pastExpiry = Date.now() - 1000
     ddbMock.on(GetCommand).resolves({
       Item: { id: requestObjectId, requestObject, expires_at: pastExpiry },
     })
@@ -87,22 +87,25 @@ describe('dynamodbRequestObjectStore', () => {
     assert.equal(fetched, null)
   })
 
-  it('should save with correct table name and expires_at', async () => {
+  it('should save with epoch-ms expires_at and epoch-seconds ttl', async () => {
     ddbMock.on(PutCommand).resolves({})
-    const before = Math.floor(Date.now() / 1000)
+    const before = Date.now()
 
     const provider = createProvider()
     await provider.save(requestObjectId, requestObject)
 
-    const after = Math.floor(Date.now() / 1000)
+    const after = Date.now()
     const putCall = ddbMock.commandCalls(PutCommand)[0]
     const item = putCall?.args[0].input.Item
 
     assert.equal(putCall?.args[0].input.TableName, TABLE_NAME)
     assert.equal(item?.id, requestObjectId)
     assert.deepEqual(item?.requestObject, requestObject)
-    assert.ok(item?.expires_at >= before + 300)
-    assert.ok(item?.expires_at <= after + 300)
+    // expires_at is epoch ms (parity with Firestore / in-memory).
+    assert.ok(item?.expires_at >= before + 300 * 1000)
+    assert.ok(item?.expires_at <= after + 300 * 1000)
+    // ttl is epoch seconds, rounded up so TTL never fires before the real (ms) expiry.
+    assert.equal(item?.ttl, Math.ceil(item?.expires_at / 1000))
   })
 
   it('should delete a request object', async () => {

--- a/server/aws/README.ja.md
+++ b/server/aws/README.ja.md
@@ -76,13 +76,13 @@ cp .env.example .env
 | `AWS_REGION` | Issuer | DynamoDB テーブルがデプロイされている AWS リージョン（例: `ap-northeast-1`） |
 | `AWS_PROFILE` | Issuer（任意） | 使用する AWS プロファイル（省略時はデフォルトを使用） |
 | `ISSUERS_TABLE_NAME` | Issuer **必須** | DynamoDB テーブル名（スタック出力: `IssuersTableName`） |
-| `NONCES_TABLE_NAME` | Issuer（任意） | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
+| `NONCES_TABLE_NAME` | Issuer **必須** | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
 | `PRE_CODES_TABLE_NAME` | Issuer（任意） | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
 | `AUTH_SERVERS_TABLE_NAME` | Authz **必須** | DynamoDB テーブル名（スタック出力: `AuthServersTableName`） |
 | `PRE_CODES_TABLE_NAME` | Authz（任意） | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
 | `VERIFIERS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `VerifiersTableName`） |
 | `REQUEST_OBJECTS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `RequestObjectsTableName`） |
-| `NONCES_TABLE_NAME` | Verifier（任意） | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
+| `NONCES_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
 | `ISSUER_PORT` | Issuer（任意） | Issuer のリッスンポートを上書き（デフォルト: `8081`） |
 | `ISSUER_BASE_URL` | Issuer（任意） | Issuer メタデータで使用するベース URL を上書き（デフォルト: `http://localhost:{ISSUER_PORT}`） |
 | `AUTHZ_PORT` | Authz（任意） | Authorization Server のリッスンポートを上書き（デフォルト: `8082`） |
@@ -90,7 +90,7 @@ cp .env.example .env
 | `VERIFIER_PORT` | Verifier（任意） | Verifier のリッスンポートを上書き（デフォルト: `8083`） |
 | `VERIFIER_BASE_URL` | Verifier（任意） | Verifier メタデータで使用するベース URL を上書き（デフォルト: `http://localhost:{VERIFIER_PORT}`） |
 
-**`ISSUERS_TABLE_NAME`・`AUTH_SERVERS_TABLE_NAME`・`VERIFIERS_TABLE_NAME`・`REQUEST_OBJECTS_TABLE_NAME` は必須**です。未設定の場合、該当サーバーは起動時に終了します。
+**`ISSUERS_TABLE_NAME`・`AUTH_SERVERS_TABLE_NAME`・`VERIFIERS_TABLE_NAME`・`REQUEST_OBJECTS_TABLE_NAME`・`NONCES_TABLE_NAME`（Issuer と Verifier）は必須**です。未設定の場合、該当サーバーは起動時に終了します。
 
 ## サーバーの起動
 

--- a/server/aws/README.md
+++ b/server/aws/README.md
@@ -76,13 +76,13 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 | `AWS_REGION` | Issuer | AWS region where DynamoDB tables are deployed (e.g. `ap-northeast-1`) |
 | `AWS_PROFILE` | Issuer (optional) | AWS profile to use (omit to use the default) |
 | `ISSUERS_TABLE_NAME` | Issuer **required** | DynamoDB table name (stack output: `IssuersTableName`) |
-| `NONCES_TABLE_NAME` | Issuer (optional) | DynamoDB table name (stack output: `NoncesTableName`) |
+| `NONCES_TABLE_NAME` | Issuer **required** | DynamoDB table name (stack output: `NoncesTableName`) |
 | `PRE_CODES_TABLE_NAME` | Issuer (optional) | DynamoDB table name (stack output: `PreCodesTableName`) |
 | `AUTH_SERVERS_TABLE_NAME` | Authz **required** | DynamoDB table name (stack output: `AuthServersTableName`) |
 | `PRE_CODES_TABLE_NAME` | Authz (optional) | DynamoDB table name (stack output: `PreCodesTableName`) |
 | `VERIFIERS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `VerifiersTableName`) |
 | `REQUEST_OBJECTS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `RequestObjectsTableName`) |
-| `NONCES_TABLE_NAME` | Verifier (optional) | DynamoDB table name (stack output: `NoncesTableName`) |
+| `NONCES_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `NoncesTableName`) |
 | `ISSUER_PORT` | Issuer (optional) | Override the Issuer listening port (default: `8081`) |
 | `ISSUER_BASE_URL` | Issuer (optional) | Override the base URL used in Issuer metadata (default: `http://localhost:{ISSUER_PORT}`) |
 | `AUTHZ_PORT` | Authz (optional) | Override the Authorization Server listening port (default: `8082`) |
@@ -90,7 +90,7 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 | `VERIFIER_PORT` | Verifier (optional) | Override the Verifier listening port (default: `8083`) |
 | `VERIFIER_BASE_URL` | Verifier (optional) | Override the base URL used in Verifier metadata (default: `http://localhost:{VERIFIER_PORT}`) |
 
-**`ISSUERS_TABLE_NAME`, `AUTH_SERVERS_TABLE_NAME`, `VERIFIERS_TABLE_NAME`, and `REQUEST_OBJECTS_TABLE_NAME` are required** — each server exits at startup if its table name is missing.
+**`ISSUERS_TABLE_NAME`, `AUTH_SERVERS_TABLE_NAME`, `VERIFIERS_TABLE_NAME`, `REQUEST_OBJECTS_TABLE_NAME`, and `NONCES_TABLE_NAME` (Issuer and Verifier) are required** — each server exits at startup if its table name is missing.
 
 ## Start the Servers
 

--- a/server/aws/resources/README.ja.md
+++ b/server/aws/resources/README.ja.md
@@ -109,11 +109,11 @@ Issuer は `@trustknots/aws` の `dynamodbIssuerMetadataStore` を使用しま�
 | IssuersTable | Issuer URL のハッシュ | なし | Credential Issuer メタデータ |
 | AuthServersTable | Authorization Server URL のハッシュ | なし | Authorization Server メタデータ |
 | PreCodesTable | Pre-Authorized Code 文字列 | あり（`expires_at`） | 発行時に使用する Pre-authorized code |
-| NoncesTable | Nonce 文字列 | あり（`expires_at`） | リプレイ防止用 Nonce |
+| NoncesTable | Nonce 文字列 | あり（`ttl`） | リプレイ防止用 Nonce |
 | VerifiersTable | Verifier client ID のハッシュ | なし | Verifier メタデータ |
-| RequestObjectsTable | Request Object ID | あり（`expires_at`） | VP リクエスト用 Request Object |
+| RequestObjectsTable | Request Object ID | あり（`ttl`） | VP リクエスト用 Request Object |
 
-`id` 以外の属性（メタデータ本体、`expires_at` など）はアプリケーションが書き込みます。
+`id` 以外の属性（メタデータ本体、`expires_at`、`ttl` など）はアプリケーションが書き込みます。NoncesTable / RequestObjectsTable では、`expires_at` はアプリケーションレベルの有効期限で **epoch ミリ秒**（Firestore / in-memory プロバイダと揃えた期限判定に使用）、`ttl` は DynamoDB TTL 専用の **epoch 秒**属性です。PreCodesTable は引き続き `expires_at`（秒）を TTL 属性として使用します。
 
 ### IAM
 

--- a/server/aws/resources/README.md
+++ b/server/aws/resources/README.md
@@ -109,11 +109,11 @@ Billing is on-demand (`PAY_PER_REQUEST`). Tables use `RETAIN` on stack deletion 
 | IssuersTable | Hash of Issuer URL | no | Credential Issuer metadata |
 | AuthServersTable | Hash of Authorization Server URL | no | Authorization Server metadata |
 | PreCodesTable | Pre-Authorized Code string | yes (`expires_at`) | Pre-authorized code used at issuance |
-| NoncesTable | Nonce string | yes (`expires_at`) | Nonce for replay protection |
+| NoncesTable | Nonce string | yes (`ttl`) | Nonce for replay protection |
 | VerifiersTable | Hash of Verifier client ID | no | Verifier metadata |
-| RequestObjectsTable | Request Object ID | yes (`expires_at`) | VP request Request Object |
+| RequestObjectsTable | Request Object ID | yes (`ttl`) | VP request Request Object |
 
-Attributes other than `id` (metadata body, `expires_at`, and so on) are written by the application.
+Attributes other than `id` (metadata body, `expires_at`, `ttl`, and so on) are written by the application. For NoncesTable / RequestObjectsTable, `expires_at` is the application-level expiry in **epoch milliseconds** (used for expiry checks, matching the Firestore / in-memory providers) and `ttl` is a separate **epoch-seconds** attribute used only by DynamoDB TTL. PreCodesTable still uses `expires_at` (seconds) as its TTL attribute.
 
 ### IAM
 

--- a/server/aws/resources/lib/construct/data/data-stores.ts
+++ b/server/aws/resources/lib/construct/data/data-stores.ts
@@ -33,14 +33,16 @@ export class DataStores extends Construct {
 
     this.noncesTable = new dynamodb.Table(this, 'NoncesTable', {
       ...baseTableProps,
-      timeToLiveAttribute: 'expires_at',
+      // `expires_at` is app-level epoch ms; DynamoDB TTL uses the epoch-seconds `ttl` attribute.
+      timeToLiveAttribute: 'ttl',
     });
 
     this.verifiersTable = new dynamodb.Table(this, 'VerifiersTable', baseTableProps);
 
     this.requestObjectsTable = new dynamodb.Table(this, 'RequestObjectsTable', {
       ...baseTableProps,
-      timeToLiveAttribute: 'expires_at',
+      // `expires_at` is app-level epoch ms; DynamoDB TTL uses the epoch-seconds `ttl` attribute.
+      timeToLiveAttribute: 'ttl',
     });
   }
 }

--- a/server/aws/src/.env.example
+++ b/server/aws/src/.env.example
@@ -7,7 +7,8 @@ AWS_REGION=ap-northeast-1
 # ISSUER_BASE_URL=http://localhost:8081
 # Required for DynamoDB issuer metadata store (deploy output: IssuersTableName)
 ISSUERS_TABLE_NAME=ResourcesStack-DataStoresIssuersTableXXXXXXXX-XXXXXXXXXXXX
-# NONCES_TABLE_NAME=ResourcesStack-...
+# Required for DynamoDB nonce store (deploy output: NoncesTableName)
+NONCES_TABLE_NAME=ResourcesStack-DataStoresNoncesTableXXXXXXXX-XXXXXXXXXXXX
 # PRE_CODES_TABLE_NAME=ResourcesStack-...
 
 # Authz (default: start:authz)
@@ -24,4 +25,4 @@ AUTH_SERVERS_TABLE_NAME=ResourcesStack-DataStoresAuthServersTableXXXXXXXX-XXXXXX
 VERIFIERS_TABLE_NAME=ResourcesStack-DataStoresVerifiersTableXXXXXXXX-XXXXXXXXXXXX
 # Required for DynamoDB request object store (deploy output: RequestObjectsTableName)
 REQUEST_OBJECTS_TABLE_NAME=ResourcesStack-DataStoresRequestObjectsTableXXXXXXXX-XXXXXXXXXXXX
-# NONCES_TABLE_NAME=ResourcesStack-...
+# NONCES_TABLE_NAME is also required for the Verifier (same table as the Issuer; set above)

--- a/server/aws/src/apps/create-issuer-app.ts
+++ b/server/aws/src/apps/create-issuer-app.ts
@@ -1,27 +1,33 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { dynamodbIssuerMetadataStore } from '@trustknots/aws'
+import { dynamodbIssuerMetadataStore, dynamodbNonceStore } from '@trustknots/aws'
 import { createIssueRouter } from '@trustknots/server-core/routes/issue'
 import { CredentialIssuer, CredentialIssuerMetadata, initializeIssuerFlow } from '@trustknots/vcknots/issuer'
 import type { VcknotsOptions } from '@trustknots/vcknots'
 import { createBaseApp } from './create-base-app.js'
 
 export function createIssuerApp(options?: VcknotsOptions) {
-  const tableName = process.env.ISSUERS_TABLE_NAME
-  if (!tableName) {
+  const issuersTableName = process.env.ISSUERS_TABLE_NAME
+  if (!issuersTableName) {
     throw new Error('ISSUERS_TABLE_NAME is required')
+  }
+
+  const noncesTableName = process.env.NONCES_TABLE_NAME
+  if (!noncesTableName) {
+    throw new Error('NONCES_TABLE_NAME is required')
   }
 
   const rawPort = process.env.ISSUER_PORT ?? '8081'
   const port = Number.parseInt(rawPort, 10)
   if (!Number.isFinite(port)) throw new Error(`Invalid ISSUER_PORT: "${rawPort}"`)
 
-  const store = dynamodbIssuerMetadataStore({ tableName })
+  const issuerMetadataStore = dynamodbIssuerMetadataStore({ tableName: issuersTableName })
+  const nonceStore = dynamodbNonceStore({ tableName: noncesTableName })
   const { app, context } = createBaseApp(
     createIssueRouter,
     { port, baseUrl: process.env.ISSUER_BASE_URL },
-    { ...options, providers: [store, ...(options?.providers ?? [])] },
+    { ...options, providers: [issuerMetadataStore, nonceStore, ...(options?.providers ?? [])] },
   )
 
   async function initialize(baseUrl: string) {

--- a/server/aws/src/apps/create-verifier-app.ts
+++ b/server/aws/src/apps/create-verifier-app.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { dynamodbRequestObjectStore, dynamodbVerifierMetadataStore } from '@trustknots/aws'
+import { dynamodbNonceStore, dynamodbRequestObjectStore, dynamodbVerifierMetadataStore } from '@trustknots/aws'
 import { createVerifierRouter } from '@trustknots/server-core/routes/verify'
 import { VerifierClientId, VerifierMetadata, initializeVerifierFlow } from '@trustknots/vcknots/verifier'
 import type { VcknotsOptions } from '@trustknots/vcknots'
@@ -18,16 +18,25 @@ export function createVerifierApp(options?: VcknotsOptions) {
     throw new Error('REQUEST_OBJECTS_TABLE_NAME is required')
   }
 
+  const noncesTableName = process.env.NONCES_TABLE_NAME
+  if (!noncesTableName) {
+    throw new Error('NONCES_TABLE_NAME is required')
+  }
+
   const rawPort = process.env.VERIFIER_PORT ?? '8083'
   const port = Number.parseInt(rawPort, 10)
   if (!Number.isFinite(port)) throw new Error(`Invalid VERIFIER_PORT: "${rawPort}"`)
 
   const verifierMetadataStore = dynamodbVerifierMetadataStore({ tableName: verifiersTableName })
   const requestObjectStore = dynamodbRequestObjectStore({ tableName: requestObjectsTableName })
+  const nonceStore = dynamodbNonceStore({ tableName: noncesTableName })
   const { app, context } = createBaseApp(
     createVerifierRouter,
     { port, baseUrl: process.env.VERIFIER_BASE_URL },
-    { ...options, providers: [verifierMetadataStore, requestObjectStore, ...(options?.providers ?? [])] },
+    {
+      ...options,
+      providers: [verifierMetadataStore, requestObjectStore, nonceStore, ...(options?.providers ?? [])],
+    },
   )
 
   async function initialize(baseUrl: string) {


### PR DESCRIPTION
## 概要

OID4VCI の c_nonce（Proof-of-Possession 用ノンス）を DynamoDB に永続化する `nonce-store-provider` の AWS 実装を追加します。これまで in-memory 版と Google Cloud(Firestore) 版のみだった `nonce-store-provider` の AWS(DynamoDB) 版を実装し、Issuer / Verifier アプリに組み込みます。

## 背景

- `nonce-store-provider` インターフェース（`save` / `validate` / `revoke` / `consume`）は issuer / verifier / authz が共有する単一プロバイダ
- in-memory 版・Firestore 版は実装済みだが **DynamoDB 版のみ未実装**（ロードマップの「ノンス実装」に相当）
- CDK 側には既に `NoncesTable`（PK=`id`、TTL属性=`expires_at`）が定義済みのため、インフラ変更は不要

## 変更内容

### ライブラリ（`@trustknots/aws`）
- `dynamodbNonceStore` プロバイダを新規追加（`dynamodb-request-object-store.provider.ts` のパターンを踏襲）
  - TTL は DynamoDB 仕様に合わせ **epoch 秒**で `expires_at` に保存
  - `validate`: TTL の結果整合を考慮し、読み取り時に手動で期限判定（削除は TTL に委譲）
  - `revoke` / `consume`: `ReturnValues: 'ALL_OLD'` を用い、`consume` は取得＋削除を1回のDeleteで原子的に実行し nonce の再利用を防止
- `index.ts` から `dynamodbNonceStore` / `DynamoDbNonceStoreOptions` を re-export
- ユニットテストケースを追加（`aws-sdk-client-mock`）

### サーバアプリ（`@trustknots/server-aws`）
- `createIssuerApp` / `createVerifierApp` に `dynamodbNonceStore` を組み込み（`single: true` によりデフォルトの in-memory nonce store を上書き）
- 両アプリで `NONCES_TABLE_NAME` を必須化
- `README.md` / `README.ja.md` / `.env.example` を更新（`NONCES_TABLE_NAME` を Issuer/Verifier で required 化）

> Authz は CDK/IAM 上 NoncesTable にアクセスしない設計（DPoP nonce は in-memory 運用）のため、本 PR では wire していません。

## 動作確認

- [x] 全パッケージ typecheck パス
- [x] `aws` ユニットテスト（新規11件を含む33件）パス
- [x] biome lint クリーン



## 更新（レビュー反映: `expires_at` ms + `ttl` 秒）

レビュー指摘（他プロバイダとの単位・境界判定の不一致）を受け、期限の持ち方を変更しました。

- アプリの期限判定は **`expires_at`（epoch ミリ秒）** に統一し、Firestore / in-memory と同名・同意味・同判定（`Date.now() > expires_at`、境界ちょうどは有効）にしました。
- DynamoDB TTL 用には **`ttl`（epoch 秒 = `Math.ceil(expires_at / 1000)`）** を別項目として保存します（TTL が実期限より早く発火しないよう切り上げ）。
- CDK: NoncesTable / RequestObjectsTable の `timeToLiveAttribute` を `expires_at` → **`ttl`** に変更（`server/aws/resources`）。README のテーブル一覧も更新。

### 移行方針
- DynamoDB は TTL 属性名を1回の update で変更できません（`Cannot change time-to-live attribute name` — disable→enable が必要）。**既存テーブルは作り直し**で移行します（test 環境は対応済み）。
- 旧 item（`expires_at` が秒値のみ）が残っていても、新ロジックは ms として読むため必ず期限切れ判定となりアクセス時に掃除されます。nonce / request object は短命なため実害はありません。

> PreCodesTable の `ttl` 化と pre-code プロバイダの ms/ttl 化は、プロバイダが別ブランチ（`feat/dynamodb-pre-authorized-code-store`）にあるため別途対応します。本 PR は NoncesTable / RequestObjectsTable のみ変更しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DynamoDB を使った nonce ストアに対応し、Issuer/Verifier で nonce を保存・検証・無効化・1回利用できるようになりました。
* **Configuration**
  * サーバー起動時に nonce 用テーブル名（`NONCES_TABLE_NAME`）の設定が必須になりました（Issuer/Verifier 両方）。
* **Documentation**
  * `NONCES_TABLE_NAME` を含む環境変数の案内と `.env.example` を更新しました。
* **Tests**
  * DynamoDB nonce ストアの挙動を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
