### PR TITLE
feat(aws): DynamoDBベースの事前認可コード(pre-authorized code)ストアプロバイダを追加

### DIFF
--- a/aws/.env.test
+++ b/aws/.env.test
@@ -1,0 +1,1 @@
+TX_CODE_PEPPER=test-only-do-not-use-in-production

--- a/aws/package.json
+++ b/aws/package.json
@@ -12,9 +12,9 @@
 		"build": "tsc",
 		"format": "biome format --write ./src/**/*.ts",
 		"lint": "biome lint ./src/**/*.ts",
-		"test": "node --import tsx --test test/**/*.spec.ts",
-		"test:ci": "node --import tsx --test --experimental-test-coverage \"test/**/*.spec.ts\"",
-		"test:all": "node --import tsx --test --experimental-test-coverage --test-coverage-include=\"src/**/*.ts\" --test-coverage-exclude=\"test/**/*.ts\" --test-coverage-lines=80 --test-coverage-functions=80 --test-coverage-branches=80 \"test/**/*.spec.ts\"",
+		"test": "node --env-file=.env.test --import tsx --test test/**/*.spec.ts",
+		"test:ci": "node --env-file=.env.test --import tsx --test --experimental-test-coverage \"test/**/*.spec.ts\"",
+		"test:all": "node --env-file=.env.test --import tsx --test --experimental-test-coverage --test-coverage-include=\"src/**/*.ts\" --test-coverage-exclude=\"test/**/*.ts\" --test-coverage-lines=80 --test-coverage-functions=80 --test-coverage-branches=80 \"test/**/*.spec.ts\"",
 		"typecheck": "tsc --noEmit"
 	},
 	"keywords": [],

--- a/aws/src/index.ts
+++ b/aws/src/index.ts
@@ -18,3 +18,7 @@ export {
   DynamoDbRequestObjectStoreOptions,
   dynamodbRequestObjectStore,
 } from './providers/dynamodb-request-object-store.provider'
+export {
+  DynamoDbPreAuthorizedCodeStoreOptions,
+  dynamodbPreAuthorizedCodeStore,
+} from './providers/dynamodb-pre-authorized-code-store.provider'

--- a/aws/src/index.ts
+++ b/aws/src/index.ts
@@ -18,3 +18,7 @@ export {
   DynamoDbRequestObjectStoreOptions,
   dynamodbRequestObjectStore,
 } from './providers/dynamodb-request-object-store.provider'
+export {
+  DynamoDbNonceStoreOptions,
+  dynamodbNonceStore,
+} from './providers/dynamodb-nonce-store.provider'

--- a/aws/src/providers/dynamodb-nonce-store.provider.ts
+++ b/aws/src/providers/dynamodb-nonce-store.provider.ts
@@ -10,16 +10,19 @@ export type DynamoDbNonceStoreOptions = DynamoDbProviderOptions & {
 type NonceItem = {
   id: string
   nonce: Nonce
+  /** Epoch milliseconds — used for manual expiry checks (parity with Firestore / in-memory). */
   expires_at: number
+  /** Epoch seconds — DynamoDB TTL attribute (infra-only, see CDK `timeToLiveAttribute: 'ttl'`). */
+  ttl: number
 }
 
 export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceStoreProvider => {
   const client = resolveDynamoDbDocumentClient(options)
   const { tableName } = options
 
-  // Treat the boundary second as expired (>=) to avoid reusing a nonce at its exact expiry.
+  // Match the Firestore / in-memory providers: expires_at is epoch ms and the exact boundary is still valid (>).
   const isExpired = (expires_at: unknown): boolean =>
-    typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) >= expires_at
+    typeof expires_at !== 'number' || Date.now() > expires_at
 
   return {
     kind: 'nonce-store-provider',
@@ -31,12 +34,13 @@ export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceSto
       if (ttlMs == null) {
         throw new Error('nonce_expires_in is required when saving nonce')
       }
-      // DynamoDB TTL expects an epoch time in seconds.
-      const expires_at = Math.floor((Date.now() + ttlMs) / 1000)
+      const expires_at = Date.now() + ttlMs
+      // DynamoDB TTL expects epoch seconds; round up so TTL never deletes before the real (ms) expiry.
+      const ttl = Math.ceil(expires_at / 1000)
       await client.send(
         new PutCommand({
           TableName: tableName,
-          Item: { id: nonce.nonce, nonce, expires_at } satisfies NonceItem,
+          Item: { id: nonce.nonce, nonce, expires_at, ttl } satisfies NonceItem,
         })
       )
     },

--- a/aws/src/providers/dynamodb-nonce-store.provider.ts
+++ b/aws/src/providers/dynamodb-nonce-store.provider.ts
@@ -1,0 +1,89 @@
+import { DeleteCommand, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { Nonce } from '@trustknots/vcknots'
+import { NonceStoreProvider } from '@trustknots/vcknots/providers'
+import { DynamoDbProviderOptions, resolveDynamoDbDocumentClient } from './dynamodb'
+
+export type DynamoDbNonceStoreOptions = DynamoDbProviderOptions & {
+  tableName: string
+}
+
+type NonceItem = {
+  id: string
+  nonce: Nonce
+  expires_at: number
+}
+
+export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceStoreProvider => {
+  const client = resolveDynamoDbDocumentClient(options)
+  const { tableName } = options
+
+  const isExpired = (expires_at: unknown): boolean =>
+    typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) > expires_at
+
+  return {
+    kind: 'nonce-store-provider',
+    name: 'dynamodb-nonce-store-provider',
+    single: true,
+
+    async save(nonce): Promise<void> {
+      const ttlMs = nonce.nonce_expires_in
+      if (ttlMs == null) {
+        throw new Error('nonce_expires_in is required when saving nonce')
+      }
+      // DynamoDB TTL expects an epoch time in seconds.
+      const expires_at = Math.floor((Date.now() + ttlMs) / 1000)
+      await client.send(
+        new PutCommand({
+          TableName: tableName,
+          Item: { id: nonce.nonce, nonce, expires_at } satisfies NonceItem,
+        })
+      )
+    },
+
+    async validate(nonce): Promise<boolean> {
+      const result = await client.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: { id: nonce.nonce },
+        })
+      )
+
+      if (!result.Item) {
+        return false
+      }
+
+      // DynamoDB TTL deletion is eventually consistent — check expiry manually.
+      const { expires_at } = result.Item as NonceItem
+      return !isExpired(expires_at)
+    },
+
+    async revoke(nonce): Promise<boolean> {
+      const result = await client.send(
+        new DeleteCommand({
+          TableName: tableName,
+          Key: { id: nonce.nonce },
+          ReturnValues: 'ALL_OLD',
+        })
+      )
+      return result.Attributes != null
+    },
+
+    async consume(nonce): Promise<boolean> {
+      // Atomically remove and return the previous item so a nonce can be used only once.
+      const result = await client.send(
+        new DeleteCommand({
+          TableName: tableName,
+          Key: { id: nonce.nonce },
+          ReturnValues: 'ALL_OLD',
+        })
+      )
+
+      if (!result.Attributes) {
+        return false
+      }
+
+      const { expires_at } = result.Attributes as NonceItem
+      return !isExpired(expires_at)
+    },
+  }
+}

--- a/aws/src/providers/dynamodb-nonce-store.provider.ts
+++ b/aws/src/providers/dynamodb-nonce-store.provider.ts
@@ -55,7 +55,17 @@ export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceSto
 
       // DynamoDB TTL deletion is eventually consistent — check expiry manually.
       const { expires_at } = result.Item as NonceItem
