### PR TITLE
feat(wallet): add cose identifier support

### DIFF
--- a/wallet/receiver/types/types.go
+++ b/wallet/receiver/types/types.go
@@ -2,6 +2,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -98,6 +99,7 @@ func DPoPNonceFromError(err error) (string, bool) {
 }
 
 type SupportedReceivingTypes int
+type SignatureAlgorithm jose.SignatureAlgorithm
 
 const (
 	Oid4vci SupportedReceivingTypes = iota
@@ -119,7 +121,44 @@ type CredentialConfiguration struct {
 	CryptographicBindingMethodsSupported *[]string                         `json:"cryptographic_binding_methods_supported,omitempty"`
 	Format                               string                            `json:"format"`
 	CredentialDefinition                 *CredentialDefinition             `json:"credential_definition,omitempty"`
-	CredentialSigningAlgValuesSupported  []jose.SignatureAlgorithm         `json:"credential_signing_alg_values_supported,omitempty"`
+	CredentialSigningAlgValuesSupported  []SignatureAlgorithm              `json:"credential_signing_alg_values_supported,omitempty"`
+}
+
+var coseAlgToJWA = map[int64]jose.SignatureAlgorithm{
+	-8:   jose.EdDSA,
+	5:    jose.HS256,
+	6:    jose.HS384,
+	7:    jose.HS512,
+	-257: jose.RS256,
+	-258: jose.RS384,
+	-259: jose.RS512,
+	-7:   jose.ES256,
+	-35:  jose.ES384,
+	-36:  jose.ES512,
+	-37:  jose.PS256,
+	-38:  jose.PS384,
+	-39:  jose.PS512,
+}
+
+func (c *SignatureAlgorithm) UnmarshalJSON(raw []byte) error {
+	var coseID int64
+	if err := json.Unmarshal(raw, &coseID); err == nil {
+		// COSE algorithm identifier
+		alg, ok := coseAlgToJWA[coseID]
+		if !ok {
+			return fmt.Errorf("unsupported COSE algorithm identifier %d", coseID)
+		}
+		*c = SignatureAlgorithm(alg)
+		return nil
+	}
+
+	// JWA name
+	var alg string
+	if err := json.Unmarshal(raw, &alg); err != nil {
+		return fmt.Errorf("invalid credential_signing_alg_values_supported entry: %w", err)
+	}
+	*c = SignatureAlgorithm(alg)
+	return nil
 }
 
 type CredentialIssuerMetadataDisplay struct {

--- a/wallet/receiver/types/types.go
+++ b/wallet/receiver/types/types.go
@@ -133,6 +133,7 @@ var coseAlgToJWA = map[int64]jose.SignatureAlgorithm{
 	-258: jose.RS384,
 	-259: jose.RS512,
 	-7:   jose.ES256,
+	-9:   jose.ES256, // ESP256 (fully-specified ECDSA using P-256 and SHA-256)
 	-35:  jose.ES384,
 	-36:  jose.ES512,
 	-37:  jose.PS256,

--- a/wallet/receiver/types/types_test.go
+++ b/wallet/receiver/types/types_test.go
@@ -1,0 +1,93 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+func TestSignatureAlgorithmUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected SignatureAlgorithm
+		wantErr  bool
+	}{
+		{
+			name:     "JWA name",
+			raw:      `"ES256"`,
+			expected: SignatureAlgorithm(jose.ES256),
+		},
+		{
+			name:     "COSE identifier for ES256",
+			raw:      `-7`,
+			expected: SignatureAlgorithm(jose.ES256),
+		},
+		{
+			name:     "COSE identifier for EdDSA",
+			raw:      `-8`,
+			expected: SignatureAlgorithm(jose.EdDSA),
+		},
+		{
+			name:     "COSE identifier for PS512",
+			raw:      `-39`,
+			expected: SignatureAlgorithm(jose.PS512),
+		},
+		{
+			name:    "unsupported COSE identifier",
+			raw:     `999`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			raw:     `{}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var alg SignatureAlgorithm
+			err := json.Unmarshal([]byte(tt.raw), &alg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (alg=%v)", alg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if alg != tt.expected {
+				t.Fatalf("got %v, want %v", alg, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCredentialConfigurationUnmarshalJSONMixedAlgValues(t *testing.T) {
+	raw := `{
+		"format": "mso_mdoc",
+		"credential_signing_alg_values_supported": ["ES256", -8, -257]
+	}`
+
+	var cfg CredentialConfiguration
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []SignatureAlgorithm{
+		SignatureAlgorithm(jose.ES256),
+		SignatureAlgorithm(jose.EdDSA),
+		SignatureAlgorithm(jose.RS256),
+	}
+	if len(cfg.CredentialSigningAlgValuesSupported) != len(want) {
+		t.Fatalf("got %v, want %v", cfg.CredentialSigningAlgValuesSupported, want)
+	}
+	for i, alg := range want {
+		if cfg.CredentialSigningAlgValuesSupported[i] != alg {
+			t.Fatalf("index %d: got %v, want %v", i, cfg.CredentialSigningAlgValuesSupported[i], alg)
+		}
+	}
+}

--- a/wallet/receiver/types/types_test.go
+++ b/wallet/receiver/types/types_test.go
@@ -30,6 +30,11 @@ func TestSignatureAlgorithmUnmarshalJSON(t *testing.T) {
 			expected: SignatureAlgorithm(jose.EdDSA),
 		},
 		{
+			name:     "COSE identifier for ESP256 (fully-specified ES256)",
+			raw:      `-9`,
+			expected: SignatureAlgorithm(jose.ES256),
+		},
+		{
 			name:     "COSE identifier for PS512",
 			raw:      `-39`,
 			expected: SignatureAlgorithm(jose.PS512),
@@ -69,7 +74,7 @@ func TestSignatureAlgorithmUnmarshalJSON(t *testing.T) {
 func TestCredentialConfigurationUnmarshalJSONMixedAlgValues(t *testing.T) {
 	raw := `{
 		"format": "mso_mdoc",
-		"credential_signing_alg_values_supported": ["ES256", -8, -257]
+		"credential_signing_alg_values_supported": ["ES256", -7, -9, -8, -257]
 	}`
 
 	var cfg CredentialConfiguration
@@ -78,6 +83,8 @@ func TestCredentialConfigurationUnmarshalJSONMixedAlgValues(t *testing.T) {
 	}
 
 	want := []SignatureAlgorithm{
+		SignatureAlgorithm(jose.ES256),
+		SignatureAlgorithm(jose.ES256),
 		SignatureAlgorithm(jose.ES256),
 		SignatureAlgorithm(jose.EdDSA),
 		SignatureAlgorithm(jose.RS256),


### PR DESCRIPTION
Issue: https://github.com/trustknots/vcknots-internal/issues/651

Issuerのメタデータに含まれる Credential Configuration において、`credential_signing_alg_values_supported` に COSE algorithm identifier が指定された場合に、パースできるようにしました。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 認証情報の署名アルゴリズム指定で、JWA形式の文字列とCOSE形式の数値を利用できるようになりました。
  * 文字列と数値が混在する署名アルゴリズム一覧にも対応しました。

* **改善**
  * 未対応のアルゴリズムや不正な形式を検出し、適切にエラーを返すようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->