### PR TITLE
fix(wallet): join tenant path to well-known path, with RFC 8414 style

### DIFF
--- a/wallet/receiver/plugins/oid4vci/oid4vci.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci.go
@@ -55,7 +55,7 @@ func (o *Oid4vciReceiver) doRequest(method string, endpoint common.URIField, pat
 		return fmt.Errorf("unsupported URL scheme for OID4VCI endpoint: %q (https required)", endpointURL.Scheme)
 	}
 
-	if path == "/.well-known/oauth-authorization-server" {
+	if path == "/.well-known/oauth-authorization-server" || path == "/.well-known/openid-credential-issuer" {
 		// Special handling for metadata discovery as per RFC 8414 §3
 		// The well-known string MUST be inserted between the host component and the path component.
 		originalPath := strings.TrimSuffix(endpointURL.Path, "/")

--- a/wallet/receiver/plugins/oid4vci/oid4vci_test.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci_test.go
@@ -985,7 +985,7 @@ func TestOid4vciReceiver_MetadataDiscovery_UrlPatterns(t *testing.T) {
 		{
 			name:         "Credential Issuer (With Path)",
 			identifier:   "/tenant2",
-			expectedPath: "/tenant2/.well-known/openid-credential-issuer",
+			expectedPath: "/.well-known/openid-credential-issuer/tenant2",
 			discovery: func(u common.URIField) error {
 				_, err := receiver.FetchIssuerMetadata(u, types.Oid4vci)
 				return err
@@ -994,7 +994,7 @@ func TestOid4vciReceiver_MetadataDiscovery_UrlPatterns(t *testing.T) {
 		{
 			name:         "Credential Issuer (With Trailing Slash)",
 			identifier:   "/tenant2/",
-			expectedPath: "/tenant2/.well-known/openid-credential-issuer",
+			expectedPath: "/.well-known/openid-credential-issuer/tenant2",
 			discovery: func(u common.URIField) error {
 				_, err := receiver.FetchIssuerMetadata(u, types.Oid4vci)
 				return err


### PR DESCRIPTION
Issuer metadataを取得する際、Issuerの識別子にパスが付いている場合、`/.well-known/openid-credential-issuer/パス` にアクセスできるようにしました。
従来は `/パス/.well-known/openid-credential-issuer` へアクセスしてしまっており、RFC 8414に準拠できていませんでした。