-      return !isExpired(expires_at)
+      if (isExpired(expires_at)) {
+        // Match the Firestore provider: proactively delete expired nonces instead of waiting for TTL.
+        await client.send(
+          new DeleteCommand({
+            TableName: tableName,
+            Key: { id: nonce.nonce },
+          })
+        )
+        return false
+      }
+      return true
     },
 
     async revoke(nonce): Promise<boolean> {

--- a/aws/src/providers/dynamodb-nonce-store.provider.ts
+++ b/aws/src/providers/dynamodb-nonce-store.provider.ts
@@ -17,8 +17,9 @@ export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceSto
   const client = resolveDynamoDbDocumentClient(options)
   const { tableName } = options
 
+  // Treat the boundary second as expired (>=) to avoid reusing a nonce at its exact expiry.
   const isExpired = (expires_at: unknown): boolean =>
-    typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) > expires_at
+    typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) >= expires_at
 
   return {
     kind: 'nonce-store-provider',

--- a/aws/src/providers/dynamodb-nonce-store.provider.ts
+++ b/aws/src/providers/dynamodb-nonce-store.provider.ts
@@ -34,6 +34,9 @@ export const dynamodbNonceStore = (options: DynamoDbNonceStoreOptions): NonceSto
       if (ttlMs == null) {
         throw new Error('nonce_expires_in is required when saving nonce')
       }
+      if (!Number.isFinite(ttlMs)) {
+        throw new Error('nonce_expires_in must be a finite number when saving nonce')
+      }
       const expires_at = Date.now() + ttlMs
       // DynamoDB TTL expects epoch seconds; round up so TTL never deletes before the real (ms) expiry.
       const ttl = Math.ceil(expires_at / 1000)

--- a/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
+++ b/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
@@ -1,4 +1,4 @@
-import { DeleteCommand, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { DeleteCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import { PreAuthorizedCodeStoreEntry } from '@trustknots/vcknots'
 import { raise } from '@trustknots/vcknots/errors'
 import { PreAuthorizedCodeStoreProvider } from '@trustknots/vcknots/providers'
@@ -9,9 +9,15 @@ export type DynamoDbPreAuthorizedCodeStoreOptions = DynamoDbProviderOptions & {
   tableName: string
   /** Default TTL in milliseconds when a per-save ttlSec is not provided. Defaults to 5 minutes. */
   expiresIn?: number
+  /**
+   * Number of failed `tx_code` attempts allowed per pre-authorized code before it
+   * is invalidated (brute-force lockout). Defaults to 5.
+   */
+  maxTxCodeAttempts?: number
 }
 
 const DEFAULT_EXPIRES_IN_MS = 60 * 5 * 1000
+const DEFAULT_MAX_TX_CODE_ATTEMPTS = 5
 
 /**
  * Item stored in DynamoDB. The pre-authorized code itself is the partition key
@@ -28,6 +34,8 @@ type DynamoDbPreAuthorizedCodeItem = {
   tx_code_hash?: string
   expires_at: number
   ttl: number
+  /** Number of failed `tx_code` attempts so far (brute-force lockout counter). */
+  attempts?: number
 }
 
 const toDigitString = (value: string | number): string | null => {
@@ -43,6 +51,10 @@ export const dynamodbPreAuthorizedCodeStore = (
   const client = resolveDynamoDbDocumentClient(options)
   const { tableName, expiresIn = DEFAULT_EXPIRES_IN_MS } = options
   const defaultTtlSec = Math.max(1, Math.floor(expiresIn / 1000))
+  const maxTxCodeAttempts = Math.max(
+    1,
+    Math.floor(options.maxTxCodeAttempts ?? DEFAULT_MAX_TX_CODE_ATTEMPTS)
+  )
 
   /**
    * Deletes a stored code. When `conditional` is true the delete only succeeds
@@ -112,20 +124,36 @@ export const dynamodbPreAuthorizedCodeStore = (
     },
 
     async consume(code, tx_code) {
-      const result = await client.send(
-        new GetCommand({
-          TableName: tableName,
-          Key: { id: code },
-        })
-      )
-
-      if (!result.Item) {
-        throw raise('invalid_grant', {
-          message: 'Pre-authorized code not found',
-        })
+      // Count-first admission gate (brute-force lockout): atomically increment `attempts`
+      // only while the code still exists AND the per-code limit hasn't been reached, then
+      // read the item back to compare the tx_code. DynamoDB serializes conditional writes
+      // per item, so even a highly concurrent burst admits at most `maxTxCodeAttempts`
+      // guesses — once the limit is hit, every further attempt (including the correct PIN)
+      // fails the condition and is rejected before the tx_code is ever compared.
+      let item: DynamoDbPreAuthorizedCodeItem
+      try {
+        const result = await client.send(
+          new UpdateCommand({
+            TableName: tableName,
+            Key: { id: code },
+            UpdateExpression: 'ADD #attempts :one',
+            ConditionExpression:
+              'attribute_exists(id) AND (attribute_not_exists(#attempts) OR #attempts < :max)',
+            ExpressionAttributeNames: { '#attempts': 'attempts' },
+            ExpressionAttributeValues: { ':one': 1, ':max': maxTxCodeAttempts },
+            ReturnValues: 'ALL_NEW',
+          })
+        )
+        item = result.Attributes as DynamoDbPreAuthorizedCodeItem
+      } catch (error) {
+        if ((error as { name?: string })?.name === 'ConditionalCheckFailedException') {
+          // Not found, already consumed, or locked out after too many tx_code attempts.
+          throw raise('invalid_grant', {
+            message: 'Pre-authorized code is invalid, consumed, or locked',
+          })
+        }
+        throw error
       }
-
-      const item = result.Item as DynamoDbPreAuthorizedCodeItem
 
       // expires_at is epoch ms (parity with Firestore / in-memory). DynamoDB TTL is eventually consistent — check manually.
       if (typeof item.expires_at !== 'number' || Date.now() > item.expires_at) {

--- a/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
+++ b/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
@@ -16,8 +16,10 @@ const DEFAULT_EXPIRES_IN_MS = 60 * 5 * 1000
 /**
  * Item stored in DynamoDB. The pre-authorized code itself is the partition key
  * (`id`). `tx_code` is never persisted in the clear — only its HMAC hash is
- * stored as `tx_code_hash`. `expires_at` is a UNIX timestamp in **seconds** so
- * DynamoDB TTL can expire the item automatically.
+ * stored as `tx_code_hash`. `expires_at` is the application-level expiry in
+ * **epoch milliseconds** (used for manual expiry checks, matching the Firestore /
+ * in-memory providers); `ttl` is a separate **epoch-seconds** value used only by
+ * DynamoDB TTL.
  */
 type DynamoDbPreAuthorizedCodeItem = {
   id: string
@@ -25,6 +27,7 @@ type DynamoDbPreAuthorizedCodeItem = {
   tx_code_input_mode?: 'numeric' | 'text'
   tx_code_hash?: string
   expires_at: number
+  ttl: number
 }
 
 const toDigitString = (value: string | number): string | null => {
@@ -75,13 +78,15 @@ export const dynamodbPreAuthorizedCodeStore = (
       const ttlSec =
         Number.isFinite(ttlSecRaw) && ttlSecCandidate > 0 ? ttlSecCandidate : defaultTtlSec
       const tx_code_input_mode = saveOptions?.tx_code_input_mode ?? 'numeric'
-      const expires_at = Math.floor(Date.now() / 1000) + ttlSec
+      const expires_at = Date.now() + ttlSec * 1000
 
       const item: DynamoDbPreAuthorizedCodeItem = {
         id: code,
         credential_configuration_ids: credentialConfigurationIds,
         tx_code_input_mode,
         expires_at,
+        // DynamoDB TTL expects epoch seconds; round up so TTL never deletes before the real (ms) expiry.
+        ttl: Math.ceil(expires_at / 1000),
       }
 
       if (tx_code !== undefined) {
@@ -122,8 +127,8 @@ export const dynamodbPreAuthorizedCodeStore = (
 
       const item = result.Item as DynamoDbPreAuthorizedCodeItem
 
-      // DynamoDB TTL deletion is eventually consistent — check expiry manually.
-      if (typeof item.expires_at !== 'number' || Math.floor(Date.now() / 1000) > item.expires_at) {
+      // expires_at is epoch ms (parity with Firestore / in-memory). DynamoDB TTL is eventually consistent — check manually.
+      if (typeof item.expires_at !== 'number' || Date.now() > item.expires_at) {
         await deleteCode(code)
         throw raise('invalid_grant', {
           message: 'Pre-authorized code has expired',

--- a/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
+++ b/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
@@ -20,6 +20,12 @@ const DEFAULT_EXPIRES_IN_MS = 60 * 5 * 1000
 const DEFAULT_MAX_TX_CODE_ATTEMPTS = 5
 
 /**
+ * Returned for every code that can no longer be exchanged — unknown, already consumed,
+ * or locked out. The three cases are deliberately indistinguishable to the caller.
+ */
+const LOCKED_MESSAGE = 'Pre-authorized code is invalid, consumed, or locked'
+
+/**
  * Item stored in DynamoDB. The pre-authorized code itself is the partition key
  * (`id`). `tx_code` is never persisted in the clear — only its HMAC hash is
  * stored as `tx_code_hash`. `expires_at` is the application-level expiry in
@@ -148,22 +154,23 @@ export const dynamodbPreAuthorizedCodeStore = (
       } catch (error) {
         if ((error as { name?: string })?.name === 'ConditionalCheckFailedException') {
           // Not found, already consumed, or locked out after too many tx_code attempts.
-          throw raise('invalid_grant', {
-            message: 'Pre-authorized code is invalid, consumed, or locked',
-          })
+          throw raise('invalid_grant', { message: LOCKED_MESSAGE })
         }
         throw error
       }
 
       /**
        * Called before failing an attempt that the gate admitted. When the attempt
-       * exhausted the per-code limit the code is deleted, so a locked-out code never
-       * lingers until its TTL — later attempts fail the gate's `attribute_exists(id)`
-       * check and surface the same error.
+       * exhausted the per-code limit, the code is deleted and the lockout is reported
+       * right away: the holder learns the code is dead on the attempt that killed it,
+       * rather than being told only that the tx_code was wrong — which would invite a
+       * retry that can no longer succeed. Attempts that leave the limit intact fall
+       * through, so the holder still gets the specific `Invalid tx_code` error.
        */
       const lockoutIfExhausted = async (): Promise<void> => {
         if ((item.attempts ?? 0) >= maxTxCodeAttempts) {
           await deleteCode(code)
+          raise('invalid_grant', { message: LOCKED_MESSAGE })
         }
       }
 

--- a/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
+++ b/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
@@ -1,0 +1,167 @@
+import { DeleteCommand, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { PreAuthorizedCodeStoreEntry } from '@trustknots/vcknots'
+import { raise } from '@trustknots/vcknots/errors'
+import { PreAuthorizedCodeStoreProvider } from '@trustknots/vcknots/providers'
+import { DynamoDbProviderOptions, resolveDynamoDbDocumentClient } from './dynamodb'
+import { hashTxCode } from './hash.utils'
+
+export type DynamoDbPreAuthorizedCodeStoreOptions = DynamoDbProviderOptions & {
+  tableName: string
+  /** Default TTL in milliseconds when a per-save ttlSec is not provided. Defaults to 5 minutes. */
+  expiresIn?: number
+}
+
+const DEFAULT_EXPIRES_IN_MS = 60 * 5 * 1000
+
+/**
+ * Item stored in DynamoDB. The pre-authorized code itself is the partition key
+ * (`id`). `tx_code` is never persisted in the clear — only its HMAC hash is
+ * stored as `tx_code_hash`. `expires_at` is a UNIX timestamp in **seconds** so
+ * DynamoDB TTL can expire the item automatically.
+ */
+type DynamoDbPreAuthorizedCodeItem = {
+  id: string
+  credential_configuration_ids: PreAuthorizedCodeStoreEntry['credential_configuration_ids']
+  tx_code_input_mode?: 'numeric' | 'text'
+  tx_code_hash?: string
+  expires_at: number
+}
+
+const toDigitString = (value: string | number): string | null => {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 0 ? value.toString() : null
+  }
+  return /^\d+$/.test(value) ? value : null
+}
+
+export const dynamodbPreAuthorizedCodeStore = (
+  options: DynamoDbPreAuthorizedCodeStoreOptions
+): PreAuthorizedCodeStoreProvider => {
+  const client = resolveDynamoDbDocumentClient(options)
+  const { tableName, expiresIn = DEFAULT_EXPIRES_IN_MS } = options
+  const defaultTtlSec = Math.max(1, Math.floor(expiresIn / 1000))
+
+  /**
+   * Deletes a stored code. When `conditional` is true the delete only succeeds
+   * if the item still exists, and a lost race is surfaced as `invalid_grant`.
+   */
+  const deleteCode = async (code: string, conditional = false): Promise<void> => {
+    try {
+      await client.send(
+        new DeleteCommand({
+          TableName: tableName,
+          Key: { id: code },
+          ...(conditional && { ConditionExpression: 'attribute_exists(id)' }),
+        })
+      )
+    } catch (error) {
+      if (conditional && (error as { name?: string })?.name === 'ConditionalCheckFailedException') {
+        throw raise('invalid_grant', {
+          message: 'Pre-authorized code has already been consumed',
+        })
+      }
+      throw error
+    }
+  }
+
+  return {
+    kind: 'pre-authorized-code-store-provider',
+    name: 'dynamodb-pre-authorized-code-store-provider',
+    single: true,
+
+    async save(code, credentialConfigurationIds, tx_code, saveOptions) {
+      const ttlSecRaw = Number(saveOptions?.ttlSec ?? defaultTtlSec)
+      const ttlSecCandidate = Math.floor(ttlSecRaw)
+      const ttlSec =
+        Number.isFinite(ttlSecRaw) && ttlSecCandidate > 0 ? ttlSecCandidate : defaultTtlSec
+      const tx_code_input_mode = saveOptions?.tx_code_input_mode ?? 'numeric'
+      const expires_at = Math.floor(Date.now() / 1000) + ttlSec
+
+      const item: DynamoDbPreAuthorizedCodeItem = {
+        id: code,
+        credential_configuration_ids: credentialConfigurationIds,
+        tx_code_input_mode,
+        expires_at,
+      }
+
+      if (tx_code !== undefined) {
+        if (tx_code_input_mode !== 'text') {
+          const canonical = toDigitString(tx_code)
+          if (canonical === null) {
+            raise('invalid_tx_code', {
+              message: 'tx_code must be a non-negative integer for numeric input mode',
+            })
+          }
+          item.tx_code_hash = hashTxCode(canonical)
+        } else {
+          item.tx_code_hash = hashTxCode(tx_code)
+        }
+      }
+
+      await client.send(
+        new PutCommand({
+          TableName: tableName,
+          Item: item,
+        })
+      )
+    },
+
+    async consume(code, tx_code) {
+      const result = await client.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: { id: code },
+        })
+      )
+
+      if (!result.Item) {
+        throw raise('invalid_grant', {
+          message: 'Pre-authorized code not found',
+        })
+      }
+
+      const item = result.Item as DynamoDbPreAuthorizedCodeItem
+
+      // DynamoDB TTL deletion is eventually consistent — check expiry manually.
+      if (typeof item.expires_at !== 'number' || Math.floor(Date.now() / 1000) > item.expires_at) {
+        await deleteCode(code)
+        throw raise('invalid_grant', {
+          message: 'Pre-authorized code has expired',
+        })
+      }
+
+      if (item.tx_code_hash) {
+        if (tx_code === undefined) {
+          throw raise('invalid_request', {
+            message: 'tx_code is required for this pre-authorized code',
+          })
+        }
+        const inputMode = item.tx_code_input_mode ?? 'numeric'
+        if (inputMode !== 'text') {
+          const actual = toDigitString(tx_code)
+          if (actual === null || item.tx_code_hash !== hashTxCode(actual)) {
+            throw raise('invalid_grant', {
+              message: 'Invalid tx_code provided',
+            })
+          }
+        } else {
+          if (typeof tx_code !== 'string' || item.tx_code_hash !== hashTxCode(tx_code)) {
+            throw raise('invalid_grant', {
+              message: 'Invalid tx_code provided',
+            })
+          }
+        }
+      } else if (tx_code !== undefined) {
+        throw raise('invalid_request', {
+          message: 'tx_code should not be provided for this pre-authorized code',
+        })
+      }
+
+      // Atomically delete to prevent the code from being consumed twice. A
+      // failed condition means another request already consumed it.
+      await deleteCode(code, true)
+
+      return item.credential_configuration_ids ?? null
+    },
+  }
+}

--- a/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
+++ b/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
@@ -155,6 +155,18 @@ export const dynamodbPreAuthorizedCodeStore = (
         throw error
       }
 
+      /**
+       * Called before failing an attempt that the gate admitted. When the attempt
+       * exhausted the per-code limit the code is deleted, so a locked-out code never
+       * lingers until its TTL — later attempts fail the gate's `attribute_exists(id)`
+       * check and surface the same error.
+       */
+      const lockoutIfExhausted = async (): Promise<void> => {
+        if ((item.attempts ?? 0) >= maxTxCodeAttempts) {
+          await deleteCode(code)
+        }
+      }
+
       // expires_at is epoch ms (parity with Firestore / in-memory). DynamoDB TTL is eventually consistent — check manually.
       if (typeof item.expires_at !== 'number' || Date.now() > item.expires_at) {
         await deleteCode(code)
@@ -165,6 +177,7 @@ export const dynamodbPreAuthorizedCodeStore = (
 
       if (item.tx_code_hash) {
         if (tx_code === undefined) {
+          await lockoutIfExhausted()
           throw raise('invalid_request', {
             message: 'tx_code is required for this pre-authorized code',
           })
@@ -173,18 +186,21 @@ export const dynamodbPreAuthorizedCodeStore = (
         if (inputMode !== 'text') {
           const actual = toDigitString(tx_code)
           if (actual === null || item.tx_code_hash !== hashTxCode(actual)) {
+            await lockoutIfExhausted()
             throw raise('invalid_grant', {
               message: 'Invalid tx_code provided',
             })
           }
         } else {
           if (typeof tx_code !== 'string' || item.tx_code_hash !== hashTxCode(tx_code)) {
+            await lockoutIfExhausted()
             throw raise('invalid_grant', {
               message: 'Invalid tx_code provided',
             })
           }
         }
       } else if (tx_code !== undefined) {
+        await lockoutIfExhausted()
         throw raise('invalid_request', {
           message: 'tx_code should not be provided for this pre-authorized code',
         })

--- a/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
+++ b/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
@@ -20,10 +20,6 @@ const DEFAULT_EXPIRES_IN_MS = 60 * 5 * 1000
 const DEFAULT_TTL_SEC = DEFAULT_EXPIRES_IN_MS / 1000
 const DEFAULT_MAX_TX_CODE_ATTEMPTS = 5
 
-/**
- * Returned for every code that can no longer be exchanged — unknown, already consumed,
- * or locked out. The three cases are deliberately indistinguishable to the caller.
- */
 const LOCKED_MESSAGE = 'Pre-authorized code is invalid, consumed, or locked'
 
 /**
@@ -57,14 +53,10 @@ export const dynamodbPreAuthorizedCodeStore = (
 ): PreAuthorizedCodeStoreProvider => {
   const client = resolveDynamoDbDocumentClient(options)
   const { tableName, expiresIn = DEFAULT_EXPIRES_IN_MS } = options
-  // save() falls back to this value, so a non-finite expiresIn has to be resolved here —
-  // otherwise NaN flows straight through that fallback into `expires_at` and `ttl`.
   const defaultTtlSecRaw = Math.floor(expiresIn / 1000)
   const defaultTtlSec = Number.isFinite(defaultTtlSecRaw)
     ? Math.max(1, defaultTtlSecRaw)
     : DEFAULT_TTL_SEC
-  // A non-finite limit would reach DynamoDB as the gate's `:max` and fail every consume,
-  // so fall back to the default rather than propagating it.
   const maxTxCodeAttemptsRaw = options.maxTxCodeAttempts ?? DEFAULT_MAX_TX_CODE_ATTEMPTS
   const maxTxCodeAttempts = Number.isFinite(maxTxCodeAttemptsRaw)
     ? Math.max(1, Math.floor(maxTxCodeAttemptsRaw))
@@ -167,14 +159,6 @@ export const dynamodbPreAuthorizedCodeStore = (
         throw error
       }
 
-      /**
-       * Called before failing an attempt that the gate admitted. When the attempt
-       * exhausted the per-code limit, the code is deleted and the lockout is reported
-       * right away: the holder learns the code is dead on the attempt that killed it,
-       * rather than being told only that the tx_code was wrong — which would invite a
-       * retry that can no longer succeed. Attempts that leave the limit intact fall
-       * through, so the holder still gets the specific `Invalid tx_code` error.
-       */
       const lockoutIfExhausted = async (): Promise<void> => {
         if ((item.attempts ?? 0) >= maxTxCodeAttempts) {
           await deleteCode(code)

--- a/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
+++ b/aws/src/providers/dynamodb-pre-authorized-code-store.provider.ts
@@ -17,6 +17,7 @@ export type DynamoDbPreAuthorizedCodeStoreOptions = DynamoDbProviderOptions & {
 }
 
 const DEFAULT_EXPIRES_IN_MS = 60 * 5 * 1000
+const DEFAULT_TTL_SEC = DEFAULT_EXPIRES_IN_MS / 1000
 const DEFAULT_MAX_TX_CODE_ATTEMPTS = 5
 
 /**
@@ -56,11 +57,18 @@ export const dynamodbPreAuthorizedCodeStore = (
 ): PreAuthorizedCodeStoreProvider => {
   const client = resolveDynamoDbDocumentClient(options)
   const { tableName, expiresIn = DEFAULT_EXPIRES_IN_MS } = options
-  const defaultTtlSec = Math.max(1, Math.floor(expiresIn / 1000))
-  const maxTxCodeAttempts = Math.max(
-    1,
-    Math.floor(options.maxTxCodeAttempts ?? DEFAULT_MAX_TX_CODE_ATTEMPTS)
-  )
+  // save() falls back to this value, so a non-finite expiresIn has to be resolved here —
+  // otherwise NaN flows straight through that fallback into `expires_at` and `ttl`.
+  const defaultTtlSecRaw = Math.floor(expiresIn / 1000)
+  const defaultTtlSec = Number.isFinite(defaultTtlSecRaw)
+    ? Math.max(1, defaultTtlSecRaw)
+    : DEFAULT_TTL_SEC
+  // A non-finite limit would reach DynamoDB as the gate's `:max` and fail every consume,
+  // so fall back to the default rather than propagating it.
+  const maxTxCodeAttemptsRaw = options.maxTxCodeAttempts ?? DEFAULT_MAX_TX_CODE_ATTEMPTS
+  const maxTxCodeAttempts = Number.isFinite(maxTxCodeAttemptsRaw)
+    ? Math.max(1, Math.floor(maxTxCodeAttemptsRaw))
+    : DEFAULT_MAX_TX_CODE_ATTEMPTS
 
   /**
    * Deletes a stored code. When `conditional` is true the delete only succeeds

--- a/aws/src/providers/dynamodb-request-object-store.provider.ts
+++ b/aws/src/providers/dynamodb-request-object-store.provider.ts
@@ -39,8 +39,8 @@ export const dynamodbRequestObjectStore = (
         requestObject: RequestObject
       }
 
-      // DynamoDB TTL deletion is eventually consistent — check expiry manually.
-      if (typeof expires_at !== 'number' || Math.floor(Date.now() / 1000) > expires_at) {
+      // expires_at is epoch ms (parity with Firestore / in-memory). DynamoDB TTL is eventually consistent — check manually.
+      if (typeof expires_at !== 'number' || Date.now() > expires_at) {
         return null
       }
 
@@ -48,11 +48,13 @@ export const dynamodbRequestObjectStore = (
     },
 
     async save(id, requestObject) {
-      const expires_at = Math.floor((Date.now() + expiresIn) / 1000)
+      const expires_at = Date.now() + expiresIn
+      // DynamoDB TTL expects epoch seconds; round up so TTL never deletes before the real (ms) expiry.
+      const ttl = Math.ceil(expires_at / 1000)
       await client.send(
         new PutCommand({
           TableName: tableName,
-          Item: { id, requestObject, expires_at },
+          Item: { id, requestObject, expires_at, ttl },
         })
       )
     },

--- a/aws/src/providers/dynamodb-request-object-store.provider.ts
+++ b/aws/src/providers/dynamodb-request-object-store.provider.ts
@@ -16,6 +16,7 @@ export const dynamodbRequestObjectStore = (
 ): RequestObjectStoreProvider => {
   const client = resolveDynamoDbDocumentClient(options)
   const { tableName, expiresIn = DEFAULT_EXPIRES_IN_MS } = options
+  const ttlMs = Number.isFinite(expiresIn) ? expiresIn : DEFAULT_EXPIRES_IN_MS
 
   return {
     kind: 'request-object-store-provider',
@@ -48,7 +49,7 @@ export const dynamodbRequestObjectStore = (
     },
 
     async save(id, requestObject) {
-      const expires_at = Date.now() + expiresIn
+      const expires_at = Date.now() + ttlMs
       // DynamoDB TTL expects epoch seconds; round up so TTL never deletes before the real (ms) expiry.
       const ttl = Math.ceil(expires_at / 1000)
       await client.send(

--- a/aws/src/providers/hash.utils.ts
+++ b/aws/src/providers/hash.utils.ts
@@ -1,0 +1,11 @@
+import { createHmac } from 'node:crypto'
+
+const PEPPER = process.env.TX_CODE_PEPPER
+if (!PEPPER) {
+  throw new Error('TX_CODE_PEPPER environment variable is required')
+}
+
+export const hashTxCode = (txCode: string | number): string => {
+  const input = typeof txCode === 'number' ? txCode.toString() : txCode
+  return createHmac('sha256', PEPPER).update(input).digest('hex')
+}

--- a/aws/test/dynamodb-nonce-store.provider.spec.ts
+++ b/aws/test/dynamodb-nonce-store.provider.spec.ts
@@ -28,22 +28,25 @@ describe('dynamodbNonceStore', () => {
     assert.equal(provider.single, true)
   })
 
-  it('should save with correct table name and epoch-seconds expires_at', async () => {
+  it('should save with epoch-ms expires_at and epoch-seconds ttl', async () => {
     ddbMock.on(PutCommand).resolves({})
-    const before = Math.floor(Date.now() / 1000)
+    const before = Date.now()
 
     const provider = createProvider()
     await provider.save(nonce)
 
-    const after = Math.floor(Date.now() / 1000)
+    const after = Date.now()
     const putCall = ddbMock.commandCalls(PutCommand)[0]
     const item = putCall?.args[0].input.Item
 
     assert.equal(putCall?.args[0].input.TableName, TABLE_NAME)
     assert.equal(item?.id, nonce.nonce)
     assert.deepEqual(item?.nonce, nonce)
-    assert.ok(item?.expires_at >= before + 300)
-    assert.ok(item?.expires_at <= after + 300)
+    // expires_at is epoch ms (parity with Firestore / in-memory).
+    assert.ok(item?.expires_at >= before + 300 * 1000)
+    assert.ok(item?.expires_at <= after + 300 * 1000)
+    // ttl is epoch seconds, rounded up so TTL never fires before the real (ms) expiry.
+    assert.equal(item?.ttl, Math.ceil(item?.expires_at / 1000))
   })
 
   it('should throw when nonce_expires_in is missing on save', async () => {
@@ -53,7 +56,7 @@ describe('dynamodbNonceStore', () => {
   })
 
   it('validate should return true for a valid nonce', async () => {
-    const futureExpiry = Math.floor(Date.now() / 1000) + 300
+    const futureExpiry = Date.now() + 300 * 1000
     ddbMock.on(GetCommand).resolves({
       Item: { id: nonce.nonce, nonce, expires_at: futureExpiry },
     })
@@ -73,7 +76,7 @@ describe('dynamodbNonceStore', () => {
   })
 
   it('validate should return false and delete an expired nonce', async () => {
-    const pastExpiry = Math.floor(Date.now() / 1000) - 1
+    const pastExpiry = Date.now() - 1000
     ddbMock.on(GetCommand).resolves({
       Item: { id: nonce.nonce, nonce, expires_at: pastExpiry },
     })
@@ -90,7 +93,7 @@ describe('dynamodbNonceStore', () => {
 
   it('revoke should return true when the nonce existed', async () => {
     ddbMock.on(DeleteCommand).resolves({
-      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) + 300 },
+      Attributes: { id: nonce.nonce, nonce, expires_at: Date.now() + 300 * 1000 },
     })
 
     const provider = createProvider()
@@ -110,7 +113,7 @@ describe('dynamodbNonceStore', () => {
 
   it('consume should return true and delete a valid nonce', async () => {
     ddbMock.on(DeleteCommand).resolves({
-      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) + 300 },
+      Attributes: { id: nonce.nonce, nonce, expires_at: Date.now() + 300 * 1000 },
     })
 
     const provider = createProvider()
@@ -128,7 +131,7 @@ describe('dynamodbNonceStore', () => {
 
   it('consume should return false for an expired nonce', async () => {
     ddbMock.on(DeleteCommand).resolves({
-      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) - 1 },
+      Attributes: { id: nonce.nonce, nonce, expires_at: Date.now() - 1000 },
     })
 
     const provider = createProvider()

--- a/aws/test/dynamodb-nonce-store.provider.spec.ts
+++ b/aws/test/dynamodb-nonce-store.provider.spec.ts
@@ -72,14 +72,20 @@ describe('dynamodbNonceStore', () => {
     assert.equal(await provider.validate(nonce), false)
   })
 
-  it('validate should return false for an expired nonce', async () => {
+  it('validate should return false and delete an expired nonce', async () => {
     const pastExpiry = Math.floor(Date.now() / 1000) - 1
     ddbMock.on(GetCommand).resolves({
       Item: { id: nonce.nonce, nonce, expires_at: pastExpiry },
     })
+    ddbMock.on(DeleteCommand).resolves({})
 
     const provider = createProvider()
     assert.equal(await provider.validate(nonce), false)
+
+    // Match the Firestore provider: expired nonces are proactively deleted, not left to TTL.
+    const deleteCall = ddbMock.commandCalls(DeleteCommand)[0]
+    assert.equal(deleteCall?.args[0].input.TableName, TABLE_NAME)
+    assert.deepEqual(deleteCall?.args[0].input.Key, { id: nonce.nonce })
   })
 
   it('revoke should return true when the nonce existed', async () => {

--- a/aws/test/dynamodb-nonce-store.provider.spec.ts
+++ b/aws/test/dynamodb-nonce-store.provider.spec.ts
@@ -55,6 +55,24 @@ describe('dynamodbNonceStore', () => {
     assert.equal(ddbMock.commandCalls(PutCommand).length, 0)
   })
 
+  it('should throw when nonce_expires_in is NaN on save', async () => {
+    const provider = createProvider()
+    await assert.rejects(
+      () => provider.save({ nonce: 'bad-ttl-nan', nonce_expires_in: Number.NaN }),
+      /nonce_expires_in must be a finite number/
+    )
+    assert.equal(ddbMock.commandCalls(PutCommand).length, 0)
+  })
+
+  it('should throw when nonce_expires_in is Infinity on save', async () => {
+    const provider = createProvider()
+    await assert.rejects(
+      () => provider.save({ nonce: 'bad-ttl-inf', nonce_expires_in: Number.POSITIVE_INFINITY }),
+      /nonce_expires_in must be a finite number/
+    )
+    assert.equal(ddbMock.commandCalls(PutCommand).length, 0)
+  })
+
   it('validate should return true for a valid nonce', async () => {
     const futureExpiry = Date.now() + 300 * 1000
     ddbMock.on(GetCommand).resolves({

--- a/aws/test/dynamodb-nonce-store.provider.spec.ts
+++ b/aws/test/dynamodb-nonce-store.provider.spec.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { mockClient } from 'aws-sdk-client-mock'
+import { Nonce } from '@trustknots/vcknots'
+import { dynamodbNonceStore } from '../src/providers/dynamodb-nonce-store.provider'
+
+const TABLE_NAME = 'NoncesTable'
+const ddbMock = mockClient(DynamoDBDocumentClient)
+
+describe('dynamodbNonceStore', () => {
+  const nonce: Nonce = { nonce: 'test-nonce', nonce_expires_in: 300 * 1000 }
+
+  afterEach(() => {
+    ddbMock.reset()
+  })
+
+  const createProvider = () =>
+    dynamodbNonceStore({
+      client: ddbMock as unknown as DynamoDBDocumentClient,
+      tableName: TABLE_NAME,
+    })
+
+  it('should have correct provider metadata', () => {
+    const provider = createProvider()
+    assert.equal(provider.kind, 'nonce-store-provider')
+    assert.equal(provider.name, 'dynamodb-nonce-store-provider')
+    assert.equal(provider.single, true)
+  })
+
+  it('should save with correct table name and epoch-seconds expires_at', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Math.floor(Date.now() / 1000)
+
+    const provider = createProvider()
+    await provider.save(nonce)
+
+    const after = Math.floor(Date.now() / 1000)
+    const putCall = ddbMock.commandCalls(PutCommand)[0]
+    const item = putCall?.args[0].input.Item
+
+    assert.equal(putCall?.args[0].input.TableName, TABLE_NAME)
+    assert.equal(item?.id, nonce.nonce)
+    assert.deepEqual(item?.nonce, nonce)
+    assert.ok(item?.expires_at >= before + 300)
+    assert.ok(item?.expires_at <= after + 300)
+  })
+
+  it('should throw when nonce_expires_in is missing on save', async () => {
+    const provider = createProvider()
+    await assert.rejects(() => provider.save({ nonce: 'no-ttl' }), /nonce_expires_in is required/)
+    assert.equal(ddbMock.commandCalls(PutCommand).length, 0)
+  })
+
+  it('validate should return true for a valid nonce', async () => {
+    const futureExpiry = Math.floor(Date.now() / 1000) + 300
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: nonce.nonce, nonce, expires_at: futureExpiry },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.validate(nonce), true)
+    const getCall = ddbMock.commandCalls(GetCommand)[0]
+    assert.equal(getCall?.args[0].input.TableName, TABLE_NAME)
+    assert.deepEqual(getCall?.args[0].input.Key, { id: nonce.nonce })
+  })
+
+  it('validate should return false for an unknown nonce', async () => {
+    ddbMock.on(GetCommand).resolves({})
+
+    const provider = createProvider()
+    assert.equal(await provider.validate(nonce), false)
+  })
+
+  it('validate should return false for an expired nonce', async () => {
+    const pastExpiry = Math.floor(Date.now() / 1000) - 1
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: nonce.nonce, nonce, expires_at: pastExpiry },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.validate(nonce), false)
+  })
+
+  it('revoke should return true when the nonce existed', async () => {
+    ddbMock.on(DeleteCommand).resolves({
+      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) + 300 },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.revoke(nonce), true)
+    const deleteCall = ddbMock.commandCalls(DeleteCommand)[0]
+    assert.equal(deleteCall?.args[0].input.TableName, TABLE_NAME)
+    assert.deepEqual(deleteCall?.args[0].input.Key, { id: nonce.nonce })
+    assert.equal(deleteCall?.args[0].input.ReturnValues, 'ALL_OLD')
+  })
+
+  it('revoke should return false when the nonce did not exist', async () => {
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    assert.equal(await provider.revoke(nonce), false)
+  })
+
+  it('consume should return true and delete a valid nonce', async () => {
+    ddbMock.on(DeleteCommand).resolves({
+      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) + 300 },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.consume(nonce), true)
+    const deleteCall = ddbMock.commandCalls(DeleteCommand)[0]
+    assert.equal(deleteCall?.args[0].input.ReturnValues, 'ALL_OLD')
+  })
+
+  it('consume should return false for an unknown nonce', async () => {
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    assert.equal(await provider.consume(nonce), false)
+  })
+
+  it('consume should return false for an expired nonce', async () => {
+    ddbMock.on(DeleteCommand).resolves({
+      Attributes: { id: nonce.nonce, nonce, expires_at: Math.floor(Date.now() / 1000) - 1 },
+    })
+
+    const provider = createProvider()
+    assert.equal(await provider.consume(nonce), false)
+  })
+})

--- a/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
+++ b/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
@@ -374,6 +374,9 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
   })
 
   describe('tx_code brute-force lockout (count-first gate)', () => {
+    const LOCKED_MESSAGE = 'Pre-authorized code is invalid, consumed, or locked'
+    const INVALID_TX_CODE_MESSAGE = 'Invalid tx_code provided'
+
     const saveWithTxCode = async (provider: ReturnType<typeof createProvider>, code: string) => {
       await provider.save(PreAuthorizedCode(code), configurations, 1234, {
         tx_code_input_mode: 'numeric',
@@ -414,6 +417,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
       // Even the correct PIN is rejected once the code is locked.
       await assert.rejects(provider.consume(PreAuthorizedCode('bf-locked'), 1234), {
         name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
       })
       // The tx_code is never compared, and nothing is consumed.
       assert.equal(ddbMock.commandCalls(DeleteCommand).length, 0)
@@ -444,10 +448,11 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
       // 1st of the 5 allowed attempts.
       armConsumeFromLastPut(1)
 
+      // Attempts remain, so the holder is told what was actually wrong and can retry.
       await assert.rejects(provider.consume(PreAuthorizedCode('bf-under'), 9999), {
         name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
       })
-      // Attempts remain, so the code stays available for the legitimate holder.
       assert.equal(ddbMock.commandCalls(DeleteCommand).length, 0)
     })
 
@@ -460,8 +465,11 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
       // The gate admits the 5th (final) attempt, which then fails the tx_code check.
       armConsumeFromLastPut(5)
 
+      // The lockout is reported on the attempt that trips it — not `Invalid tx_code`,
+      // which would invite a retry that can no longer succeed.
       await assert.rejects(provider.consume(PreAuthorizedCode('bf-exhaust'), 9999), {
         name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
       })
       // A locked-out code is removed rather than left to linger until its TTL.
       assert.equal(ddbMock.commandCalls(DeleteCommand).length, 1)
@@ -480,6 +488,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
 
       await assert.rejects(provider.consume(PreAuthorizedCode('bf-custom-exhaust'), 9999), {
         name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
       })
       assert.equal(ddbMock.commandCalls(DeleteCommand).length, 1)
     })

--- a/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
+++ b/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
@@ -230,74 +230,78 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     assert.deepEqual(lastPutItem()?.credential_configuration_ids, configurations)
   })
 
-  it('should store expires_at as a UNIX timestamp in seconds', async () => {
+  it('should store expires_at in epoch ms and ttl in epoch seconds', async () => {
     ddbMock.on(PutCommand).resolves({})
-    const before = Math.floor(Date.now() / 1000)
+    const before = Date.now()
 
     const provider = createProvider()
     await provider.save(PreAuthorizedCode('ttl-default'), configurations)
 
-    const after = Math.floor(Date.now() / 1000)
-    const expiresAt = lastPutItem()?.expires_at
+    const after = Date.now()
+    const item = lastPutItem()
+    const expiresAt = item?.expires_at
     assert.equal(typeof expiresAt, 'number')
-    assert.ok(expiresAt >= before + 300)
-    assert.ok(expiresAt <= after + 300)
+    // expires_at is epoch ms (parity with Firestore / in-memory).
+    assert.ok(expiresAt >= before + 300 * 1000)
+    assert.ok(expiresAt <= after + 300 * 1000)
+    // ttl is epoch seconds, rounded up so TTL never fires before the real (ms) expiry.
+    assert.equal(item?.ttl, Math.ceil(expiresAt / 1000))
   })
 
   it('should honor a custom expiresIn', async () => {
     ddbMock.on(PutCommand).resolves({})
-    const before = Math.floor(Date.now() / 1000)
+    const before = Date.now()
 
     const provider = createProvider(60 * 1000)
     await provider.save(PreAuthorizedCode('ttl-custom'), configurations)
 
-    const after = Math.floor(Date.now() / 1000)
+    const after = Date.now()
     const expiresAt = lastPutItem()?.expires_at
-    assert.ok(expiresAt >= before + 60)
-    assert.ok(expiresAt <= after + 60)
+    assert.ok(expiresAt >= before + 60 * 1000)
+    assert.ok(expiresAt <= after + 60 * 1000)
   })
 
   it('should prefer saveOptions.ttlSec over the default', async () => {
     ddbMock.on(PutCommand).resolves({})
-    const before = Math.floor(Date.now() / 1000)
+    const before = Date.now()
 
     const provider = createProvider()
     await provider.save(PreAuthorizedCode('ttl-override'), configurations, undefined, {
       ttlSec: 30,
     })
 
-    const after = Math.floor(Date.now() / 1000)
+    const after = Date.now()
     const expiresAt = lastPutItem()?.expires_at
-    assert.ok(expiresAt >= before + 30)
-    assert.ok(expiresAt <= after + 30)
+    assert.ok(expiresAt >= before + 30 * 1000)
+    assert.ok(expiresAt <= after + 30 * 1000)
   })
 
   it('should fall back to the default ttl when saveOptions.ttlSec is invalid', async () => {
     ddbMock.on(PutCommand).resolves({})
-    const before = Math.floor(Date.now() / 1000)
+    const before = Date.now()
 
     const provider = createProvider()
     await provider.save(PreAuthorizedCode('ttl-nan'), configurations, undefined, {
       ttlSec: Number.NaN,
     })
 
-    const after = Math.floor(Date.now() / 1000)
+    const after = Date.now()
     const expiresAt = lastPutItem()?.expires_at
-    assert.ok(expiresAt >= before + 300)
-    assert.ok(expiresAt <= after + 300)
+    assert.ok(expiresAt >= before + 300 * 1000)
+    assert.ok(expiresAt <= after + 300 * 1000)
   })
 
   it('should floor a fractional ttlSec', async () => {
     ddbMock.on(PutCommand).resolves({})
-    const before = Math.floor(Date.now() / 1000)
+    const before = Date.now()
 
     const provider = createProvider()
     await provider.save(PreAuthorizedCode('ttl-frac'), configurations, undefined, { ttlSec: 30.9 })
 
-    const after = Math.floor(Date.now() / 1000)
+    const after = Date.now()
     const expiresAt = lastPutItem()?.expires_at
-    assert.ok(expiresAt >= before + 30)
-    assert.ok(expiresAt <= after + 30)
+    assert.ok(expiresAt >= before + 30 * 1000)
+    assert.ok(expiresAt <= after + 30 * 1000)
   })
 
   it('should throw invalid_grant when the code is unknown', async () => {
@@ -310,7 +314,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
   })
 
   it('should throw invalid_grant and delete when the code is expired', async () => {
-    const pastExpiry = Math.floor(Date.now() / 1000) - 1
+    const pastExpiry = Date.now() - 1000
     ddbMock.on(GetCommand).resolves({
       Item: { id: 'expired', credential_configuration_ids: configurations, expires_at: pastExpiry },
     })

--- a/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
+++ b/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
@@ -1,0 +1,370 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from '@aws-sdk/lib-dynamodb'
+import { CredentialConfigurationId, PreAuthorizedCode } from '@trustknots/vcknots'
+import { mockClient } from 'aws-sdk-client-mock'
+import { dynamodbPreAuthorizedCodeStore } from '../src/providers/dynamodb-pre-authorized-code-store.provider'
+
+const TABLE_NAME = 'PreCodesTable'
+const ddbMock = mockClient(DynamoDBDocumentClient)
+
+const configurations: CredentialConfigurationId[] = [CredentialConfigurationId('University_Degree')]
+
+describe('dynamodbPreAuthorizedCodeStore', () => {
+  afterEach(() => {
+    ddbMock.reset()
+  })
+
+  const createProvider = (expiresIn?: number) =>
+    dynamodbPreAuthorizedCodeStore({
+      client: ddbMock as unknown as DynamoDBDocumentClient,
+      tableName: TABLE_NAME,
+      ...(expiresIn !== undefined && { expiresIn }),
+    })
+
+  /** Grab the Item written by the most recent PutCommand. */
+  const lastPutItem = () => ddbMock.commandCalls(PutCommand).at(-1)?.args[0].input.Item
+
+  /** Wire GetCommand to return whatever the last save persisted. */
+  const armGetFromLastPut = () => {
+    ddbMock.on(GetCommand).resolves({ Item: lastPutItem() })
+  }
+
+  it('should have correct provider metadata', () => {
+    const provider = createProvider()
+    assert.equal(provider.kind, 'pre-authorized-code-store-provider')
+    assert.equal(provider.name, 'dynamodb-pre-authorized-code-store-provider')
+    assert.equal(provider.single, true)
+  })
+
+  it('should save and consume a code without tx_code', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-123'), configurations)
+    armGetFromLastPut()
+
+    const result = await provider.consume(PreAuthorizedCode('code-123'))
+    assert.deepEqual(result, configurations)
+    assert.equal(ddbMock.commandCalls(DeleteCommand).length, 1)
+  })
+
+  it('should save and validate a code with tx_code (numeric)', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-numeric'), configurations, 123, {
+      tx_code_input_mode: 'numeric',
+    })
+    armGetFromLastPut()
+
+    const result = await provider.consume(PreAuthorizedCode('code-numeric'), 123)
+    assert.deepEqual(result, configurations)
+  })
+
+  it('should save and validate a code with tx_code (text)', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-text'), configurations, 'abc123', {
+      tx_code_input_mode: 'text',
+    })
+    armGetFromLastPut()
+
+    const result = await provider.consume(PreAuthorizedCode('code-text'), 'abc123')
+    assert.deepEqual(result, configurations)
+  })
+
+  it('should throw invalid_grant for incorrect tx_code', async () => {
+    ddbMock.on(PutCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-wrong'), configurations, 123, {
+      tx_code_input_mode: 'numeric',
+    })
+    armGetFromLastPut()
+
+    await assert.rejects(provider.consume(PreAuthorizedCode('code-wrong'), 456), {
+      name: 'invalid_grant',
+    })
+  })
+
+  it('should allow string numeric tx_code in numeric mode', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-type'), configurations, 123, {
+      tx_code_input_mode: 'numeric',
+    })
+    armGetFromLastPut()
+
+    const result = await provider.consume(PreAuthorizedCode('code-type'), '123')
+    assert.deepEqual(result, configurations)
+  })
+
+  it('should throw invalid_grant for non-numeric string tx_code in numeric mode', async () => {
+    ddbMock.on(PutCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-invalid-num'), configurations, 123, {
+      tx_code_input_mode: 'numeric',
+    })
+    armGetFromLastPut()
+
+    await assert.rejects(provider.consume(PreAuthorizedCode('code-invalid-num'), '12a3'), {
+      name: 'invalid_grant',
+    })
+  })
+
+  it('should preserve leading zeros in numeric mode', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-leading-zero'), configurations, '0123', {
+      tx_code_input_mode: 'numeric',
+    })
+    armGetFromLastPut()
+
+    const result = await provider.consume(PreAuthorizedCode('code-leading-zero'), '0123')
+    assert.deepEqual(result, configurations)
+  })
+
+  it('should throw invalid_grant when leading-zero digit-string is validated as number', async () => {
+    ddbMock.on(PutCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-leading-zero-mismatch'), configurations, '0123', {
+      tx_code_input_mode: 'numeric',
+    })
+    armGetFromLastPut()
+
+    await assert.rejects(provider.consume(PreAuthorizedCode('code-leading-zero-mismatch'), 123), {
+      name: 'invalid_grant',
+    })
+  })
+
+  it('should throw invalid_tx_code for a non-digit tx_code in numeric mode on save', async () => {
+    ddbMock.on(PutCommand).resolves({})
+
+    const provider = createProvider()
+    await assert.rejects(
+      provider.save(PreAuthorizedCode('code-bad-save'), configurations, 'not-a-number', {
+        tx_code_input_mode: 'numeric',
+      }),
+      { name: 'invalid_tx_code' }
+    )
+  })
+
+  it('should require tx_code when a hash is stored', async () => {
+    ddbMock.on(PutCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-requires-tx'), configurations, 123, {
+      tx_code_input_mode: 'numeric',
+    })
+    armGetFromLastPut()
+
+    await assert.rejects(provider.consume(PreAuthorizedCode('code-requires-tx')), {
+      name: 'invalid_request',
+    })
+  })
+
+  it('should reject tx_code when none was stored', async () => {
+    ddbMock.on(PutCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('code-no-tx'), configurations)
+    armGetFromLastPut()
+
+    await assert.rejects(provider.consume(PreAuthorizedCode('code-no-tx'), 123), {
+      name: 'invalid_request',
+    })
+  })
+
+  it('should store only the hashed tx_code, never the clear value', async () => {
+    ddbMock.on(PutCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('hashed-code'), configurations, 123, {
+      tx_code_input_mode: 'numeric',
+    })
+
+    const item = lastPutItem()
+    assert.ok(item)
+    assert.equal(item.tx_code_input_mode, 'numeric')
+    assert.equal(typeof item.tx_code_hash, 'string')
+    assert.equal(item.tx_code_hash.length, 64) // SHA-256 hex length
+    assert.ok(!('tx_code' in item))
+    assert.ok(!Object.values(item).includes(123))
+    assert.ok(!Object.values(item).includes('123'))
+  })
+
+  it('should default to numeric mode when not specified', async () => {
+    ddbMock.on(PutCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('default-mode'), configurations, 456)
+
+    assert.equal(lastPutItem()?.tx_code_input_mode, 'numeric')
+  })
+
+  it('should persist credential_configuration_ids and id', async () => {
+    ddbMock.on(PutCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('stored-config'), configurations)
+
+    const putCall = ddbMock.commandCalls(PutCommand)[0]
+    assert.equal(putCall?.args[0].input.TableName, TABLE_NAME)
+    assert.equal(lastPutItem()?.id, 'stored-config')
+    assert.deepEqual(lastPutItem()?.credential_configuration_ids, configurations)
+  })
+
+  it('should store expires_at as a UNIX timestamp in seconds', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Math.floor(Date.now() / 1000)
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('ttl-default'), configurations)
+
+    const after = Math.floor(Date.now() / 1000)
+    const expiresAt = lastPutItem()?.expires_at
+    assert.equal(typeof expiresAt, 'number')
+    assert.ok(expiresAt >= before + 300)
+    assert.ok(expiresAt <= after + 300)
+  })
+
+  it('should honor a custom expiresIn', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Math.floor(Date.now() / 1000)
+
+    const provider = createProvider(60 * 1000)
+    await provider.save(PreAuthorizedCode('ttl-custom'), configurations)
+
+    const after = Math.floor(Date.now() / 1000)
+    const expiresAt = lastPutItem()?.expires_at
+    assert.ok(expiresAt >= before + 60)
+    assert.ok(expiresAt <= after + 60)
+  })
+
+  it('should prefer saveOptions.ttlSec over the default', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Math.floor(Date.now() / 1000)
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('ttl-override'), configurations, undefined, {
+      ttlSec: 30,
+    })
+
+    const after = Math.floor(Date.now() / 1000)
+    const expiresAt = lastPutItem()?.expires_at
+    assert.ok(expiresAt >= before + 30)
+    assert.ok(expiresAt <= after + 30)
+  })
+
+  it('should fall back to the default ttl when saveOptions.ttlSec is invalid', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Math.floor(Date.now() / 1000)
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('ttl-nan'), configurations, undefined, {
+      ttlSec: Number.NaN,
+    })
+
+    const after = Math.floor(Date.now() / 1000)
+    const expiresAt = lastPutItem()?.expires_at
+    assert.ok(expiresAt >= before + 300)
+    assert.ok(expiresAt <= after + 300)
+  })
+
+  it('should floor a fractional ttlSec', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Math.floor(Date.now() / 1000)
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('ttl-frac'), configurations, undefined, { ttlSec: 30.9 })
+
+    const after = Math.floor(Date.now() / 1000)
+    const expiresAt = lastPutItem()?.expires_at
+    assert.ok(expiresAt >= before + 30)
+    assert.ok(expiresAt <= after + 30)
+  })
+
+  it('should throw invalid_grant when the code is unknown', async () => {
+    ddbMock.on(GetCommand).resolves({})
+
+    const provider = createProvider()
+    await assert.rejects(provider.consume(PreAuthorizedCode('unknown')), {
+      name: 'invalid_grant',
+    })
+  })
+
+  it('should throw invalid_grant and delete when the code is expired', async () => {
+    const pastExpiry = Math.floor(Date.now() / 1000) - 1
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: 'expired', credential_configuration_ids: configurations, expires_at: pastExpiry },
+    })
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    await assert.rejects(provider.consume(PreAuthorizedCode('expired')), {
+      name: 'invalid_grant',
+    })
+    assert.equal(ddbMock.commandCalls(DeleteCommand).length, 1)
+  })
+
+  it('should throw invalid_grant when expires_at is missing', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: 'no-exp', credential_configuration_ids: configurations },
+    })
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    await assert.rejects(provider.consume(PreAuthorizedCode('no-exp')), {
+      name: 'invalid_grant',
+    })
+  })
+
+  it('should delete the code conditionally after a successful consume', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    ddbMock.on(DeleteCommand).resolves({})
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('consume-delete'), configurations)
+    armGetFromLastPut()
+
+    await provider.consume(PreAuthorizedCode('consume-delete'))
+
+    const deleteCall = ddbMock.commandCalls(DeleteCommand)[0]
+    assert.equal(deleteCall?.args[0].input.TableName, TABLE_NAME)
+    assert.deepEqual(deleteCall?.args[0].input.Key, { id: 'consume-delete' })
+    assert.equal(deleteCall?.args[0].input.ConditionExpression, 'attribute_exists(id)')
+  })
+
+  it('should surface a lost delete race as invalid_grant (double consume)', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    ddbMock.on(DeleteCommand).rejects(
+      Object.assign(new Error('conditional check failed'), {
+        name: 'ConditionalCheckFailedException',
+      })
+    )
+
+    const provider = createProvider()
+    await provider.save(PreAuthorizedCode('race'), configurations)
+    armGetFromLastPut()
+
+    await assert.rejects(provider.consume(PreAuthorizedCode('race')), {
+      name: 'invalid_grant',
+    })
+  })
+})

