### PR TITLE
feat(docusaurus): add Google Analytics (GA4) gtag configuration

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -59,6 +59,10 @@ const config: Config = {
         theme: {
           customCss: './src/css/custom.css',
         },
+        gtag: {
+          trackingID: 'G-8MTSNHBXG4',
+          anonymizeIP: true,
+        },
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
## Summary
- Added Google Analytics (GA4) configuration (`gtag`) to Docusaurus `preset-classic` in `docusaurus.config.ts`.
- Set up Measurement ID (`G-8MTSNHBXG4`).
## Testing
- Verified `docusaurus.config.ts` options against `@docusaurus/preset-classic` type definitions.
- Confirmed that tracking is automatically disabled during local development (`docusaurus start`) by Docusaurus `gtag` plugin design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Google Analytics によるサイト利用状況の計測に対応しました。
  * IPアドレスの匿名化を有効にし、プライバシーに配慮した計測を行います。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->