### PR TITLE
fix(issuer): align credential request errors with OID4VCI conformance tests

### DIFF
--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -328,9 +328,10 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
         })
       rejectInsecureIssuerMetadata(metadata)
 
-      const hasCredentialIdentifier = credentialRequest.credential_identifier !== undefined
-      const hasCredentialConfigurationId =
-        credentialRequest.credential_configuration_id !== undefined
+      const credentialIdentifier = credentialRequest.credential_identifier
+      const credentialConfigurationId = credentialRequest.credential_configuration_id
+      const hasCredentialIdentifier = credentialIdentifier !== undefined
+      const hasCredentialConfigurationId = credentialConfigurationId !== undefined
 
       if (hasCredentialIdentifier && hasCredentialConfigurationId) {
         throw err('invalid_credential_request', {
@@ -343,11 +344,11 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
         // TODO: Resolve identifiers issued in the Token Response and verify that
         // the identifier is authorized for the presented access token.
         throw err('unknown_credential_identifier', {
-          message: `Credential identifier ${credentialRequest.credential_identifier} is unknown.`,
+          message: `Credential identifier ${credentialIdentifier} is unknown.`,
         })
       }
 
-      if (!credentialRequest.credential_configuration_id) {
+      if (!hasCredentialConfigurationId) {
         throw err('invalid_credential_request', {
           message: 'Credential configuration id is not specified.',
         })
@@ -355,11 +356,10 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
 
       // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-ID1.html#name-credential-request-2
       const credentialConfigurationSupported = metadata.credential_configurations_supported
-      const configuration =
-        credentialConfigurationSupported[credentialRequest.credential_configuration_id]
+      const configuration = credentialConfigurationSupported[credentialConfigurationId]
       if (!configuration) {
         throw err('unknown_credential_configuration', {
-          message: `Credential configuration ${credentialRequest.credential_configuration_id} is not supported by issuer ${issuer}.`,
+          message: `Credential configuration ${credentialConfigurationId} is not supported by issuer ${issuer}.`,
         })
       }
       if (!authorizationContext.allowedCredentialConfigurationKey) {
@@ -375,9 +375,8 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
           message: 'Allowed credential configurations for this access token were not found',
         })
       }
-      const requestedCredentialConfigurationId = CredentialConfigurationId(
-        credentialRequest.credential_configuration_id
-      )
+      const requestedCredentialConfigurationId =
+        CredentialConfigurationId(credentialConfigurationId)
 
       if (!allowedCredentialConfigurationIds.includes(requestedCredentialConfigurationId)) {
         throw err('invalid_credential_request', {

--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -440,7 +440,7 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
         }
       }
       if (!verifyProof) {
-        throw err('invalid_credential_request', {
+        throw err('invalid_proof', {
           message: 'Proof is required to issue credential.',
         })
       }

--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -328,17 +328,18 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
         })
       rejectInsecureIssuerMetadata(metadata)
 
-      if (
-        credentialRequest.credential_identifier &&
-        credentialRequest.credential_configuration_id
-      ) {
+      const hasCredentialIdentifier = credentialRequest.credential_identifier !== undefined
+      const hasCredentialConfigurationId =
+        credentialRequest.credential_configuration_id !== undefined
+
+      if (hasCredentialIdentifier && hasCredentialConfigurationId) {
         throw err('invalid_credential_request', {
           message:
             'credential_identifier and credential_configuration_id must not be used together.',
         })
       }
 
-      if (credentialRequest.credential_identifier) {
+      if (hasCredentialIdentifier) {
         // TODO: Resolve identifiers issued in the Token Response and verify that
         // the identifier is authorized for the presented access token.
         throw err('unknown_credential_identifier', {

--- a/issuer+verifier/src/issuer.flows.ts
+++ b/issuer+verifier/src/issuer.flows.ts
@@ -328,6 +328,24 @@ export const initializeIssuerFlow = (context: VcknotsContext): IssuerFlow => {
         })
       rejectInsecureIssuerMetadata(metadata)
 
+      if (
+        credentialRequest.credential_identifier &&
+        credentialRequest.credential_configuration_id
+      ) {
+        throw err('invalid_credential_request', {
+          message:
+            'credential_identifier and credential_configuration_id must not be used together.',
+        })
+      }
+
+      if (credentialRequest.credential_identifier) {
+        // TODO: Resolve identifiers issued in the Token Response and verify that
+        // the identifier is authorized for the presented access token.
+        throw err('unknown_credential_identifier', {
+          message: `Credential identifier ${credentialRequest.credential_identifier} is unknown.`,
+        })
+      }
+
       if (!credentialRequest.credential_configuration_id) {
         throw err('invalid_credential_request', {
           message: 'Credential configuration id is not specified.',

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -1208,6 +1208,80 @@ describe('IssuerFlow', () => {
       )
     })
 
+    it('should throw "invalid_credential_request" if both credential identifier and configuration id are specified', async () => {
+      // 1. Arrange
+      const issuer = CredentialIssuer('did:example:issuer')
+      const metadata: CredentialIssuerMetadata = {
+        credential_issuer: issuer,
+        credential_endpoint: 'https://example.com/credentials',
+        credential_configurations_supported: {
+          University_Degree: {
+            format: 'jwt_vc_json',
+            credential_definition: {
+              type: ['VCKnots'],
+              credentialSubject: {},
+            },
+            credential_signing_alg_values_supported: ['ES256'],
+          },
+        },
+      }
+      const credentialRequest = createCredentialRequest({
+        credential_identifier: 'credential-identifier',
+      })
+
+      mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
+
+      // 2. Act & 3. Assert
+      await assert.rejects(
+        issuerFlow.issueCredential(issuer, credentialRequest, {
+          authorizationContext: createAuthorizationContext(),
+          alg: 'ES256',
+        }),
+        {
+          name: 'invalid_credential_request',
+          message:
+            'credential_identifier and credential_configuration_id must not be used together.',
+        }
+      )
+    })
+
+    it('should throw "unknown_credential_identifier" if credential identifier is specified', async () => {
+      // 1. Arrange
+      const issuer = CredentialIssuer('did:example:issuer')
+      const metadata: CredentialIssuerMetadata = {
+        credential_issuer: issuer,
+        credential_endpoint: 'https://example.com/credentials',
+        credential_configurations_supported: {
+          University_Degree: {
+            format: 'jwt_vc_json',
+            credential_definition: {
+              type: ['VCKnots'],
+              credentialSubject: {},
+            },
+            credential_signing_alg_values_supported: ['ES256'],
+          },
+        },
+      }
+      const credentialRequest = createCredentialRequest({
+        credential_identifier: 'unknown-credential-identifier',
+        credential_configuration_id: undefined,
+      })
+
+      mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
+
+      // 2. Act & 3. Assert
+      await assert.rejects(
+        issuerFlow.issueCredential(issuer, credentialRequest, {
+          authorizationContext: createAuthorizationContext(),
+          alg: 'ES256',
+        }),
+        {
+          name: 'unknown_credential_identifier',
+          message: 'Credential identifier unknown-credential-identifier is unknown.',
+        }
+      )
+    })
+
     it('should throw "unknown_credential_configuration" if requested configuration is not supported', async () => {
       // 1. Arrange
       const issuer = CredentialIssuer('did:example:issuer')

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -1245,6 +1245,43 @@ describe('IssuerFlow', () => {
       )
     })
 
+    it('should throw "invalid_credential_request" if an empty credential identifier and configuration id are specified', async () => {
+      // 1. Arrange
+      const issuer = CredentialIssuer('did:example:issuer')
+      const metadata: CredentialIssuerMetadata = {
+        credential_issuer: issuer,
+        credential_endpoint: 'https://example.com/credentials',
+        credential_configurations_supported: {
+          University_Degree: {
+            format: 'jwt_vc_json',
+            credential_definition: {
+              type: ['VCKnots'],
+              credentialSubject: {},
+            },
+            credential_signing_alg_values_supported: ['ES256'],
+          },
+        },
+      }
+      const credentialRequest = createCredentialRequest({
+        credential_identifier: '',
+      })
+
+      mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
+
+      // 2. Act & 3. Assert
+      await assert.rejects(
+        issuerFlow.issueCredential(issuer, credentialRequest, {
+          authorizationContext: createAuthorizationContext(),
+          alg: 'ES256',
+        }),
+        {
+          name: 'invalid_credential_request',
+          message:
+            'credential_identifier and credential_configuration_id must not be used together.',
+        }
+      )
+    })
+
     it('should throw "unknown_credential_identifier" if credential identifier is specified', async () => {
       // 1. Arrange
       const issuer = CredentialIssuer('did:example:issuer')

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -1347,7 +1347,7 @@ describe('IssuerFlow', () => {
       )
     })
 
-    it('should throw "invalid_credential_request" if proofs are missing', async () => {
+    it('should throw "invalid_proof" if proofs are missing', async () => {
       // 1. Arrange
       const issuer = CredentialIssuer('did:example:issuer')
       const metadata = {
@@ -1376,7 +1376,7 @@ describe('IssuerFlow', () => {
           alg: 'ES256',
         }),
         {
-          name: 'invalid_credential_request',
+          name: 'invalid_proof',
           message: 'Proof is required to issue credential.',
         }
       )

--- a/issuer+verifier/test/issuer.flow.spec.ts
+++ b/issuer+verifier/test/issuer.flow.spec.ts
@@ -1208,6 +1208,42 @@ describe('IssuerFlow', () => {
       )
     })
 
+    it('should throw "unknown_credential_configuration" if credential configuration id is empty', async () => {
+      // 1. Arrange
+      const issuer = CredentialIssuer('did:example:issuer')
+      const metadata: CredentialIssuerMetadata = {
+        credential_issuer: issuer,
+        credential_endpoint: 'https://example.com/credentials',
+        credential_configurations_supported: {
+          University_Degree: {
+            format: 'jwt_vc_json',
+            credential_definition: {
+              type: ['VCKnots'],
+              credentialSubject: {},
+            },
+            credential_signing_alg_values_supported: ['ES256'],
+          },
+        },
+      }
+      const credentialRequest = createCredentialRequest({
+        credential_configuration_id: '',
+      })
+
+      mock.method(mockIssuerMetadataProvider, 'fetch', async () => metadata)
+
+      // 2. Act & 3. Assert
+      await assert.rejects(
+        issuerFlow.issueCredential(issuer, credentialRequest, {
+          authorizationContext: createAuthorizationContext(),
+          alg: 'ES256',
+        }),
+        {
+          name: 'unknown_credential_configuration',
+          message: `Credential configuration  is not supported by issuer ${issuer}.`,
+        }
+      )
+    })
+
     it('should throw "invalid_credential_request" if both credential identifier and configuration id are specified', async () => {
       // 1. Arrange
       const issuer = CredentialIssuer('did:example:issuer')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - `credential_identifier` と `credential_configuration_id` の同時指定を禁止し、不正リクエストを適切なエラーで拒否するようにしました。
  - `credential_identifier` のみ指定された場合も無効として拒否するようにしました。
  - Proof が取得できないケースのエラー種別を `invalid_proof` に変更しました。

- **テスト**
  - `credential_identifier`／`credential_configuration_id` の入力バリデーションと、`invalid_proof` になる失敗期待を追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->