--- a/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
+++ b/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
@@ -299,6 +299,28 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     assert.ok(expiresAt <= after + 300 * 1000)
   })
 
+  // A non-finite expiresIn is the fallback that save() itself relies on, so it has to
+  // resolve to the default — otherwise NaN reaches DynamoDB as `expires_at` / `ttl`.
+  for (const [label, value] of [
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ] as const) {
+    it(`should fall back to the default ttl when expiresIn is ${label}`, async () => {
+      ddbMock.on(PutCommand).resolves({})
+      const before = Date.now()
+
+      const provider = createProvider(value)
+      await provider.save(PreAuthorizedCode(`exp-${label}`), configurations, undefined)
+
+      const after = Date.now()
+      const item = lastPutItem()
+      assert.ok(Number.isFinite(item?.expires_at), 'expires_at must never be NaN')
+      assert.ok(Number.isFinite(item?.ttl), 'ttl must never be NaN')
+      assert.ok(item?.expires_at >= before + 300 * 1000)
+      assert.ok(item?.expires_at <= after + 300 * 1000)
+    })
+  }
+
   it('should floor a fractional ttlSec', async () => {
     ddbMock.on(PutCommand).resolves({})
     const before = Date.now()
@@ -421,6 +443,45 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
       })
       // The tx_code is never compared, and nothing is consumed.
       assert.equal(ddbMock.commandCalls(DeleteCommand).length, 0)
+    })
+
+    // A non-finite limit would otherwise reach DynamoDB as `:max` and fail every consume.
+    for (const [label, value] of [
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+    ] as const) {
+      it(`falls back to the default limit when maxTxCodeAttempts is ${label}`, async () => {
+        ddbMock.on(PutCommand).resolves({})
+
+        const provider = createProvider(undefined, value)
+        await saveWithTxCode(provider, `bf-${label}`)
+        armConsumeFromLastPut(1)
+
+        await assert.rejects(provider.consume(PreAuthorizedCode(`bf-${label}`), 9999), {
+          name: 'invalid_grant',
+          message: INVALID_TX_CODE_MESSAGE,
+        })
+        assert.equal(
+          ddbMock.commandCalls(UpdateCommand)[0]?.args[0].input.ExpressionAttributeValues?.[':max'],
+          5
+        )
+      })
+    }
+
+    it('clamps a maxTxCodeAttempts below 1 up to a single attempt', async () => {
+      ddbMock.on(PutCommand).resolves({})
+
+      const provider = createProvider(undefined, 0)
+      await saveWithTxCode(provider, 'bf-zero')
+      armConsumeFromLastPut(1)
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-zero'), 9999), {
+        name: 'invalid_grant',
+      })
+      assert.equal(
+        ddbMock.commandCalls(UpdateCommand)[0]?.args[0].input.ExpressionAttributeValues?.[':max'],
+        1
+      )
     })
 
     it('enforces a custom maxTxCodeAttempts in the gate condition', async () => {

--- a/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
+++ b/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
@@ -1,11 +1,6 @@
 import assert from 'node:assert/strict'
 import { afterEach, describe, it } from 'node:test'
-import {
-  DeleteCommand,
-  DynamoDBDocumentClient,
-  GetCommand,
-  PutCommand,
-} from '@aws-sdk/lib-dynamodb'
+import { DeleteCommand, DynamoDBDocumentClient, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import { CredentialConfigurationId, PreAuthorizedCode } from '@trustknots/vcknots'
 import { mockClient } from 'aws-sdk-client-mock'
 import { dynamodbPreAuthorizedCodeStore } from '../src/providers/dynamodb-pre-authorized-code-store.provider'
@@ -15,25 +10,38 @@ const ddbMock = mockClient(DynamoDBDocumentClient)
 
 const configurations: CredentialConfigurationId[] = [CredentialConfigurationId('University_Degree')]
 
+const conditionalCheckFailed = () =>
+  Object.assign(new Error('conditional check failed'), {
+    name: 'ConditionalCheckFailedException',
+  })
+
 describe('dynamodbPreAuthorizedCodeStore', () => {
   afterEach(() => {
     ddbMock.reset()
   })
 
-  const createProvider = (expiresIn?: number) =>
+  const createProvider = (expiresIn?: number, maxTxCodeAttempts?: number) =>
     dynamodbPreAuthorizedCodeStore({
       client: ddbMock as unknown as DynamoDBDocumentClient,
       tableName: TABLE_NAME,
       ...(expiresIn !== undefined && { expiresIn }),
+      ...(maxTxCodeAttempts !== undefined && { maxTxCodeAttempts }),
     })
 
   /** Grab the Item written by the most recent PutCommand. */
   const lastPutItem = () => ddbMock.commandCalls(PutCommand).at(-1)?.args[0].input.Item
 
-  /** Wire GetCommand to return whatever the last save persisted. */
-  const armGetFromLastPut = () => {
-    ddbMock.on(GetCommand).resolves({ Item: lastPutItem() })
+  /**
+   * Wire the count-first consume gate: the UpdateCommand (ReturnValues ALL_NEW) returns the
+   * item that would exist, with the given attempt count. Defaults to the last saved item.
+   */
+  const armConsume = (item: Record<string, unknown> | undefined, attempts = 1) => {
+    ddbMock.on(UpdateCommand).resolves(item === undefined ? {} : { Attributes: { ...item, attempts } })
   }
+  const armConsumeFromLastPut = (attempts = 1) =>
+    armConsume(lastPutItem() as Record<string, unknown>, attempts)
+  /** Wire the gate to reject the attempt (code not found, consumed, or locked out). */
+  const armConsumeRejected = () => ddbMock.on(UpdateCommand).rejects(conditionalCheckFailed())
 
   it('should have correct provider metadata', () => {
     const provider = createProvider()
@@ -48,7 +56,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
 
     const provider = createProvider()
     await provider.save(PreAuthorizedCode('code-123'), configurations)
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     const result = await provider.consume(PreAuthorizedCode('code-123'))
     assert.deepEqual(result, configurations)
@@ -63,7 +71,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     await provider.save(PreAuthorizedCode('code-numeric'), configurations, 123, {
       tx_code_input_mode: 'numeric',
     })
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     const result = await provider.consume(PreAuthorizedCode('code-numeric'), 123)
     assert.deepEqual(result, configurations)
@@ -77,7 +85,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     await provider.save(PreAuthorizedCode('code-text'), configurations, 'abc123', {
       tx_code_input_mode: 'text',
     })
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     const result = await provider.consume(PreAuthorizedCode('code-text'), 'abc123')
     assert.deepEqual(result, configurations)
@@ -90,7 +98,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     await provider.save(PreAuthorizedCode('code-wrong'), configurations, 123, {
       tx_code_input_mode: 'numeric',
     })
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     await assert.rejects(provider.consume(PreAuthorizedCode('code-wrong'), 456), {
       name: 'invalid_grant',
@@ -105,7 +113,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     await provider.save(PreAuthorizedCode('code-type'), configurations, 123, {
       tx_code_input_mode: 'numeric',
     })
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     const result = await provider.consume(PreAuthorizedCode('code-type'), '123')
     assert.deepEqual(result, configurations)
@@ -118,7 +126,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     await provider.save(PreAuthorizedCode('code-invalid-num'), configurations, 123, {
       tx_code_input_mode: 'numeric',
     })
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     await assert.rejects(provider.consume(PreAuthorizedCode('code-invalid-num'), '12a3'), {
       name: 'invalid_grant',
@@ -133,7 +141,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     await provider.save(PreAuthorizedCode('code-leading-zero'), configurations, '0123', {
       tx_code_input_mode: 'numeric',
     })
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     const result = await provider.consume(PreAuthorizedCode('code-leading-zero'), '0123')
     assert.deepEqual(result, configurations)
@@ -146,7 +154,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     await provider.save(PreAuthorizedCode('code-leading-zero-mismatch'), configurations, '0123', {
       tx_code_input_mode: 'numeric',
     })
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     await assert.rejects(provider.consume(PreAuthorizedCode('code-leading-zero-mismatch'), 123), {
       name: 'invalid_grant',
@@ -172,7 +180,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     await provider.save(PreAuthorizedCode('code-requires-tx'), configurations, 123, {
       tx_code_input_mode: 'numeric',
     })
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     await assert.rejects(provider.consume(PreAuthorizedCode('code-requires-tx')), {
       name: 'invalid_request',
@@ -184,7 +192,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
 
     const provider = createProvider()
     await provider.save(PreAuthorizedCode('code-no-tx'), configurations)
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     await assert.rejects(provider.consume(PreAuthorizedCode('code-no-tx'), 123), {
       name: 'invalid_request',
@@ -305,7 +313,8 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
   })
 
   it('should throw invalid_grant when the code is unknown', async () => {
-    ddbMock.on(GetCommand).resolves({})
+    // The count-first gate rejects (attribute_exists(id) fails) when the code doesn't exist.
+    armConsumeRejected()
 
     const provider = createProvider()
     await assert.rejects(provider.consume(PreAuthorizedCode('unknown')), {
@@ -315,9 +324,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
 
   it('should throw invalid_grant and delete when the code is expired', async () => {
     const pastExpiry = Date.now() - 1000
-    ddbMock.on(GetCommand).resolves({
-      Item: { id: 'expired', credential_configuration_ids: configurations, expires_at: pastExpiry },
-    })
+    armConsume({ id: 'expired', credential_configuration_ids: configurations, expires_at: pastExpiry })
     ddbMock.on(DeleteCommand).resolves({})
 
     const provider = createProvider()
@@ -328,9 +335,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
   })
 
   it('should throw invalid_grant when expires_at is missing', async () => {
-    ddbMock.on(GetCommand).resolves({
-      Item: { id: 'no-exp', credential_configuration_ids: configurations },
-    })
+    armConsume({ id: 'no-exp', credential_configuration_ids: configurations })
     ddbMock.on(DeleteCommand).resolves({})
 
     const provider = createProvider()
@@ -345,7 +350,7 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
 
     const provider = createProvider()
     await provider.save(PreAuthorizedCode('consume-delete'), configurations)
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     await provider.consume(PreAuthorizedCode('consume-delete'))
 
@@ -357,18 +362,92 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
 
   it('should surface a lost delete race as invalid_grant (double consume)', async () => {
     ddbMock.on(PutCommand).resolves({})
-    ddbMock.on(DeleteCommand).rejects(
-      Object.assign(new Error('conditional check failed'), {
-        name: 'ConditionalCheckFailedException',
-      })
-    )
+    ddbMock.on(DeleteCommand).rejects(conditionalCheckFailed())
 
     const provider = createProvider()
     await provider.save(PreAuthorizedCode('race'), configurations)
-    armGetFromLastPut()
+    armConsumeFromLastPut()
 
     await assert.rejects(provider.consume(PreAuthorizedCode('race')), {
       name: 'invalid_grant',
+    })
+  })
+
+  describe('tx_code brute-force lockout (count-first gate)', () => {
+    const saveWithTxCode = async (provider: ReturnType<typeof createProvider>, code: string) => {
+      await provider.save(PreAuthorizedCode(code), configurations, 1234, {
+        tx_code_input_mode: 'numeric',
+      })
+    }
+
+    it('gates each attempt with an atomic, capped ADD before comparing tx_code', async () => {
+      ddbMock.on(PutCommand).resolves({})
+
+      const provider = createProvider()
+      await saveWithTxCode(provider, 'bf-gate')
+      armConsumeFromLastPut(1)
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-gate'), 9999), {
+        name: 'invalid_grant',
+      })
+
+      const upd = ddbMock.commandCalls(UpdateCommand)[0]?.args[0].input
+      assert.equal(upd?.UpdateExpression, 'ADD #attempts :one')
+      assert.equal(
+        upd?.ConditionExpression,
+        'attribute_exists(id) AND (attribute_not_exists(#attempts) OR #attempts < :max)'
+      )
+      assert.deepEqual(upd?.ExpressionAttributeNames, { '#attempts': 'attempts' })
+      // Default limit of 5 is enforced atomically in the condition.
+      assert.equal(upd?.ExpressionAttributeValues?.[':max'], 5)
+      assert.deepEqual(upd?.Key, { id: 'bf-gate' })
+    })
+
+    it('rejects a locked/exhausted code before comparing the tx_code', async () => {
+      ddbMock.on(PutCommand).resolves({})
+      // Gate fails: the code is over the attempt limit (or gone) — DynamoDB rejects the ADD.
+      armConsumeRejected()
+
+      const provider = createProvider()
+      await saveWithTxCode(provider, 'bf-locked')
+
+      // Even the correct PIN is rejected once the code is locked.
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-locked'), 1234), {
+        name: 'invalid_grant',
+      })
+      // The tx_code is never compared, and nothing is consumed.
+      assert.equal(ddbMock.commandCalls(DeleteCommand).length, 0)
+    })
+
+    it('enforces a custom maxTxCodeAttempts in the gate condition', async () => {
+      ddbMock.on(PutCommand).resolves({})
+
+      const provider = createProvider(undefined, 2)
+      await saveWithTxCode(provider, 'bf-custom')
+      armConsumeFromLastPut(1)
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-custom'), 9999), {
+        name: 'invalid_grant',
+      })
+      assert.equal(
+        ddbMock.commandCalls(UpdateCommand)[0]?.args[0].input.ExpressionAttributeValues?.[':max'],
+        2
+      )
+    })
+
+    it('admits and consumes the correct tx_code through the same gate', async () => {
+      ddbMock.on(PutCommand).resolves({})
+      ddbMock.on(DeleteCommand).resolves({})
+
+      const provider = createProvider()
+      await saveWithTxCode(provider, 'bf-ok')
+      armConsumeFromLastPut(1)
+
+      const result = await provider.consume(PreAuthorizedCode('bf-ok'), 1234)
+      assert.deepEqual(result, configurations)
+      // Exactly one gated increment, then a conditional delete on success.
+      assert.equal(ddbMock.commandCalls(UpdateCommand).length, 1)
+      assert.equal(ddbMock.commandCalls(DeleteCommand).length, 1)
     })
   })
 })

--- a/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
+++ b/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
@@ -435,6 +435,55 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
       )
     })
 
+    it('keeps the code while attempts remain below the limit', async () => {
+      ddbMock.on(PutCommand).resolves({})
+      ddbMock.on(DeleteCommand).resolves({})
+
+      const provider = createProvider()
+      await saveWithTxCode(provider, 'bf-under')
+      // 1st of the 5 allowed attempts.
+      armConsumeFromLastPut(1)
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-under'), 9999), {
+        name: 'invalid_grant',
+      })
+      // Attempts remain, so the code stays available for the legitimate holder.
+      assert.equal(ddbMock.commandCalls(DeleteCommand).length, 0)
+    })
+
+    it('deletes the code once a failed attempt exhausts the limit', async () => {
+      ddbMock.on(PutCommand).resolves({})
+      ddbMock.on(DeleteCommand).resolves({})
+
+      const provider = createProvider()
+      await saveWithTxCode(provider, 'bf-exhaust')
+      // The gate admits the 5th (final) attempt, which then fails the tx_code check.
+      armConsumeFromLastPut(5)
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-exhaust'), 9999), {
+        name: 'invalid_grant',
+      })
+      // A locked-out code is removed rather than left to linger until its TTL.
+      assert.equal(ddbMock.commandCalls(DeleteCommand).length, 1)
+      const del = ddbMock.commandCalls(DeleteCommand)[0]?.args[0].input
+      assert.deepEqual(del?.Key, { id: 'bf-exhaust' })
+      assert.equal(del?.ConditionExpression, undefined)
+    })
+
+    it('deletes the code when a custom maxTxCodeAttempts is exhausted', async () => {
+      ddbMock.on(PutCommand).resolves({})
+      ddbMock.on(DeleteCommand).resolves({})
+
+      const provider = createProvider(undefined, 2)
+      await saveWithTxCode(provider, 'bf-custom-exhaust')
+      armConsumeFromLastPut(2)
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-custom-exhaust'), 9999), {
+        name: 'invalid_grant',
+      })
+      assert.equal(ddbMock.commandCalls(DeleteCommand).length, 1)
+    })
+
     it('admits and consumes the correct tx_code through the same gate', async () => {
       ddbMock.on(PutCommand).resolves({})
       ddbMock.on(DeleteCommand).resolves({})

--- a/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
+++ b/aws/test/dynamodb-pre-authorized-code-store.provider.spec.ts
@@ -299,27 +299,35 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
     assert.ok(expiresAt <= after + 300 * 1000)
   })
 
-  // A non-finite expiresIn is the fallback that save() itself relies on, so it has to
-  // resolve to the default — otherwise NaN reaches DynamoDB as `expires_at` / `ttl`.
-  for (const [label, value] of [
-    ['NaN', Number.NaN],
-    ['Infinity', Number.POSITIVE_INFINITY],
-  ] as const) {
-    it(`should fall back to the default ttl when expiresIn is ${label}`, async () => {
-      ddbMock.on(PutCommand).resolves({})
-      const before = Date.now()
+  it('should fall back to the default ttl when expiresIn is NaN', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Date.now()
 
-      const provider = createProvider(value)
-      await provider.save(PreAuthorizedCode(`exp-${label}`), configurations, undefined)
+    const provider = createProvider(Number.NaN)
+    await provider.save(PreAuthorizedCode('exp-nan'), configurations, undefined)
 
-      const after = Date.now()
-      const item = lastPutItem()
-      assert.ok(Number.isFinite(item?.expires_at), 'expires_at must never be NaN')
-      assert.ok(Number.isFinite(item?.ttl), 'ttl must never be NaN')
-      assert.ok(item?.expires_at >= before + 300 * 1000)
-      assert.ok(item?.expires_at <= after + 300 * 1000)
-    })
-  }
+    const after = Date.now()
+    const item = lastPutItem()
+    assert.ok(Number.isFinite(item?.expires_at))
+    assert.ok(Number.isFinite(item?.ttl))
+    assert.ok(item?.expires_at >= before + 300 * 1000)
+    assert.ok(item?.expires_at <= after + 300 * 1000)
+  })
+
+  it('should fall back to the default ttl when expiresIn is Infinity', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Date.now()
+
+    const provider = createProvider(Number.POSITIVE_INFINITY)
+    await provider.save(PreAuthorizedCode('exp-inf'), configurations, undefined)
+
+    const after = Date.now()
+    const item = lastPutItem()
+    assert.ok(Number.isFinite(item?.expires_at))
+    assert.ok(Number.isFinite(item?.ttl))
+    assert.ok(item?.expires_at >= before + 300 * 1000)
+    assert.ok(item?.expires_at <= after + 300 * 1000)
+  })
 
   it('should floor a fractional ttlSec', async () => {
     ddbMock.on(PutCommand).resolves({})
@@ -445,28 +453,39 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
       assert.equal(ddbMock.commandCalls(DeleteCommand).length, 0)
     })
 
-    // A non-finite limit would otherwise reach DynamoDB as `:max` and fail every consume.
-    for (const [label, value] of [
-      ['NaN', Number.NaN],
-      ['Infinity', Number.POSITIVE_INFINITY],
-    ] as const) {
-      it(`falls back to the default limit when maxTxCodeAttempts is ${label}`, async () => {
-        ddbMock.on(PutCommand).resolves({})
+    it('falls back to the default limit when maxTxCodeAttempts is NaN', async () => {
+      ddbMock.on(PutCommand).resolves({})
 
-        const provider = createProvider(undefined, value)
-        await saveWithTxCode(provider, `bf-${label}`)
-        armConsumeFromLastPut(1)
+      const provider = createProvider(undefined, Number.NaN)
+      await saveWithTxCode(provider, 'bf-nan')
+      armConsumeFromLastPut(1)
 
-        await assert.rejects(provider.consume(PreAuthorizedCode(`bf-${label}`), 9999), {
-          name: 'invalid_grant',
-          message: INVALID_TX_CODE_MESSAGE,
-        })
-        assert.equal(
-          ddbMock.commandCalls(UpdateCommand)[0]?.args[0].input.ExpressionAttributeValues?.[':max'],
-          5
-        )
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-nan'), 9999), {
+        name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
       })
-    }
+      assert.equal(
+        ddbMock.commandCalls(UpdateCommand)[0]?.args[0].input.ExpressionAttributeValues?.[':max'],
+        5
+      )
+    })
+
+    it('falls back to the default limit when maxTxCodeAttempts is Infinity', async () => {
+      ddbMock.on(PutCommand).resolves({})
+
+      const provider = createProvider(undefined, Number.POSITIVE_INFINITY)
+      await saveWithTxCode(provider, 'bf-inf')
+      armConsumeFromLastPut(1)
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-inf'), 9999), {
+        name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
+      })
+      assert.equal(
+        ddbMock.commandCalls(UpdateCommand)[0]?.args[0].input.ExpressionAttributeValues?.[':max'],
+        5
+      )
+    })
 
     it('clamps a maxTxCodeAttempts below 1 up to a single attempt', async () => {
       ddbMock.on(PutCommand).resolves({})
@@ -506,10 +525,8 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
 
       const provider = createProvider()
       await saveWithTxCode(provider, 'bf-under')
-      // 1st of the 5 allowed attempts.
       armConsumeFromLastPut(1)
 
-      // Attempts remain, so the holder is told what was actually wrong and can retry.
       await assert.rejects(provider.consume(PreAuthorizedCode('bf-under'), 9999), {
         name: 'invalid_grant',
         message: INVALID_TX_CODE_MESSAGE,
@@ -523,16 +540,12 @@ describe('dynamodbPreAuthorizedCodeStore', () => {
 
       const provider = createProvider()
       await saveWithTxCode(provider, 'bf-exhaust')
-      // The gate admits the 5th (final) attempt, which then fails the tx_code check.
       armConsumeFromLastPut(5)
 
-      // The lockout is reported on the attempt that trips it — not `Invalid tx_code`,
-      // which would invite a retry that can no longer succeed.
       await assert.rejects(provider.consume(PreAuthorizedCode('bf-exhaust'), 9999), {
         name: 'invalid_grant',
         message: LOCKED_MESSAGE,
       })
-      // A locked-out code is removed rather than left to linger until its TTL.
       assert.equal(ddbMock.commandCalls(DeleteCommand).length, 1)
       const del = ddbMock.commandCalls(DeleteCommand)[0]?.args[0].input
       assert.deepEqual(del?.Key, { id: 'bf-exhaust' })

--- a/aws/test/dynamodb-request-object-store.provider.spec.ts
+++ b/aws/test/dynamodb-request-object-store.provider.spec.ts
@@ -40,7 +40,7 @@ describe('dynamodbRequestObjectStore', () => {
   })
 
   it('should save and fetch a request object', async () => {
-    const futureExpiry = Math.floor(Date.now() / 1000) + 300
+    const futureExpiry = Date.now() + 300 * 1000
     ddbMock.on(PutCommand).resolves({})
     ddbMock.on(GetCommand).resolves({
       Item: { id: requestObjectId, requestObject, expires_at: futureExpiry },
@@ -65,7 +65,7 @@ describe('dynamodbRequestObjectStore', () => {
   })
 
   it('should return null when the item is expired', async () => {
-    const pastExpiry = Math.floor(Date.now() / 1000) - 1
+    const pastExpiry = Date.now() - 1000
     ddbMock.on(GetCommand).resolves({
       Item: { id: requestObjectId, requestObject, expires_at: pastExpiry },
     })
@@ -87,22 +87,25 @@ describe('dynamodbRequestObjectStore', () => {
     assert.equal(fetched, null)
   })
 
-  it('should save with correct table name and expires_at', async () => {
+  it('should save with epoch-ms expires_at and epoch-seconds ttl', async () => {
     ddbMock.on(PutCommand).resolves({})
-    const before = Math.floor(Date.now() / 1000)
+    const before = Date.now()
 
     const provider = createProvider()
     await provider.save(requestObjectId, requestObject)
 
-    const after = Math.floor(Date.now() / 1000)
+    const after = Date.now()
     const putCall = ddbMock.commandCalls(PutCommand)[0]
     const item = putCall?.args[0].input.Item
 
     assert.equal(putCall?.args[0].input.TableName, TABLE_NAME)
     assert.equal(item?.id, requestObjectId)
     assert.deepEqual(item?.requestObject, requestObject)
-    assert.ok(item?.expires_at >= before + 300)
-    assert.ok(item?.expires_at <= after + 300)
+    // expires_at is epoch ms (parity with Firestore / in-memory).
+    assert.ok(item?.expires_at >= before + 300 * 1000)
+    assert.ok(item?.expires_at <= after + 300 * 1000)
+    // ttl is epoch seconds, rounded up so TTL never fires before the real (ms) expiry.
+    assert.equal(item?.ttl, Math.ceil(item?.expires_at / 1000))
   })
 
   it('should delete a request object', async () => {

--- a/aws/test/dynamodb-request-object-store.provider.spec.ts
+++ b/aws/test/dynamodb-request-object-store.provider.spec.ts
@@ -108,6 +108,36 @@ describe('dynamodbRequestObjectStore', () => {
     assert.equal(item?.ttl, Math.ceil(item?.expires_at / 1000))
   })
 
+  it('should fall back to the default ttl when expiresIn is NaN', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Date.now()
+
+    const provider = createProvider(Number.NaN)
+    await provider.save(requestObjectId, requestObject)
+
+    const after = Date.now()
+    const item = ddbMock.commandCalls(PutCommand)[0]?.args[0].input.Item
+    assert.ok(Number.isFinite(item?.expires_at))
+    assert.ok(Number.isFinite(item?.ttl))
+    assert.ok(item?.expires_at >= before + 300 * 1000)
+    assert.ok(item?.expires_at <= after + 300 * 1000)
+  })
+
+  it('should fall back to the default ttl when expiresIn is Infinity', async () => {
+    ddbMock.on(PutCommand).resolves({})
+    const before = Date.now()
+
+    const provider = createProvider(Number.POSITIVE_INFINITY)
+    await provider.save(requestObjectId, requestObject)
+
+    const after = Date.now()
+    const item = ddbMock.commandCalls(PutCommand)[0]?.args[0].input.Item
+    assert.ok(Number.isFinite(item?.expires_at))
+    assert.ok(Number.isFinite(item?.ttl))
+    assert.ok(item?.expires_at >= before + 300 * 1000)
+    assert.ok(item?.expires_at <= after + 300 * 1000)
+  })
+
   it('should delete a request object', async () => {
     ddbMock.on(DeleteCommand).resolves({})
 

--- a/server/aws/README.ja.md
+++ b/server/aws/README.ja.md
@@ -78,9 +78,8 @@ cp .env.example .env
 | `TX_CODE_PEPPER` | 全サーバー **必須** | `tx_code` を DynamoDB に保存する前に HMAC ハッシュ化するための秘密 pepper |
 | `ISSUERS_TABLE_NAME` | Issuer **必須** | DynamoDB テーブル名（スタック出力: `IssuersTableName`） |
 | `NONCES_TABLE_NAME` | Issuer **必須** | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
-| `PRE_CODES_TABLE_NAME` | Issuer **必須** | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
+| `PRE_CODES_TABLE_NAME` | Issuer・Authz **必須** | DynamoDB テーブル名（Issuer/Authz 共通、スタック出力: `PreCodesTableName`） |
 | `AUTH_SERVERS_TABLE_NAME` | Authz **必須** | DynamoDB テーブル名（スタック出力: `AuthServersTableName`） |
-| `PRE_CODES_TABLE_NAME` | Authz **必須** | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
 | `VERIFIERS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `VerifiersTableName`） |
 | `REQUEST_OBJECTS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `RequestObjectsTableName`） |
 | `NONCES_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |

--- a/server/aws/README.ja.md
+++ b/server/aws/README.ja.md
@@ -75,11 +75,12 @@ cp .env.example .env
 |---|---|---|
 | `AWS_REGION` | Issuer | DynamoDB テーブルがデプロイされている AWS リージョン（例: `ap-northeast-1`） |
 | `AWS_PROFILE` | Issuer（任意） | 使用する AWS プロファイル（省略時はデフォルトを使用） |
+| `TX_CODE_PEPPER` | 全サーバー **必須** | `tx_code` を DynamoDB に保存する前に HMAC ハッシュ化するための秘密 pepper |
 | `ISSUERS_TABLE_NAME` | Issuer **必須** | DynamoDB テーブル名（スタック出力: `IssuersTableName`） |
 | `NONCES_TABLE_NAME` | Issuer（任意） | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
-| `PRE_CODES_TABLE_NAME` | Issuer（任意） | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
+| `PRE_CODES_TABLE_NAME` | Issuer **必須** | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
 | `AUTH_SERVERS_TABLE_NAME` | Authz **必須** | DynamoDB テーブル名（スタック出力: `AuthServersTableName`） |
-| `PRE_CODES_TABLE_NAME` | Authz（任意） | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
+| `PRE_CODES_TABLE_NAME` | Authz **必須** | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
 | `VERIFIERS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `VerifiersTableName`） |
 | `REQUEST_OBJECTS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `RequestObjectsTableName`） |
 | `NONCES_TABLE_NAME` | Verifier（任意） | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
@@ -90,7 +91,9 @@ cp .env.example .env
 | `VERIFIER_PORT` | Verifier（任意） | Verifier のリッスンポートを上書き（デフォルト: `8083`） |
 | `VERIFIER_BASE_URL` | Verifier（任意） | Verifier メタデータで使用するベース URL を上書き（デフォルト: `http://localhost:{VERIFIER_PORT}`） |
 
-**`ISSUERS_TABLE_NAME`・`AUTH_SERVERS_TABLE_NAME`・`VERIFIERS_TABLE_NAME`・`REQUEST_OBJECTS_TABLE_NAME` は必須**です。未設定の場合、該当サーバーは起動時に終了します。
+**`ISSUERS_TABLE_NAME`・`PRE_CODES_TABLE_NAME`（Issuer・Authz）・`AUTH_SERVERS_TABLE_NAME`・`VERIFIERS_TABLE_NAME`・`REQUEST_OBJECTS_TABLE_NAME` は必須**です。必要なテーブル名が未設定の場合、該当サーバーは起動時に終了します。
+
+**`TX_CODE_PEPPER` は全サーバーで必須**です。`tx_code` を DynamoDB に保存する前に HMAC-SHA256 でハッシュ化するための秘密値（pepper）です。`@trustknots/aws` は import 時にこの値を評価するため、未設定の場合は Issuer・Authorization Server・Verifier のいずれも起動時に `TX_CODE_PEPPER environment variable is required` でエラーになります。十分に長いランダム文字列を設定し、環境ごとに固定して運用してください（変更すると既存データの `tx_code` 検証に失敗します）。
 
 ## サーバーの起動
 

--- a/server/aws/README.ja.md
+++ b/server/aws/README.ja.md
@@ -76,13 +76,13 @@ cp .env.example .env
 | `AWS_REGION` | Issuer | DynamoDB テーブルがデプロイされている AWS リージョン（例: `ap-northeast-1`） |
 | `AWS_PROFILE` | Issuer（任意） | 使用する AWS プロファイル（省略時はデフォルトを使用） |
 | `ISSUERS_TABLE_NAME` | Issuer **必須** | DynamoDB テーブル名（スタック出力: `IssuersTableName`） |
-| `NONCES_TABLE_NAME` | Issuer（任意） | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
+| `NONCES_TABLE_NAME` | Issuer **必須** | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
 | `PRE_CODES_TABLE_NAME` | Issuer（任意） | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
 | `AUTH_SERVERS_TABLE_NAME` | Authz **必須** | DynamoDB テーブル名（スタック出力: `AuthServersTableName`） |
 | `PRE_CODES_TABLE_NAME` | Authz（任意） | DynamoDB テーブル名（スタック出力: `PreCodesTableName`） |
 | `VERIFIERS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `VerifiersTableName`） |
 | `REQUEST_OBJECTS_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `RequestObjectsTableName`） |
-| `NONCES_TABLE_NAME` | Verifier（任意） | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
+| `NONCES_TABLE_NAME` | Verifier **必須** | DynamoDB テーブル名（スタック出力: `NoncesTableName`） |
 | `ISSUER_PORT` | Issuer（任意） | Issuer のリッスンポートを上書き（デフォルト: `8081`） |
 | `ISSUER_BASE_URL` | Issuer（任意） | Issuer メタデータで使用するベース URL を上書き（デフォルト: `http://localhost:{ISSUER_PORT}`） |
 | `AUTHZ_PORT` | Authz（任意） | Authorization Server のリッスンポートを上書き（デフォルト: `8082`） |
@@ -90,7 +90,7 @@ cp .env.example .env
 | `VERIFIER_PORT` | Verifier（任意） | Verifier のリッスンポートを上書き（デフォルト: `8083`） |
 | `VERIFIER_BASE_URL` | Verifier（任意） | Verifier メタデータで使用するベース URL を上書き（デフォルト: `http://localhost:{VERIFIER_PORT}`） |
 
-**`ISSUERS_TABLE_NAME`・`AUTH_SERVERS_TABLE_NAME`・`VERIFIERS_TABLE_NAME`・`REQUEST_OBJECTS_TABLE_NAME` は必須**です。未設定の場合、該当サーバーは起動時に終了します。
+**`ISSUERS_TABLE_NAME`・`AUTH_SERVERS_TABLE_NAME`・`VERIFIERS_TABLE_NAME`・`REQUEST_OBJECTS_TABLE_NAME`・`NONCES_TABLE_NAME`（Issuer と Verifier）は必須**です。未設定の場合、該当サーバーは起動時に終了します。
 
 ## サーバーの起動
 

--- a/server/aws/README.md
+++ b/server/aws/README.md
@@ -75,11 +75,12 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 |---|---|---|
 | `AWS_REGION` | Issuer | AWS region where DynamoDB tables are deployed (e.g. `ap-northeast-1`) |
 | `AWS_PROFILE` | Issuer (optional) | AWS profile to use (omit to use the default) |
+| `TX_CODE_PEPPER` | All **required** | Secret pepper used to HMAC-hash `tx_code` before storing it in DynamoDB |
 | `ISSUERS_TABLE_NAME` | Issuer **required** | DynamoDB table name (stack output: `IssuersTableName`) |
 | `NONCES_TABLE_NAME` | Issuer (optional) | DynamoDB table name (stack output: `NoncesTableName`) |
-| `PRE_CODES_TABLE_NAME` | Issuer (optional) | DynamoDB table name (stack output: `PreCodesTableName`) |
+| `PRE_CODES_TABLE_NAME` | Issuer **required** | DynamoDB table name (stack output: `PreCodesTableName`) |
 | `AUTH_SERVERS_TABLE_NAME` | Authz **required** | DynamoDB table name (stack output: `AuthServersTableName`) |
-| `PRE_CODES_TABLE_NAME` | Authz (optional) | DynamoDB table name (stack output: `PreCodesTableName`) |
+| `PRE_CODES_TABLE_NAME` | Authz **required** | DynamoDB table name (stack output: `PreCodesTableName`) |
 | `VERIFIERS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `VerifiersTableName`) |
 | `REQUEST_OBJECTS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `RequestObjectsTableName`) |
 | `NONCES_TABLE_NAME` | Verifier (optional) | DynamoDB table name (stack output: `NoncesTableName`) |
@@ -90,7 +91,9 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 | `VERIFIER_PORT` | Verifier (optional) | Override the Verifier listening port (default: `8083`) |
 | `VERIFIER_BASE_URL` | Verifier (optional) | Override the base URL used in Verifier metadata (default: `http://localhost:{VERIFIER_PORT}`) |
 
-**`ISSUERS_TABLE_NAME`, `AUTH_SERVERS_TABLE_NAME`, `VERIFIERS_TABLE_NAME`, and `REQUEST_OBJECTS_TABLE_NAME` are required** — each server exits at startup if its table name is missing.
+**`ISSUERS_TABLE_NAME`, `PRE_CODES_TABLE_NAME` (Issuer & Authz), `AUTH_SERVERS_TABLE_NAME`, `VERIFIERS_TABLE_NAME`, and `REQUEST_OBJECTS_TABLE_NAME` are required** — each server exits at startup if a table name it needs is missing.
+
+**`TX_CODE_PEPPER` is required by every server.** It is a secret pepper used to HMAC-hash `tx_code` values before storing them in DynamoDB. Because `@trustknots/aws` evaluates it at import time, the Issuer, Authorization Server, and Verifier all fail at startup with `TX_CODE_PEPPER environment variable is required` when it is missing. Use a sufficiently long random secret and keep it stable per environment — rotating it invalidates previously stored `tx_code` hashes.
 
 ## Start the Servers
 

--- a/server/aws/README.md
+++ b/server/aws/README.md
@@ -76,13 +76,13 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 | `AWS_REGION` | Issuer | AWS region where DynamoDB tables are deployed (e.g. `ap-northeast-1`) |
 | `AWS_PROFILE` | Issuer (optional) | AWS profile to use (omit to use the default) |
 | `ISSUERS_TABLE_NAME` | Issuer **required** | DynamoDB table name (stack output: `IssuersTableName`) |
-| `NONCES_TABLE_NAME` | Issuer (optional) | DynamoDB table name (stack output: `NoncesTableName`) |
+| `NONCES_TABLE_NAME` | Issuer **required** | DynamoDB table name (stack output: `NoncesTableName`) |
 | `PRE_CODES_TABLE_NAME` | Issuer (optional) | DynamoDB table name (stack output: `PreCodesTableName`) |
 | `AUTH_SERVERS_TABLE_NAME` | Authz **required** | DynamoDB table name (stack output: `AuthServersTableName`) |
 | `PRE_CODES_TABLE_NAME` | Authz (optional) | DynamoDB table name (stack output: `PreCodesTableName`) |
 | `VERIFIERS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `VerifiersTableName`) |
 | `REQUEST_OBJECTS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `RequestObjectsTableName`) |
-| `NONCES_TABLE_NAME` | Verifier (optional) | DynamoDB table name (stack output: `NoncesTableName`) |
+| `NONCES_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `NoncesTableName`) |
 | `ISSUER_PORT` | Issuer (optional) | Override the Issuer listening port (default: `8081`) |
 | `ISSUER_BASE_URL` | Issuer (optional) | Override the base URL used in Issuer metadata (default: `http://localhost:{ISSUER_PORT}`) |
 | `AUTHZ_PORT` | Authz (optional) | Override the Authorization Server listening port (default: `8082`) |
@@ -90,7 +90,7 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 | `VERIFIER_PORT` | Verifier (optional) | Override the Verifier listening port (default: `8083`) |
 | `VERIFIER_BASE_URL` | Verifier (optional) | Override the base URL used in Verifier metadata (default: `http://localhost:{VERIFIER_PORT}`) |
 
-**`ISSUERS_TABLE_NAME`, `AUTH_SERVERS_TABLE_NAME`, `VERIFIERS_TABLE_NAME`, and `REQUEST_OBJECTS_TABLE_NAME` are required** — each server exits at startup if its table name is missing.
+**`ISSUERS_TABLE_NAME`, `AUTH_SERVERS_TABLE_NAME`, `VERIFIERS_TABLE_NAME`, `REQUEST_OBJECTS_TABLE_NAME`, and `NONCES_TABLE_NAME` (Issuer and Verifier) are required** — each server exits at startup if its table name is missing.
 
 ## Start the Servers
 

--- a/server/aws/README.md
+++ b/server/aws/README.md
@@ -78,9 +78,8 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 | `TX_CODE_PEPPER` | All **required** | Secret pepper used to HMAC-hash `tx_code` before storing it in DynamoDB |
 | `ISSUERS_TABLE_NAME` | Issuer **required** | DynamoDB table name (stack output: `IssuersTableName`) |
 | `NONCES_TABLE_NAME` | Issuer **required** | DynamoDB table name (stack output: `NoncesTableName`) |
-| `PRE_CODES_TABLE_NAME` | Issuer **required** | DynamoDB table name (stack output: `PreCodesTableName`) |
+| `PRE_CODES_TABLE_NAME` | Issuer & Authz **required** | DynamoDB table name, shared by both servers (stack output: `PreCodesTableName`) |
 | `AUTH_SERVERS_TABLE_NAME` | Authz **required** | DynamoDB table name (stack output: `AuthServersTableName`) |
-| `PRE_CODES_TABLE_NAME` | Authz **required** | DynamoDB table name (stack output: `PreCodesTableName`) |
 | `VERIFIERS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `VerifiersTableName`) |
 | `REQUEST_OBJECTS_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `RequestObjectsTableName`) |
 | `NONCES_TABLE_NAME` | Verifier **required** | DynamoDB table name (stack output: `NoncesTableName`) |

--- a/server/aws/resources/README.ja.md
+++ b/server/aws/resources/README.ja.md
@@ -108,12 +108,12 @@ Issuer は `@trustknots/aws` の `dynamodbIssuerMetadataStore` を使用しま�
 |---|---|---|---|
 | IssuersTable | Issuer URL のハッシュ | なし | Credential Issuer メタデータ |
 | AuthServersTable | Authorization Server URL のハッシュ | なし | Authorization Server メタデータ |
-| PreCodesTable | Pre-Authorized Code 文字列 | あり（`expires_at`） | 発行時に使用する Pre-authorized code |
+| PreCodesTable | Pre-Authorized Code 文字列 | あり（`ttl`） | 発行時に使用する Pre-authorized code |
 | NoncesTable | Nonce 文字列 | あり（`ttl`） | リプレイ防止用 Nonce |
 | VerifiersTable | Verifier client ID のハッシュ | なし | Verifier メタデータ |
 | RequestObjectsTable | Request Object ID | あり（`ttl`） | VP リクエスト用 Request Object |
 
-`id` 以外の属性（メタデータ本体、`expires_at`、`ttl` など）はアプリケーションが書き込みます。NoncesTable / RequestObjectsTable では、`expires_at` はアプリケーションレベルの有効期限で **epoch ミリ秒**（Firestore / in-memory プロバイダと揃えた期限判定に使用）、`ttl` は DynamoDB TTL 専用の **epoch 秒**属性です。PreCodesTable は引き続き `expires_at`（秒）を TTL 属性として使用します。
+`id` 以外の属性（メタデータ本体、`expires_at`、`ttl` など）はアプリケーションが書き込みます。TTL を使うテーブル（PreCodesTable / NoncesTable / RequestObjectsTable）では、`expires_at` はアプリケーションレベルの有効期限で **epoch ミリ秒**（Firestore / in-memory プロバイダと揃えた期限判定に使用）、`ttl` は DynamoDB TTL 専用の **epoch 秒**属性です。
 
 ### IAM
 

--- a/server/aws/resources/README.ja.md
+++ b/server/aws/resources/README.ja.md
@@ -109,11 +109,11 @@ Issuer は `@trustknots/aws` の `dynamodbIssuerMetadataStore` を使用しま�
 | IssuersTable | Issuer URL のハッシュ | なし | Credential Issuer メタデータ |
 | AuthServersTable | Authorization Server URL のハッシュ | なし | Authorization Server メタデータ |
 | PreCodesTable | Pre-Authorized Code 文字列 | あり（`expires_at`） | 発行時に使用する Pre-authorized code |
-| NoncesTable | Nonce 文字列 | あり（`expires_at`） | リプレイ防止用 Nonce |
+| NoncesTable | Nonce 文字列 | あり（`ttl`） | リプレイ防止用 Nonce |
 | VerifiersTable | Verifier client ID のハッシュ | なし | Verifier メタデータ |
-| RequestObjectsTable | Request Object ID | あり（`expires_at`） | VP リクエスト用 Request Object |
+| RequestObjectsTable | Request Object ID | あり（`ttl`） | VP リクエスト用 Request Object |
 
-`id` 以外の属性（メタデータ本体、`expires_at` など）はアプリケーションが書き込みます。
+`id` 以外の属性（メタデータ本体、`expires_at`、`ttl` など）はアプリケーションが書き込みます。NoncesTable / RequestObjectsTable では、`expires_at` はアプリケーションレベルの有効期限で **epoch ミリ秒**（Firestore / in-memory プロバイダと揃えた期限判定に使用）、`ttl` は DynamoDB TTL 専用の **epoch 秒**属性です。PreCodesTable は引き続き `expires_at`（秒）を TTL 属性として使用します。
 
 ### IAM
 

--- a/server/aws/resources/README.md
+++ b/server/aws/resources/README.md
@@ -108,12 +108,12 @@ Billing is on-demand (`PAY_PER_REQUEST`). Tables use `RETAIN` on stack deletion 
 |---|---|---|---|
 | IssuersTable | Hash of Issuer URL | no | Credential Issuer metadata |
 | AuthServersTable | Hash of Authorization Server URL | no | Authorization Server metadata |
-| PreCodesTable | Pre-Authorized Code string | yes (`expires_at`) | Pre-authorized code used at issuance |
+| PreCodesTable | Pre-Authorized Code string | yes (`ttl`) | Pre-authorized code used at issuance |
 | NoncesTable | Nonce string | yes (`ttl`) | Nonce for replay protection |
 | VerifiersTable | Hash of Verifier client ID | no | Verifier metadata |
 | RequestObjectsTable | Request Object ID | yes (`ttl`) | VP request Request Object |
 
-Attributes other than `id` (metadata body, `expires_at`, `ttl`, and so on) are written by the application. For NoncesTable / RequestObjectsTable, `expires_at` is the application-level expiry in **epoch milliseconds** (used for expiry checks, matching the Firestore / in-memory providers) and `ttl` is a separate **epoch-seconds** attribute used only by DynamoDB TTL. PreCodesTable still uses `expires_at` (seconds) as its TTL attribute.
+Attributes other than `id` (metadata body, `expires_at`, `ttl`, and so on) are written by the application. For the TTL-enabled tables (PreCodesTable / NoncesTable / RequestObjectsTable), `expires_at` is the application-level expiry in **epoch milliseconds** (used for expiry checks, matching the Firestore / in-memory providers) and `ttl` is a separate **epoch-seconds** attribute used only by DynamoDB TTL.
 
 ### IAM
 

--- a/server/aws/resources/README.md
+++ b/server/aws/resources/README.md
@@ -109,11 +109,11 @@ Billing is on-demand (`PAY_PER_REQUEST`). Tables use `RETAIN` on stack deletion 
 | IssuersTable | Hash of Issuer URL | no | Credential Issuer metadata |
 | AuthServersTable | Hash of Authorization Server URL | no | Authorization Server metadata |
 | PreCodesTable | Pre-Authorized Code string | yes (`expires_at`) | Pre-authorized code used at issuance |
-| NoncesTable | Nonce string | yes (`expires_at`) | Nonce for replay protection |
+| NoncesTable | Nonce string | yes (`ttl`) | Nonce for replay protection |
 | VerifiersTable | Hash of Verifier client ID | no | Verifier metadata |
-| RequestObjectsTable | Request Object ID | yes (`expires_at`) | VP request Request Object |
+| RequestObjectsTable | Request Object ID | yes (`ttl`) | VP request Request Object |
 
-Attributes other than `id` (metadata body, `expires_at`, and so on) are written by the application.
+Attributes other than `id` (metadata body, `expires_at`, `ttl`, and so on) are written by the application. For NoncesTable / RequestObjectsTable, `expires_at` is the application-level expiry in **epoch milliseconds** (used for expiry checks, matching the Firestore / in-memory providers) and `ttl` is a separate **epoch-seconds** attribute used only by DynamoDB TTL. PreCodesTable still uses `expires_at` (seconds) as its TTL attribute.
 
 ### IAM
 

--- a/server/aws/resources/lib/construct/data/data-stores.ts
+++ b/server/aws/resources/lib/construct/data/data-stores.ts
@@ -33,14 +33,16 @@ export class DataStores extends Construct {
 
     this.noncesTable = new dynamodb.Table(this, 'NoncesTable', {
       ...baseTableProps,
-      timeToLiveAttribute: 'expires_at',
+      // `expires_at` is app-level epoch ms; DynamoDB TTL uses the epoch-seconds `ttl` attribute.
+      timeToLiveAttribute: 'ttl',
     });
 
     this.verifiersTable = new dynamodb.Table(this, 'VerifiersTable', baseTableProps);
 
     this.requestObjectsTable = new dynamodb.Table(this, 'RequestObjectsTable', {
       ...baseTableProps,
-      timeToLiveAttribute: 'expires_at',
+      // `expires_at` is app-level epoch ms; DynamoDB TTL uses the epoch-seconds `ttl` attribute.
+      timeToLiveAttribute: 'ttl',
     });
   }
 }

--- a/server/aws/resources/lib/construct/data/data-stores.ts
+++ b/server/aws/resources/lib/construct/data/data-stores.ts
@@ -28,7 +28,8 @@ export class DataStores extends Construct {
 
     this.preCodesTable = new dynamodb.Table(this, 'PreCodesTable', {
       ...baseTableProps,
-      timeToLiveAttribute: 'expires_at',
+      // `expires_at` is app-level epoch ms; DynamoDB TTL uses the epoch-seconds `ttl` attribute.
+      timeToLiveAttribute: 'ttl',
     });
 
     this.noncesTable = new dynamodb.Table(this, 'NoncesTable', {

--- a/server/aws/src/.env.example
+++ b/server/aws/src/.env.example
@@ -2,20 +2,25 @@
 # AWS_PROFILE=vc-knots
 AWS_REGION=ap-northeast-1
 
+# Required by every server (HMAC pepper for tx_code hashing in the pre-authorized code store)
+TX_CODE_PEPPER=<your-tx-code-pepper-here>
+
 # Issuer (default: start:issuer)
 # ISSUER_PORT=8081
 # ISSUER_BASE_URL=http://localhost:8081
 # Required for DynamoDB issuer metadata store (deploy output: IssuersTableName)
 ISSUERS_TABLE_NAME=ResourcesStack-DataStoresIssuersTableXXXXXXXX-XXXXXXXXXXXX
 # NONCES_TABLE_NAME=ResourcesStack-...
-# PRE_CODES_TABLE_NAME=ResourcesStack-...
+# Required for DynamoDB pre-authorized code store (deploy output: PreCodesTableName)
+PRE_CODES_TABLE_NAME=ResourcesStack-DataStoresPreCodesTableXXXXXXXX-XXXXXXXXXXXX
 
 # Authz (default: start:authz)
 # AUTHZ_PORT=8082
 # AUTHZ_BASE_URL=http://localhost:8082
 # Required for DynamoDB authz server metadata store (deploy output: AuthServersTableName)
 AUTH_SERVERS_TABLE_NAME=ResourcesStack-DataStoresAuthServersTableXXXXXXXX-XXXXXXXXXXXX
-# PRE_CODES_TABLE_NAME=ResourcesStack-...
+# Required for DynamoDB pre-authorized code store (deploy output: PreCodesTableName)
+PRE_CODES_TABLE_NAME=ResourcesStack-DataStoresPreCodesTableXXXXXXXX-XXXXXXXXXXXX
 
 # Verifier (default: start:verifier)
 # VERIFIER_PORT=8083

--- a/server/aws/src/.env.example
+++ b/server/aws/src/.env.example
@@ -12,7 +12,7 @@ TX_CODE_PEPPER=<your-tx-code-pepper-here>
 ISSUERS_TABLE_NAME=ResourcesStack-DataStoresIssuersTableXXXXXXXX-XXXXXXXXXXXX
 # Required for DynamoDB nonce store (deploy output: NoncesTableName)
 NONCES_TABLE_NAME=ResourcesStack-DataStoresNoncesTableXXXXXXXX-XXXXXXXXXXXX
-# Required for DynamoDB pre-authorized code store (deploy output: PreCodesTableName)
+# Required for DynamoDB pre-authorized code store — shared by Issuer & Authz (deploy output: PreCodesTableName)
 PRE_CODES_TABLE_NAME=ResourcesStack-DataStoresPreCodesTableXXXXXXXX-XXXXXXXXXXXX
 
 # Authz (default: start:authz)
@@ -20,8 +20,7 @@ PRE_CODES_TABLE_NAME=ResourcesStack-DataStoresPreCodesTableXXXXXXXX-XXXXXXXXXXXX
 # AUTHZ_BASE_URL=http://localhost:8082
 # Required for DynamoDB authz server metadata store (deploy output: AuthServersTableName)
 AUTH_SERVERS_TABLE_NAME=ResourcesStack-DataStoresAuthServersTableXXXXXXXX-XXXXXXXXXXXX
-# Required for DynamoDB pre-authorized code store (deploy output: PreCodesTableName)
-PRE_CODES_TABLE_NAME=ResourcesStack-DataStoresPreCodesTableXXXXXXXX-XXXXXXXXXXXX
+# PRE_CODES_TABLE_NAME is also required for the Authz server (same table as the Issuer; set above)
 
 # Verifier (default: start:verifier)
 # VERIFIER_PORT=8083

--- a/server/aws/src/.env.example
+++ b/server/aws/src/.env.example
@@ -7,7 +7,8 @@ AWS_REGION=ap-northeast-1
 # ISSUER_BASE_URL=http://localhost:8081
 # Required for DynamoDB issuer metadata store (deploy output: IssuersTableName)
 ISSUERS_TABLE_NAME=ResourcesStack-DataStoresIssuersTableXXXXXXXX-XXXXXXXXXXXX
-# NONCES_TABLE_NAME=ResourcesStack-...
+# Required for DynamoDB nonce store (deploy output: NoncesTableName)
+NONCES_TABLE_NAME=ResourcesStack-DataStoresNoncesTableXXXXXXXX-XXXXXXXXXXXX
 # PRE_CODES_TABLE_NAME=ResourcesStack-...
 
 # Authz (default: start:authz)
@@ -24,4 +25,4 @@ AUTH_SERVERS_TABLE_NAME=ResourcesStack-DataStoresAuthServersTableXXXXXXXX-XXXXXX
 VERIFIERS_TABLE_NAME=ResourcesStack-DataStoresVerifiersTableXXXXXXXX-XXXXXXXXXXXX
 # Required for DynamoDB request object store (deploy output: RequestObjectsTableName)
 REQUEST_OBJECTS_TABLE_NAME=ResourcesStack-DataStoresRequestObjectsTableXXXXXXXX-XXXXXXXXXXXX
-# NONCES_TABLE_NAME=ResourcesStack-...
+# NONCES_TABLE_NAME is also required for the Verifier (same table as the Issuer; set above)

--- a/server/aws/src/apps/create-authz-app.ts
+++ b/server/aws/src/apps/create-authz-app.ts
@@ -1,27 +1,33 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { dynamodbAuthzServerMetadataStore } from '@trustknots/aws'
+import { dynamodbAuthzServerMetadataStore, dynamodbPreAuthorizedCodeStore } from '@trustknots/aws'
 import { createAuthzRouter } from '@trustknots/server-core/routes/authz'
 import { AuthorizationServerIssuer, AuthorizationServerMetadata, initializeAuthzFlow } from '@trustknots/vcknots/authz'
 import type { VcknotsOptions } from '@trustknots/vcknots'
 import { createBaseApp } from './create-base-app.js'
 
 export function createAuthzApp(options?: VcknotsOptions) {
-  const tableName = process.env.AUTH_SERVERS_TABLE_NAME
-  if (!tableName) {
+  const authServersTableName = process.env.AUTH_SERVERS_TABLE_NAME
+  if (!authServersTableName) {
     throw new Error('AUTH_SERVERS_TABLE_NAME is required')
+  }
+
+  const preCodesTableName = process.env.PRE_CODES_TABLE_NAME
+  if (!preCodesTableName) {
+    throw new Error('PRE_CODES_TABLE_NAME is required')
   }
 
   const rawPort = process.env.AUTHZ_PORT ?? '8082'
   const port = Number.parseInt(rawPort, 10)
   if (!Number.isFinite(port)) throw new Error(`Invalid AUTHZ_PORT: "${rawPort}"`)
 
-  const store = dynamodbAuthzServerMetadataStore({ tableName })
+  const store = dynamodbAuthzServerMetadataStore({ tableName: authServersTableName })
+  const preAuthorizedCodeStore = dynamodbPreAuthorizedCodeStore({ tableName: preCodesTableName })
   const { app, context } = createBaseApp(
     createAuthzRouter,
     { port, baseUrl: process.env.AUTHZ_BASE_URL },
-    { ...options, providers: [store, ...(options?.providers ?? [])] },
+    { ...options, providers: [store, preAuthorizedCodeStore, ...(options?.providers ?? [])] },
   )
 
   async function initialize(baseUrl: string) {

--- a/server/aws/src/apps/create-issuer-app.ts
+++ b/server/aws/src/apps/create-issuer-app.ts
@@ -1,27 +1,33 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { dynamodbIssuerMetadataStore } from '@trustknots/aws'
+import { dynamodbIssuerMetadataStore, dynamodbNonceStore } from '@trustknots/aws'
 import { createIssueRouter } from '@trustknots/server-core/routes/issue'
 import { CredentialIssuer, CredentialIssuerMetadata, initializeIssuerFlow } from '@trustknots/vcknots/issuer'
 import type { VcknotsOptions } from '@trustknots/vcknots'
 import { createBaseApp } from './create-base-app.js'
 
 export function createIssuerApp(options?: VcknotsOptions) {
-  const tableName = process.env.ISSUERS_TABLE_NAME
-  if (!tableName) {
+  const issuersTableName = process.env.ISSUERS_TABLE_NAME
+  if (!issuersTableName) {
     throw new Error('ISSUERS_TABLE_NAME is required')
+  }
+
+  const noncesTableName = process.env.NONCES_TABLE_NAME
+  if (!noncesTableName) {
+    throw new Error('NONCES_TABLE_NAME is required')
   }
 
   const rawPort = process.env.ISSUER_PORT ?? '8081'
   const port = Number.parseInt(rawPort, 10)
   if (!Number.isFinite(port)) throw new Error(`Invalid ISSUER_PORT: "${rawPort}"`)
 
-  const store = dynamodbIssuerMetadataStore({ tableName })
+  const issuerMetadataStore = dynamodbIssuerMetadataStore({ tableName: issuersTableName })
+  const nonceStore = dynamodbNonceStore({ tableName: noncesTableName })
   const { app, context } = createBaseApp(
     createIssueRouter,
     { port, baseUrl: process.env.ISSUER_BASE_URL },
-    { ...options, providers: [store, ...(options?.providers ?? [])] },
+    { ...options, providers: [issuerMetadataStore, nonceStore, ...(options?.providers ?? [])] },
   )
 
   async function initialize(baseUrl: string) {

--- a/server/aws/src/apps/create-issuer-app.ts
+++ b/server/aws/src/apps/create-issuer-app.ts
@@ -1,27 +1,33 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { dynamodbIssuerMetadataStore } from '@trustknots/aws'
+import { dynamodbIssuerMetadataStore, dynamodbPreAuthorizedCodeStore } from '@trustknots/aws'
 import { createIssueRouter } from '@trustknots/server-core/routes/issue'
 import { CredentialIssuer, CredentialIssuerMetadata, initializeIssuerFlow } from '@trustknots/vcknots/issuer'
 import type { VcknotsOptions } from '@trustknots/vcknots'
 import { createBaseApp } from './create-base-app.js'
 
 export function createIssuerApp(options?: VcknotsOptions) {
-  const tableName = process.env.ISSUERS_TABLE_NAME
-  if (!tableName) {
+  const issuersTableName = process.env.ISSUERS_TABLE_NAME
+  if (!issuersTableName) {
     throw new Error('ISSUERS_TABLE_NAME is required')
+  }
+
+  const preCodesTableName = process.env.PRE_CODES_TABLE_NAME
+  if (!preCodesTableName) {
+    throw new Error('PRE_CODES_TABLE_NAME is required')
   }
 
   const rawPort = process.env.ISSUER_PORT ?? '8081'
   const port = Number.parseInt(rawPort, 10)
   if (!Number.isFinite(port)) throw new Error(`Invalid ISSUER_PORT: "${rawPort}"`)
 
-  const store = dynamodbIssuerMetadataStore({ tableName })
+  const store = dynamodbIssuerMetadataStore({ tableName: issuersTableName })
+  const preAuthorizedCodeStore = dynamodbPreAuthorizedCodeStore({ tableName: preCodesTableName })
   const { app, context } = createBaseApp(
     createIssueRouter,
     { port, baseUrl: process.env.ISSUER_BASE_URL },
-    { ...options, providers: [store, ...(options?.providers ?? [])] },
+    { ...options, providers: [store, preAuthorizedCodeStore, ...(options?.providers ?? [])] },
   )
 
   async function initialize(baseUrl: string) {

--- a/server/aws/src/apps/create-verifier-app.ts
+++ b/server/aws/src/apps/create-verifier-app.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { dynamodbRequestObjectStore, dynamodbVerifierMetadataStore } from '@trustknots/aws'
+import { dynamodbNonceStore, dynamodbRequestObjectStore, dynamodbVerifierMetadataStore } from '@trustknots/aws'
 import { createVerifierRouter } from '@trustknots/server-core/routes/verify'
 import { VerifierClientId, VerifierMetadata, initializeVerifierFlow } from '@trustknots/vcknots/verifier'
 import type { VcknotsOptions } from '@trustknots/vcknots'
@@ -18,16 +18,25 @@ export function createVerifierApp(options?: VcknotsOptions) {
     throw new Error('REQUEST_OBJECTS_TABLE_NAME is required')
   }
 
+  const noncesTableName = process.env.NONCES_TABLE_NAME
+  if (!noncesTableName) {
+    throw new Error('NONCES_TABLE_NAME is required')
+  }
+
   const rawPort = process.env.VERIFIER_PORT ?? '8083'
   const port = Number.parseInt(rawPort, 10)
   if (!Number.isFinite(port)) throw new Error(`Invalid VERIFIER_PORT: "${rawPort}"`)
 
   const verifierMetadataStore = dynamodbVerifierMetadataStore({ tableName: verifiersTableName })
   const requestObjectStore = dynamodbRequestObjectStore({ tableName: requestObjectsTableName })
+  const nonceStore = dynamodbNonceStore({ tableName: noncesTableName })
   const { app, context } = createBaseApp(
     createVerifierRouter,
     { port, baseUrl: process.env.VERIFIER_BASE_URL },
-    { ...options, providers: [verifierMetadataStore, requestObjectStore, ...(options?.providers ?? [])] },
+    {
+      ...options,
+      providers: [verifierMetadataStore, requestObjectStore, nonceStore, ...(options?.providers ?? [])],
+    },
   )
 
   async function initialize(baseUrl: string) {

--- a/server/aws/src/handlers/authz.ts
+++ b/server/aws/src/handlers/authz.ts
@@ -1,10 +1,7 @@
+import "dotenv/config";
 import { serve } from "@hono/node-server";
 import { handle } from "hono/aws-lambda";
 import { createAuthzApp } from "../apps/create-authz-app.js";
-
-if (!process.env.AWS_LAMBDA_FUNCTION_NAME) {
-  await import("dotenv/config");
-}
 
 const { app, initialize } = createAuthzApp();
 

--- a/server/aws/src/handlers/authz.ts
+++ b/server/aws/src/handlers/authz.ts
@@ -1,21 +1,20 @@
-import "dotenv/config";
-import { serve } from "@hono/node-server";
-import { handle } from "hono/aws-lambda";
-import { createAuthzApp } from "../apps/create-authz-app.js";
+import 'dotenv/config'
+import { serve } from '@hono/node-server'
+import { handle } from 'hono/aws-lambda'
+import { createAuthzApp } from '../apps/create-authz-app.js'
 
-const { app, initialize } = createAuthzApp();
+const { app, initialize } = createAuthzApp()
 
-export { app };
-export const handler = handle(app);
+export { app }
+export const handler = handle(app)
 
 if (!process.env.AWS_LAMBDA_FUNCTION_NAME) {
-  const rawPort = process.env.AUTHZ_PORT ?? "8082";
-  const port = Number.parseInt(rawPort, 10);
-  if (!Number.isFinite(port))
-    throw new Error(`Invalid AUTHZ_PORT: "${rawPort}"`);
-  const baseUrl = process.env.AUTHZ_BASE_URL ?? `http://localhost:${port}`;
-  await initialize(baseUrl);
+  const rawPort = process.env.AUTHZ_PORT ?? '8082'
+  const port = Number.parseInt(rawPort, 10)
+  if (!Number.isFinite(port)) throw new Error(`Invalid AUTHZ_PORT: "${rawPort}"`)
+  const baseUrl = process.env.AUTHZ_BASE_URL ?? `http://localhost:${port}`
+  await initialize(baseUrl)
   serve({ fetch: app.fetch, port }, () => {
-    console.log(`Authz is running on ${baseUrl}`);
-  });
+    console.log(`Authz is running on ${baseUrl}`)
+  })
 }

--- a/server/aws/src/handlers/issuer.ts
+++ b/server/aws/src/handlers/issuer.ts
@@ -1,10 +1,7 @@
+import 'dotenv/config'
 import { serve } from '@hono/node-server'
 import { handle } from 'hono/aws-lambda'
 import { createIssuerApp } from '../apps/create-issuer-app.js'
-
-if (!process.env.AWS_LAMBDA_FUNCTION_NAME) {
-  await import('dotenv/config')
-}
 
 const { app, initialize } = createIssuerApp()
 

--- a/server/aws/src/handlers/verifier.ts
+++ b/server/aws/src/handlers/verifier.ts
@@ -1,10 +1,7 @@
+import 'dotenv/config'
 import { serve } from '@hono/node-server'
 import { handle } from 'hono/aws-lambda'
 import { createVerifierApp } from '../apps/create-verifier-app.js'
-
-if (!process.env.AWS_LAMBDA_FUNCTION_NAME) {
-  await import('dotenv/config')
-}
 
 const { app, initialize } = createVerifierApp()
 


### PR DESCRIPTION
## 概要

OID4VCI の事前認可コード（pre-authorized code）を DynamoDB に永続化する `pre-authorized-code-store-provider` の AWS 実装を追加します。これまで in-memory 版・Firestore 版のみだった同プロバイダの DynamoDB 版を実装し、Issuer / Authz アプリに組み込みます。あわせて、期限の持ち方を他プロバイダ（Firestore / in-memory / 本リポジトリの nonce・request object 版）と揃えます。

## 背景

- `pre-authorized-code-store-provider` は Issuer（offer 時に save）と Authz（/token 時に consume）が共有する単一プロバイダ
- CDK 側には既に `PreCodesTable`（PK=`id`、TTL属性）が定義済み

## 変更内容

### ライブラリ（`@trustknots/aws`）
- `dynamodbPreAuthorizedCodeStore` プロバイダを新規追加
  - `save` / `consume` を実装。`consume` は取得→検証→`ConditionExpression` 付き削除でコードの再利用を防止（単回消費）
  - `tx_code` は平文保存せず、HMAC-SHA256 ハッシュ（`tx_code_hash`）のみ保存。pepper は `TX_CODE_PEPPER` 環境変数（import 時に必須評価）
  - **期限の持ち方**: アプリの期限判定は `expires_at`（epoch **ミリ秒**、`Date.now() > expires_at`）に統一。DynamoDB TTL 用には `ttl`（epoch **秒**、`Math.ceil(expires_at/1000)`）を別項目で保存
- `index.ts` から re-export、ユニットテスト追加（`aws-sdk-client-mock`）

### サーバアプリ（`@trustknots/server-aws`）
- `createIssuerApp`（save）/ `createAuthzApp`（consume）に組み込み
- `PRE_CODES_TABLE_NAME` を Issuer / Authz で必須化
- `README.md` / `README.ja.md` / `.env.example` を更新

### インフラ（CDK: `@trustknots/aws-resources`）
- `PreCodesTable` の `timeToLiveAttribute` を `expires_at` → **`ttl`** に変更（アプリ期限は ms、DynamoDB TTL は秒、で属性を分離）
- resources の README のテーブル一覧・注記を更新

## 動作確認

- [x] 全パッケージ typecheck パス、biome lint クリーン
- [x] `aws` ユニットテスト（pre-code 25 件を含む 58 件）パス
- [x] test 環境の実 DynamoDB で PreCodesTable を `ttl` 属性へ移行（作り直し）済み
- [x] Issuer / Authz サーバーをローカル起動し、実 DynamoDB に対して **offer（save）→ /token（consume + アクセストークン署名発行）** の pre-authorized code フローを E2E で確認。保存 item が `expires_at`(ms) + `ttl`(秒) になること、consume での単回消費・期限切れ判定・削除も確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * DynamoDBで事前承認コードストアとNonceストアを提供し、保存・消費（形式検証/期限判定/二重消費抑止/ロックアウト）を実装しました。
  * Issuer/Authzの初期化に当該ストアを組み込みました。
* **改善**
  * `TX_CODE_PEPPER` を必須化し、事前承認コードはHMACでハッシュ化して扱います。
  * 環境設定の読み込みタイミングを統一し、VerifierのLambdaエントリポイントを明確化しました。
* **ドキュメント**
  * DynamoDBのTTL属性（`ttl` / `expires_at`）や必須環境変数を更新しました。
* **テスト**
  * `.env.test` 読込を統一し、事前承認コードストアの動作を網羅的に検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->