### PR TITLE
feat: add tx_code attempt lockout to Firestore and in-memory pre-authorized code stores

### DIFF
--- a/docs/en/issuer.md
+++ b/docs/en/issuer.md
@@ -611,6 +611,8 @@ Include a request body (JSON) only when specifying optional parameters.
 - `tx_code` can be used to include a transaction code in the Credential Offer.
 - `authorization_server` can be included only when the Issuer Metadata contains multiple entries in `authorization_servers`.
 
+When the offer includes `tx_code`, the pre-authorized-code store (in-memory, DynamoDB, and Firestore) limits failed `tx_code` guesses per code (default: **5**). After the limit is reached the code is invalidated, and later token requests fail with `invalid_grant` even if the correct `tx_code` is supplied. Change the limit with the provider factory option `maxTxCodeAttempts` (there is no environment variable for this yet).
+
 ```bash
 curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/offer \
   -H "Content-Type: application/json" \
@@ -1517,8 +1519,8 @@ In the Pre-Authorized Code flow, `credential_configuration_ids` linked to the pr
 
 **Error cases**:
 - `provider_not_found`: An unsupported algorithm is configured for the private key
-- `invalid_grant`: An invalid pre-authorized code is provided
-- `invalid_request`: The authorization server key is not registered, the algorithm is not set, or the grant type is not supported
+- `invalid_grant`: An invalid, consumed, expired, or locked (too many failed `tx_code` attempts) pre-authorized code is provided
+- `invalid_request`: The authorization server key is not registered, the algorithm is not set, the grant type is not supported, or `tx_code` is missing/unexpected for the stored code
 - `internal_server_error`: Signing failed
 - `unsupported_grant_type`: The authorization code flow is configured (currently not supported)
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/issuer.md
@@ -609,6 +609,8 @@ app.post('/configurations/:configuration/offer', async (c) => {
 - tx_code は、Credential Offer にトランザクションコードを含めるために使用できます。
 - authorization_server は、Issuer Metadata の authorization_servers に複数のエントリーが含まれる場合にのみ指定できます。
 
+`tx_code` 付きの Offer では、pre-authorized-code store（in-memory / DynamoDB / Firestore）がコードごとに誤った `tx_code` の試行回数を制限します（既定 **5** 回）。上限に達するとコードは無効化され、以降は正しい `tx_code` でも token request は `invalid_grant` になります。上限を変える場合は、各 provider 生成時の `maxTxCodeAttempts` オプションを指定してください（環境変数は未対応です）。
+
 ```bash
 curl -X POST http://localhost:8080/configurations/UniversityDegreeCredential/offer \
   -H "Content-Type: application/json" \
@@ -1517,8 +1519,8 @@ Pre-Authorized Code フローでは、token 発行時に pre-authorized code に
 
 **エラーケース**:
 - `provider_not_found`:  秘密鍵で未対応のアルゴリズムが設定された
-- `invalid_grant`: 有効でない事前認可コードが設定された
-- `invalid_request`: 認可サーバーの鍵が未登録、アルゴリズムが未設定、グラントタイプがサポートされていない
+- `invalid_grant`: 無効・消費済み・期限切れ、または `tx_code` 試行上限超過でロックされた事前認可コードが指定された
+- `invalid_request`: 認可サーバーの鍵が未登録、アルゴリズムが未設定、グラントタイプがサポートされていない、または保存済みコードに対して `tx_code` の有無が不正
 - `internal_server_error`: 署名に失敗した
 - `unsupported_grant_type`: 認可コードフローを設定（現在未対応）
 

--- a/google-cloud/src/providers/firestore-pre-authorized-code-store.provider.ts
+++ b/google-cloud/src/providers/firestore-pre-authorized-code-store.provider.ts
@@ -5,16 +5,34 @@ import { FirestoreProviderOptions, resolveFirestore } from './firestore.provider
 import { hashTxCode } from './hash.utils'
 import { raise } from '@trustknots/vcknots/errors'
 
+export type FirestorePreAuthorizedCodeStoreOptions = FirestoreProviderOptions & {
+  /**
+   * Number of failed `tx_code` attempts allowed per pre-authorized code before it
+   * is invalidated (brute-force lockout). Defaults to 5.
+   */
+  maxTxCodeAttempts?: number
+}
+
 type FirestorePreAuthorizedCodeDoc = Omit<PreAuthorizedCodeStoreEntry, 'tx_code' | 'expires_at'> & {
   expires_at: Timestamp
   tx_code_hash?: string
+  /** Number of failed `tx_code` attempts so far (brute-force lockout counter). */
+  attempts?: number
 }
 
+const DEFAULT_MAX_TX_CODE_ATTEMPTS = 5
+const LOCKED_MESSAGE = 'Pre-authorized code is invalid, consumed, or locked'
+
 export const firestorePreAuthorizedCodeStore = (
-  options?: FirestoreProviderOptions
+  options?: FirestorePreAuthorizedCodeStoreOptions
 ): PreAuthorizedCodeStoreProvider => {
   const firestore = resolveFirestore(options)
   const ns = options?.namespace?.replace(/\//g, '') || 'vcknots'
+  const maxTxCodeAttemptsRaw = options?.maxTxCodeAttempts ?? DEFAULT_MAX_TX_CODE_ATTEMPTS
+  const maxTxCodeAttempts = Number.isFinite(maxTxCodeAttemptsRaw)
+    ? Math.max(1, Math.floor(maxTxCodeAttemptsRaw))
+    : DEFAULT_MAX_TX_CODE_ATTEMPTS
+
   const toDigitString = (value: string | number): string | null => {
     if (typeof value === 'number') {
       return Number.isSafeInteger(value) && value >= 0 ? value.toString() : null
@@ -60,66 +78,78 @@ export const firestorePreAuthorizedCodeStore = (
     },
 
     async consume(code, tx_code) {
+      // Count-first admission gate (brute-force lockout): atomically increment `attempts`
+      // only while the code still exists AND the per-code limit hasn't been reached, then
+      // read the item back to compare the tx_code. Firestore transactions serialize writes
+      // per document, so even a highly concurrent burst admits at most `maxTxCodeAttempts`
+      // guesses — once the limit is hit, every further attempt (including the correct PIN)
+      // is rejected before the tx_code is ever compared.
       const docRef = firestore.doc(`${ns}/v1/preCodes/${code}`)
-      const result = await firestore.runTransaction(async (transaction) => {
+      const item = await firestore.runTransaction(async (transaction) => {
         const doc = await transaction.get(docRef)
         if (!doc.exists) {
-          throw raise('invalid_grant', {
-            message: 'Pre-authorized code not found',
-          })
+          // Not found, already consumed, or locked out after too many tx_code attempts.
+          throw raise('invalid_grant', { message: LOCKED_MESSAGE })
         }
         const data = doc.data() as FirestorePreAuthorizedCodeDoc
-
-        if (data.expires_at.toMillis() <= Date.now()) {
-          transaction.delete(docRef)
-          return { expired: true, credential_configuration_ids: null }
+        const currentAttempts = data.attempts ?? 0
+        if (currentAttempts >= maxTxCodeAttempts) {
+          throw raise('invalid_grant', { message: LOCKED_MESSAGE })
         }
-        if (data.tx_code_hash) {
-          if (tx_code === undefined) {
-            throw raise('invalid_request', {
-              message: 'tx_code is required for this pre-authorized code',
-            })
-          }
-          const inputMode = data.tx_code_input_mode ?? 'numeric'
-          if (inputMode !== 'text') {
-            const actual = toDigitString(tx_code)
-            if (actual === null || data.tx_code_hash !== hashTxCode(actual)) {
-              throw raise('invalid_grant', {
-                message: 'Invalid tx_code provided',
-              })
-            }
-          } else {
-            if (typeof tx_code !== 'string' || data.tx_code_hash !== hashTxCode(tx_code)) {
-              throw raise('invalid_grant', {
-                message: 'Invalid tx_code provided',
-              })
-            }
-          }
-          transaction.delete(docRef)
-          return {
-            expired: false,
-            credential_configuration_ids: data.credential_configuration_ids ?? null,
-          }
-        }
-        if (tx_code !== undefined) {
-          throw raise('invalid_request', {
-            message: 'tx_code should not be provided for this pre-authorized code',
-          })
-        }
-
-        transaction.delete(docRef)
-        return {
-          expired: false,
-          credential_configuration_ids: data.credential_configuration_ids ?? null,
-        }
+        const attempts = currentAttempts + 1
+        transaction.set(docRef, { attempts }, { merge: true })
+        return { ...data, attempts }
       })
-      if (result.expired) {
+
+      const lockoutIfExhausted = async (): Promise<void> => {
+        if ((item.attempts ?? 0) >= maxTxCodeAttempts) {
+          await docRef.delete()
+          raise('invalid_grant', { message: LOCKED_MESSAGE })
+        }
+      }
+
+      if (item.expires_at.toMillis() <= Date.now()) {
+        await docRef.delete()
         throw raise('invalid_grant', {
           message: 'Pre-authorized code has expired',
         })
       }
 
-      return result.credential_configuration_ids
+      if (item.tx_code_hash) {
+        if (tx_code === undefined) {
+          await lockoutIfExhausted()
+          throw raise('invalid_request', {
+            message: 'tx_code is required for this pre-authorized code',
+          })
+        }
+        const inputMode = item.tx_code_input_mode ?? 'numeric'
+        if (inputMode !== 'text') {
+          const actual = toDigitString(tx_code)
+          if (actual === null || item.tx_code_hash !== hashTxCode(actual)) {
+            await lockoutIfExhausted()
+            throw raise('invalid_grant', {
+              message: 'Invalid tx_code provided',
+            })
+          }
+        } else {
+          if (typeof tx_code !== 'string' || item.tx_code_hash !== hashTxCode(tx_code)) {
+            await lockoutIfExhausted()
+            throw raise('invalid_grant', {
+              message: 'Invalid tx_code provided',
+            })
+          }
+        }
+      } else if (tx_code !== undefined) {
+        await lockoutIfExhausted()
+        throw raise('invalid_request', {
+          message: 'tx_code should not be provided for this pre-authorized code',
+        })
+      }
+
+      // Delete to prevent the code from being consumed twice.
+      await docRef.delete()
+
+      return item.credential_configuration_ids ?? null
     },
   }
 }

--- a/google-cloud/src/providers/firestore-pre-authorized-code-store.provider.ts
+++ b/google-cloud/src/providers/firestore-pre-authorized-code-store.provider.ts
@@ -84,7 +84,34 @@ export const firestorePreAuthorizedCodeStore = (
       // per document, so even a highly concurrent burst admits at most `maxTxCodeAttempts`
       // guesses — once the limit is hit, every further attempt (including the correct PIN)
       // is rejected before the tx_code is ever compared.
+      // Successful consume uses a second conditional delete (parity with DynamoDB) so two
+      // concurrent correct-PIN requests cannot both return credential_configuration_ids.
       const docRef = firestore.doc(`${ns}/v1/preCodes/${code}`)
+
+      /**
+       * Deletes a stored code. When `conditional` is true the delete only succeeds if the
+       * document still exists; a lost race is surfaced as `invalid_grant` (DynamoDB parity).
+       */
+      const deleteCode = async (conditional = false): Promise<void> => {
+        if (!conditional) {
+          await docRef.delete()
+          return
+        }
+        const deleted = await firestore.runTransaction(async (transaction) => {
+          const doc = await transaction.get(docRef)
+          if (!doc.exists) {
+            return false
+          }
+          transaction.delete(docRef)
+          return true
+        })
+        if (!deleted) {
+          throw raise('invalid_grant', {
+            message: 'Pre-authorized code has already been consumed',
+          })
+        }
+      }
+
       const item = await firestore.runTransaction(async (transaction) => {
         const doc = await transaction.get(docRef)
         if (!doc.exists) {
@@ -103,13 +130,13 @@ export const firestorePreAuthorizedCodeStore = (
 
       const lockoutIfExhausted = async (): Promise<void> => {
         if ((item.attempts ?? 0) >= maxTxCodeAttempts) {
-          await docRef.delete()
+          await deleteCode()
           raise('invalid_grant', { message: LOCKED_MESSAGE })
         }
       }
 
       if (item.expires_at.toMillis() <= Date.now()) {
-        await docRef.delete()
+        await deleteCode()
         throw raise('invalid_grant', {
           message: 'Pre-authorized code has expired',
         })
@@ -146,8 +173,9 @@ export const firestorePreAuthorizedCodeStore = (
         })
       }
 
-      // Delete to prevent the code from being consumed twice.
-      await docRef.delete()
+      // Conditional delete to prevent the code from being consumed twice. A lost race
+      // means another request already consumed it (same idea as DynamoDB ConditionExpression).
+      await deleteCode(true)
 
       return item.credential_configuration_ids ?? null
     },

--- a/google-cloud/test/providers/firestore-pre-authorized-code-store.provider.spec.ts
+++ b/google-cloud/test/providers/firestore-pre-authorized-code-store.provider.spec.ts
@@ -54,7 +54,11 @@ describe('firestorePreAuthorizedCodeStore', () => {
     })
     await assert.rejects(provider.consume(PreAuthorizedCode('test-code-wrong'), 456), {
       name: 'invalid_grant',
+      message: 'Invalid tx_code provided',
     })
+    const doc = store.get('vcknots/v1/preCodes/test-code-wrong')
+    assert.ok(doc)
+    assert.equal(doc.attempts, 1)
   })
 
   it('should allow string numeric tx_code in numeric mode', async () => {
@@ -274,5 +278,160 @@ describe('firestorePreAuthorizedCodeStore', () => {
     const doc = store.get('vcknots/v1/preCodes/stored-config-code')
     assert.ok(doc)
     assert.deepStrictEqual(doc.credential_configuration_ids, configurations)
+  })
+
+  describe('tx_code brute-force lockout (count-first gate)', () => {
+    const LOCKED_MESSAGE = 'Pre-authorized code is invalid, consumed, or locked'
+    const INVALID_TX_CODE_MESSAGE = 'Invalid tx_code provided'
+
+    const saveWithTxCode = async (
+      provider: ReturnType<typeof firestorePreAuthorizedCodeStore>,
+      code: string
+    ) => {
+      await provider.save(PreAuthorizedCode(code), configurations, 1234, {
+        tx_code_input_mode: 'numeric',
+      })
+    }
+
+    it('increments attempts before comparing tx_code and keeps the code under the limit', async () => {
+      const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+      await saveWithTxCode(provider, 'bf-under')
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-under'), 9999), {
+        name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
+      })
+
+      const doc = store.get('vcknots/v1/preCodes/bf-under')
+      assert.ok(doc)
+      assert.equal(doc.attempts, 1)
+    })
+
+    it('rejects a locked/exhausted code before comparing the tx_code', async () => {
+      const provider = firestorePreAuthorizedCodeStore({ app: mockApp, maxTxCodeAttempts: 2 })
+      await saveWithTxCode(provider, 'bf-locked')
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-locked'), 9999), {
+        name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
+      })
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-locked'), 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+      assert.ok(!store.has('vcknots/v1/preCodes/bf-locked'))
+
+      // Even the correct PIN is rejected once the code is locked/gone.
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-locked'), 1234), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
+
+    it('falls back to the default limit when maxTxCodeAttempts is NaN', async () => {
+      const provider = firestorePreAuthorizedCodeStore({
+        app: mockApp,
+        maxTxCodeAttempts: Number.NaN,
+      })
+      await saveWithTxCode(provider, 'bf-nan')
+
+      for (let i = 0; i < 4; i++) {
+        await assert.rejects(provider.consume(PreAuthorizedCode('bf-nan'), 9999), {
+          name: 'invalid_grant',
+          message: INVALID_TX_CODE_MESSAGE,
+        })
+      }
+      assert.equal(store.get('vcknots/v1/preCodes/bf-nan')?.attempts, 4)
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-nan'), 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+      assert.ok(!store.has('vcknots/v1/preCodes/bf-nan'))
+    })
+
+    it('falls back to the default limit when maxTxCodeAttempts is Infinity', async () => {
+      const provider = firestorePreAuthorizedCodeStore({
+        app: mockApp,
+        maxTxCodeAttempts: Number.POSITIVE_INFINITY,
+      })
+      await saveWithTxCode(provider, 'bf-inf')
+
+      for (let i = 0; i < 4; i++) {
+        await assert.rejects(provider.consume(PreAuthorizedCode('bf-inf'), 9999), {
+          name: 'invalid_grant',
+          message: INVALID_TX_CODE_MESSAGE,
+        })
+      }
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-inf'), 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+      assert.ok(!store.has('vcknots/v1/preCodes/bf-inf'))
+    })
+
+    it('clamps a maxTxCodeAttempts below 1 up to a single attempt', async () => {
+      const provider = firestorePreAuthorizedCodeStore({ app: mockApp, maxTxCodeAttempts: 0 })
+      await saveWithTxCode(provider, 'bf-zero')
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-zero'), 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+      assert.ok(!store.has('vcknots/v1/preCodes/bf-zero'))
+    })
+
+    it('enforces a custom maxTxCodeAttempts and deletes when exhausted', async () => {
+      const provider = firestorePreAuthorizedCodeStore({ app: mockApp, maxTxCodeAttempts: 2 })
+      await saveWithTxCode(provider, 'bf-custom')
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-custom'), 9999), {
+        name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
+      })
+      assert.equal(store.get('vcknots/v1/preCodes/bf-custom')?.attempts, 1)
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-custom'), 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+      assert.ok(!store.has('vcknots/v1/preCodes/bf-custom'))
+    })
+
+    it('deletes the code once a failed attempt exhausts the default limit', async () => {
+      const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+      await saveWithTxCode(provider, 'bf-exhaust')
+
+      for (let i = 0; i < 4; i++) {
+        await assert.rejects(provider.consume(PreAuthorizedCode('bf-exhaust'), 9999), {
+          name: 'invalid_grant',
+          message: INVALID_TX_CODE_MESSAGE,
+        })
+      }
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-exhaust'), 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+      assert.ok(!store.has('vcknots/v1/preCodes/bf-exhaust'))
+    })
+
+    it('admits and consumes the correct tx_code through the same gate', async () => {
+      const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+      await saveWithTxCode(provider, 'bf-ok')
+
+      const result = await provider.consume(PreAuthorizedCode('bf-ok'), 1234)
+      assert.deepStrictEqual(result, configurations)
+      assert.ok(!store.has('vcknots/v1/preCodes/bf-ok'))
+    })
+
+    it('uses LOCKED_MESSAGE for unknown codes (parity with DynamoDB gate)', async () => {
+      const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-missing'), 1234), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
   })
 })

--- a/google-cloud/test/providers/firestore-pre-authorized-code-store.provider.spec.ts
+++ b/google-cloud/test/providers/firestore-pre-authorized-code-store.provider.spec.ts
@@ -495,6 +495,31 @@ describe('firestorePreAuthorizedCodeStore', () => {
       assert.ok(!store.has('vcknots/v1/preCodes/bf-ok'))
     })
 
+    it('allows only one concurrent successful consume of the same code', async () => {
+      const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+      await saveWithTxCode(provider, 'bf-race')
+
+      const outcomes = await Promise.allSettled([
+        provider.consume(PreAuthorizedCode('bf-race'), 1234),
+        provider.consume(PreAuthorizedCode('bf-race'), 1234),
+      ])
+
+      const fulfilled = outcomes.filter((o) => o.status === 'fulfilled')
+      const rejected = outcomes.filter((o) => o.status === 'rejected')
+      assert.equal(fulfilled.length, 1)
+      assert.equal(rejected.length, 1)
+      assert.deepStrictEqual(
+        (fulfilled[0] as PromiseFulfilledResult<typeof configurations>).value,
+        configurations
+      )
+      assert.equal((rejected[0] as PromiseRejectedResult).reason?.name, 'invalid_grant')
+      assert.equal(
+        (rejected[0] as PromiseRejectedResult).reason?.message,
+        'Pre-authorized code has already been consumed'
+      )
+      assert.ok(!store.has('vcknots/v1/preCodes/bf-race'))
+    })
+
     it('uses LOCKED_MESSAGE for unknown codes (parity with DynamoDB gate)', async () => {
       const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
       await assert.rejects(provider.consume(PreAuthorizedCode('bf-missing'), 1234), {

--- a/google-cloud/test/providers/firestore-pre-authorized-code-store.provider.spec.ts
+++ b/google-cloud/test/providers/firestore-pre-authorized-code-store.provider.spec.ts
@@ -47,6 +47,27 @@ describe('firestorePreAuthorizedCodeStore', () => {
     assert.deepStrictEqual(valid, configurations)
   })
 
+  it('should throw invalid_tx_code when saving a non-numeric tx_code in numeric mode', async () => {
+    const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+    await assert.rejects(
+      provider.save(PreAuthorizedCode('save-invalid-numeric'), configurations, 'abc', {
+        tx_code_input_mode: 'numeric',
+      }),
+      { name: 'invalid_tx_code' }
+    )
+    assert.ok(!store.has('vcknots/v1/preCodes/save-invalid-numeric'))
+  })
+
+  it('should throw invalid_tx_code when saving a negative number in numeric mode', async () => {
+    const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+    await assert.rejects(
+      provider.save(PreAuthorizedCode('save-negative-numeric'), configurations, -1, {
+        tx_code_input_mode: 'numeric',
+      }),
+      { name: 'invalid_tx_code' }
+    )
+  })
+
   it('should throw invalid_grant for incorrect tx_code', async () => {
     const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
     await provider.save(PreAuthorizedCode('test-code-wrong'), configurations, 123, {
@@ -215,8 +236,56 @@ describe('firestorePreAuthorizedCodeStore', () => {
 
     await assert.rejects(provider.consume(PreAuthorizedCode('expiring-code'), undefined), {
       name: 'invalid_grant',
+      message: 'Pre-authorized code has expired',
     })
     assert.ok(!store.has('vcknots/v1/preCodes/expiring-code'))
+  })
+
+  it('should throw invalid_request when tx_code is required but missing', async () => {
+    const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+    await provider.save(PreAuthorizedCode('tx-required'), configurations, 1234, {
+      tx_code_input_mode: 'numeric',
+    })
+    await assert.rejects(provider.consume(PreAuthorizedCode('tx-required')), {
+      name: 'invalid_request',
+      message: 'tx_code is required for this pre-authorized code',
+    })
+    assert.equal(store.get('vcknots/v1/preCodes/tx-required')?.attempts, 1)
+  })
+
+  it('should lock out when tx_code is required but missing on the final attempt', async () => {
+    const LOCKED_MESSAGE = 'Pre-authorized code is invalid, consumed, or locked'
+    const provider = firestorePreAuthorizedCodeStore({ app: mockApp, maxTxCodeAttempts: 1 })
+    await provider.save(PreAuthorizedCode('tx-required-lock'), configurations, 1234, {
+      tx_code_input_mode: 'numeric',
+    })
+    await assert.rejects(provider.consume(PreAuthorizedCode('tx-required-lock')), {
+      name: 'invalid_grant',
+      message: LOCKED_MESSAGE,
+    })
+    assert.ok(!store.has('vcknots/v1/preCodes/tx-required-lock'))
+  })
+
+  it('should throw invalid_request when tx_code is provided for a code without tx_code', async () => {
+    const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+    await provider.save(PreAuthorizedCode('tx-unexpected'), configurations)
+    await assert.rejects(provider.consume(PreAuthorizedCode('tx-unexpected'), 1234), {
+      name: 'invalid_request',
+      message: 'tx_code should not be provided for this pre-authorized code',
+    })
+    assert.equal(store.get('vcknots/v1/preCodes/tx-unexpected')?.attempts, 1)
+  })
+
+  it('should throw invalid_grant for incorrect tx_code in text mode', async () => {
+    const provider = firestorePreAuthorizedCodeStore({ app: mockApp })
+    await provider.save(PreAuthorizedCode('text-wrong'), configurations, 'secret', {
+      tx_code_input_mode: 'text',
+    })
+    await assert.rejects(provider.consume(PreAuthorizedCode('text-wrong'), 'wrong'), {
+      name: 'invalid_grant',
+      message: 'Invalid tx_code provided',
+    })
+    assert.equal(store.get('vcknots/v1/preCodes/text-wrong')?.attempts, 1)
   })
 
   it('should use default expiration of 5 minutes', async () => {
@@ -432,6 +501,24 @@ describe('firestorePreAuthorizedCodeStore', () => {
         name: 'invalid_grant',
         message: LOCKED_MESSAGE,
       })
+    })
+
+    it('rejects before comparing tx_code when a remaining doc already has attempts >= max', async () => {
+      const provider = firestorePreAuthorizedCodeStore({ app: mockApp, maxTxCodeAttempts: 2 })
+      await saveWithTxCode(provider, 'bf-seeded-max')
+
+      const path = 'vcknots/v1/preCodes/bf-seeded-max'
+      const existing = store.get(path)
+      assert.ok(existing)
+      store.set(path, { ...existing, attempts: 2 })
+
+      await assert.rejects(provider.consume(PreAuthorizedCode('bf-seeded-max'), 1234), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+      // Gate rejects without deleting; attempts stay at the seeded max.
+      assert.ok(store.has(path))
+      assert.equal(store.get(path)?.attempts, 2)
     })
   })
 })

--- a/google-cloud/test/providers/firestore-test-mock.ts
+++ b/google-cloud/test/providers/firestore-test-mock.ts
@@ -35,6 +35,10 @@ export const createFirestoreTestMock = (): FirestoreTestMock => {
   const store = new Map<string, Record<string, unknown>>()
 
   // Fake Firestore instance backed by the in-memory store, injected via DI.
+  // Serialize runTransaction like Firestore's per-client contention handling so
+  // concurrent consume races in unit tests see a committed prior delete.
+  let transactionQueue: Promise<unknown> = Promise.resolve()
+
   const mockFirestore = {
     settings: () => {},
     doc: (path: string) => {
@@ -62,27 +66,35 @@ export const createFirestoreTestMock = (): FirestoreTestMock => {
     runTransaction: async <T>(
       updateFunction: (transaction: MockFirestoreTransaction) => Promise<T>
     ): Promise<T> => {
-      const transaction: MockFirestoreTransaction = {
-        get: async (docRef) => ({
-          exists: store.has(docRef.path),
-          data: () => store.get(docRef.path),
-          ref: docRef,
-        }),
-        set: (docRef, data, options) => {
-          if (options?.merge) {
-            const current = store.get(docRef.path) ?? {}
-            store.set(docRef.path, { ...current, ...data })
-          } else {
-            store.set(docRef.path, { ...data })
-          }
-          return transaction
-        },
-        delete: (docRef) => {
-          store.delete(docRef.path)
-          return transaction
-        },
-      }
-      return updateFunction(transaction)
+      const run = transactionQueue.then(async () => {
+        const transaction: MockFirestoreTransaction = {
+          get: async (docRef) => ({
+            exists: store.has(docRef.path),
+            data: () => store.get(docRef.path),
+            ref: docRef,
+          }),
+          set: (docRef, data, options) => {
+            if (options?.merge) {
+              const current = store.get(docRef.path) ?? {}
+              store.set(docRef.path, { ...current, ...data })
+            } else {
+              store.set(docRef.path, { ...data })
+            }
+            return transaction
+          },
+          delete: (docRef) => {
+            store.delete(docRef.path)
+            return transaction
+          },
+        }
+        return updateFunction(transaction)
+      })
+      // Keep the queue moving even when a transaction throws.
+      transactionQueue = run.then(
+        () => undefined,
+        () => undefined
+      )
+      return run
     },
   } as unknown as Firestore
 

--- a/issuer+verifier/src/providers/in-memory/in-memory-pre-authorized-code-store.provider.ts
+++ b/issuer+verifier/src/providers/in-memory/in-memory-pre-authorized-code-store.provider.ts
@@ -2,8 +2,31 @@ import { raise } from '../../errors'
 import { PreAuthorizedCode, PreAuthorizedCodeStoreEntry } from '../../pre-authorized-code.types'
 import { PreAuthorizedCodeStoreProvider } from '../provider.types'
 
-export const inMemoryPreAuthorizedCodeStore = (): PreAuthorizedCodeStoreProvider => {
-  const codes = new Map<PreAuthorizedCode, PreAuthorizedCodeStoreEntry>()
+export type InMemoryPreAuthorizedCodeStoreOptions = {
+  /**
+   * Number of failed `tx_code` attempts allowed per pre-authorized code before it
+   * is invalidated (brute-force lockout). Defaults to 5.
+   */
+  maxTxCodeAttempts?: number
+}
+
+type InMemoryPreAuthorizedCodeEntry = PreAuthorizedCodeStoreEntry & {
+  /** Number of failed `tx_code` attempts so far (brute-force lockout counter). */
+  attempts?: number
+}
+
+const DEFAULT_MAX_TX_CODE_ATTEMPTS = 5
+const LOCKED_MESSAGE = 'Pre-authorized code is invalid, consumed, or locked'
+
+export const inMemoryPreAuthorizedCodeStore = (
+  options?: InMemoryPreAuthorizedCodeStoreOptions
+): PreAuthorizedCodeStoreProvider => {
+  const codes = new Map<PreAuthorizedCode, InMemoryPreAuthorizedCodeEntry>()
+  const maxTxCodeAttemptsRaw = options?.maxTxCodeAttempts ?? DEFAULT_MAX_TX_CODE_ATTEMPTS
+  const maxTxCodeAttempts = Number.isFinite(maxTxCodeAttemptsRaw)
+    ? Math.max(1, Math.floor(maxTxCodeAttemptsRaw))
+    : DEFAULT_MAX_TX_CODE_ATTEMPTS
+
   const toDigitString = (value: string | number): string | null => {
     if (typeof value === 'number') {
       return Number.isSafeInteger(value) && value >= 0 ? value.toString() : null
@@ -16,16 +39,30 @@ export const inMemoryPreAuthorizedCodeStore = (): PreAuthorizedCodeStoreProvider
     name: 'in-memory-pre-authorized-code-provider',
     single: true,
 
-    async save(code, credentialConfigurationIds, tx_code, options) {
-      const ttlSecRaw = Number(options?.ttlSec ?? 300)
+    async save(code, credentialConfigurationIds, tx_code, saveOptions) {
+      const ttlSecRaw = Number(saveOptions?.ttlSec ?? 300)
       const ttlSecCandidate = Math.floor(ttlSecRaw)
       const ttlSec = Number.isFinite(ttlSecRaw) && ttlSecCandidate > 0 ? ttlSecCandidate : 300
-      const tx_code_input_mode = options?.tx_code_input_mode ?? 'numeric'
+      const tx_code_input_mode = saveOptions?.tx_code_input_mode ?? 'numeric'
       const expiresAt = new Date().getTime() + ttlSec * 1000
+
+      let storedTxCode = tx_code
+      if (tx_code !== undefined && tx_code_input_mode !== 'text') {
+        const canonical = toDigitString(tx_code)
+        if (canonical === null) {
+          raise('invalid_tx_code', {
+            message: 'tx_code must be a non-negative integer for numeric input mode',
+          })
+        } else {
+          // Keep the canonical digit-string so leading zeros survive round-trips.
+          storedTxCode = canonical
+        }
+      }
+
       codes.set(code, {
         code,
         credential_configuration_ids: credentialConfigurationIds,
-        tx_code,
+        tx_code: storedTxCode,
         tx_code_input_mode,
         expires_at: expiresAt,
       })
@@ -34,49 +71,70 @@ export const inMemoryPreAuthorizedCodeStore = (): PreAuthorizedCodeStoreProvider
 
     // validate and fetch credential configuration ids
     async consume(code, tx_code) {
+      // Count-first admission gate (brute-force lockout): increment `attempts`
+      // only while the code still exists AND the per-code limit hasn't been reached,
+      // then compare the tx_code. Once the limit is hit, every further attempt
+      // (including the correct PIN) is rejected before the tx_code is compared.
       const entry = codes.get(code)
       if (!entry) {
-        throw raise('invalid_grant', {
-          message: 'Pre-authorized code not found',
-        })
+        throw raise('invalid_grant', { message: LOCKED_MESSAGE })
       }
-      if (entry.expires_at && entry.expires_at < new Date().getTime()) {
+      const currentAttempts = entry.attempts ?? 0
+      if (currentAttempts >= maxTxCodeAttempts) {
+        throw raise('invalid_grant', { message: LOCKED_MESSAGE })
+      }
+      const attempts = currentAttempts + 1
+      const item: InMemoryPreAuthorizedCodeEntry = { ...entry, attempts }
+      codes.set(code, item)
+
+      const lockoutIfExhausted = (): void => {
+        if ((item.attempts ?? 0) >= maxTxCodeAttempts) {
+          codes.delete(code)
+          raise('invalid_grant', { message: LOCKED_MESSAGE })
+        }
+      }
+
+      if (item.expires_at && item.expires_at < new Date().getTime()) {
         codes.delete(code)
         throw raise('invalid_grant', {
           message: 'Pre-authorized code has expired',
         })
       }
-      if (entry.tx_code !== undefined) {
+
+      if (item.tx_code !== undefined) {
         if (tx_code === undefined) {
+          lockoutIfExhausted()
           throw raise('invalid_request', {
             message: 'tx_code is required for this pre-authorized code',
           })
         }
-        if (entry.tx_code_input_mode !== 'text') {
-          const expected = toDigitString(entry.tx_code)
+        if (item.tx_code_input_mode !== 'text') {
+          const expected = toDigitString(item.tx_code)
           const actual = toDigitString(tx_code)
           if (expected === null || actual === null || expected !== actual) {
+            lockoutIfExhausted()
             throw raise('invalid_grant', {
               message: 'Invalid tx_code provided',
             })
           }
         } else {
-          if (entry.tx_code !== tx_code) {
+          if (item.tx_code !== tx_code) {
+            lockoutIfExhausted()
             throw raise('invalid_grant', {
               message: 'Invalid tx_code provided',
             })
           }
         }
-        codes.delete(code)
-        return entry.credential_configuration_ids
-      }
-      if (tx_code !== undefined) {
+      } else if (tx_code !== undefined) {
+        lockoutIfExhausted()
         throw raise('invalid_request', {
           message: 'tx_code should not be provided for this pre-authorized code',
         })
       }
+
+      // Delete to prevent the code from being consumed twice.
       codes.delete(code)
-      return entry.credential_configuration_ids
+      return item.credential_configuration_ids
     },
   }
 }

--- a/issuer+verifier/test/providers/in-memory/in-memory-pre-authorized-code.provider.spec.ts
+++ b/issuer+verifier/test/providers/in-memory/in-memory-pre-authorized-code.provider.spec.ts
@@ -128,5 +128,208 @@ describe('inMemoryPreAuthorizedCode', () => {
       mock.timers.tick(2_000)
       await assert.rejects(provider.consume(sampleCode), { name: 'invalid_grant' })
     })
+
+    it('should throw invalid_tx_code when saving a non-numeric tx_code in numeric mode', async () => {
+      await assert.rejects(
+        provider.save(sampleCode, configurations, 'abc', { tx_code_input_mode: 'numeric' }),
+        { name: 'invalid_tx_code' }
+      )
+    })
+
+    it('should throw invalid_request when tx_code is required but missing', async () => {
+      await provider.save(sampleCode, configurations, 1234, { tx_code_input_mode: 'numeric' })
+      await assert.rejects(provider.consume(sampleCode), {
+        name: 'invalid_request',
+        message: 'tx_code is required for this pre-authorized code',
+      })
+    })
+
+    it('should throw invalid_request when tx_code is provided for a code without tx_code', async () => {
+      await provider.save(sampleCode, configurations)
+      await assert.rejects(provider.consume(sampleCode, 1234), {
+        name: 'invalid_request',
+        message: 'tx_code should not be provided for this pre-authorized code',
+      })
+    })
+
+    it('should throw invalid_grant for incorrect tx_code in text mode', async () => {
+      await provider.save(sampleCode, configurations, 'secret', { tx_code_input_mode: 'text' })
+      await assert.rejects(provider.consume(sampleCode, 'wrong'), {
+        name: 'invalid_grant',
+        message: 'Invalid tx_code provided',
+      })
+    })
+
+    it('should throw invalid_grant with expired message for an expired code', async () => {
+      mock.timers.enable({ apis: ['Date'] })
+      await provider.save(sampleCode, configurations, undefined, { ttlSec: 1 })
+      mock.timers.tick(1001)
+      await assert.rejects(provider.consume(sampleCode), {
+        name: 'invalid_grant',
+        message: 'Pre-authorized code has expired',
+      })
+    })
+  })
+
+  describe('tx_code brute-force lockout (count-first gate)', () => {
+    const LOCKED_MESSAGE = 'Pre-authorized code is invalid, consumed, or locked'
+    const INVALID_TX_CODE_MESSAGE = 'Invalid tx_code provided'
+
+    const saveWithTxCode = async (
+      store: ReturnType<typeof inMemoryPreAuthorizedCodeStore>,
+      code: PreAuthorizedCode
+    ) => {
+      await store.save(code, configurations, 1234, { tx_code_input_mode: 'numeric' })
+    }
+
+    it('increments attempts before comparing tx_code and keeps the code under the limit', async () => {
+      const store = inMemoryPreAuthorizedCodeStore()
+      await saveWithTxCode(store, sampleCode)
+
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
+      })
+
+      // Still admit another attempt under the default limit.
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
+      })
+    })
+
+    it('rejects a locked/exhausted code before comparing the tx_code', async () => {
+      const store = inMemoryPreAuthorizedCodeStore({ maxTxCodeAttempts: 2 })
+      await saveWithTxCode(store, sampleCode)
+
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
+      })
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+
+      // Even the correct PIN is rejected once the code is locked/gone.
+      await assert.rejects(store.consume(sampleCode, 1234), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
+
+    it('falls back to the default limit when maxTxCodeAttempts is NaN', async () => {
+      const store = inMemoryPreAuthorizedCodeStore({ maxTxCodeAttempts: Number.NaN })
+      await saveWithTxCode(store, sampleCode)
+
+      for (let i = 0; i < 4; i++) {
+        await assert.rejects(store.consume(sampleCode, 9999), {
+          name: 'invalid_grant',
+          message: INVALID_TX_CODE_MESSAGE,
+        })
+      }
+
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+      await assert.rejects(store.consume(sampleCode, 1234), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
+
+    it('falls back to the default limit when maxTxCodeAttempts is Infinity', async () => {
+      const store = inMemoryPreAuthorizedCodeStore({
+        maxTxCodeAttempts: Number.POSITIVE_INFINITY,
+      })
+      await saveWithTxCode(store, sampleCode)
+
+      for (let i = 0; i < 4; i++) {
+        await assert.rejects(store.consume(sampleCode, 9999), {
+          name: 'invalid_grant',
+          message: INVALID_TX_CODE_MESSAGE,
+        })
+      }
+
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
+
+    it('clamps a maxTxCodeAttempts below 1 up to a single attempt', async () => {
+      const store = inMemoryPreAuthorizedCodeStore({ maxTxCodeAttempts: 0 })
+      await saveWithTxCode(store, sampleCode)
+
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+      await assert.rejects(store.consume(sampleCode, 1234), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
+
+    it('enforces a custom maxTxCodeAttempts and deletes when exhausted', async () => {
+      const store = inMemoryPreAuthorizedCodeStore({ maxTxCodeAttempts: 2 })
+      await saveWithTxCode(store, sampleCode)
+
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: INVALID_TX_CODE_MESSAGE,
+      })
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
+
+    it('deletes the code once a failed attempt exhausts the default limit', async () => {
+      const store = inMemoryPreAuthorizedCodeStore()
+      await saveWithTxCode(store, sampleCode)
+
+      for (let i = 0; i < 4; i++) {
+        await assert.rejects(store.consume(sampleCode, 9999), {
+          name: 'invalid_grant',
+          message: INVALID_TX_CODE_MESSAGE,
+        })
+      }
+
+      await assert.rejects(store.consume(sampleCode, 9999), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
+
+    it('admits and consumes the correct tx_code through the same gate', async () => {
+      const store = inMemoryPreAuthorizedCodeStore()
+      await saveWithTxCode(store, sampleCode)
+
+      const result = await store.consume(sampleCode, 1234)
+      assert.deepStrictEqual(result, configurations)
+      await assert.rejects(store.consume(sampleCode, 1234), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
+
+    it('uses LOCKED_MESSAGE for unknown codes (parity with DynamoDB/Firestore)', async () => {
+      const store = inMemoryPreAuthorizedCodeStore()
+      await assert.rejects(store.consume(sampleCode, 1234), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
+
+    it('locks out when tx_code is required but missing on the final attempt', async () => {
+      const store = inMemoryPreAuthorizedCodeStore({ maxTxCodeAttempts: 1 })
+      await saveWithTxCode(store, sampleCode)
+      await assert.rejects(store.consume(sampleCode), {
+        name: 'invalid_grant',
+        message: LOCKED_MESSAGE,
+      })
+    })
   })
 })

--- a/server/aws/README.ja.md
+++ b/server/aws/README.ja.md
@@ -94,6 +94,8 @@ cp .env.example .env
 
 **`TX_CODE_PEPPER` は全サーバーで必須**です。`tx_code` を DynamoDB に保存する前に HMAC-SHA256 でハッシュ化するための秘密値（pepper）です。`@trustknots/aws` は import 時にこの値を評価するため、未設定の場合は Issuer・Authorization Server・Verifier のいずれも起動時に `TX_CODE_PEPPER environment variable is required` でエラーになります。十分に長いランダム文字列を設定し、環境ごとに固定して運用してください（変更すると既存データの `tx_code` 検証に失敗します）。
 
+誤った `tx_code` の試行は、pre-authorized code ごとに `dynamodbPreAuthorizedCodeStore` が制限します（既定 **5** 回）。上限を変える場合は、`server/aws/src/apps` で provider を生成するときに `maxTxCodeAttempts` を渡してください（環境変数は未対応です）。上限到達後はコードが削除され、正しい `tx_code` でも以降のリクエストは `invalid_grant` になります。
+
 ## サーバーの起動
 
 `server/aws/src` ディレクトリで、各サーバーを別々のターミナルで起動します：

--- a/server/aws/README.md
+++ b/server/aws/README.md
@@ -94,6 +94,8 @@ Edit `.env`. Table names are available in the CloudFormation stack outputs after
 
 **`TX_CODE_PEPPER` is required by every server.** It is a secret pepper used to HMAC-hash `tx_code` values before storing them in DynamoDB. Because `@trustknots/aws` evaluates it at import time, the Issuer, Authorization Server, and Verifier all fail at startup with `TX_CODE_PEPPER environment variable is required` when it is missing. Use a sufficiently long random secret and keep it stable per environment — rotating it invalidates previously stored `tx_code` hashes.
 
+Failed `tx_code` attempts are limited per pre-authorized code (default **5**) by `dynamodbPreAuthorizedCodeStore`. To change the limit, pass `maxTxCodeAttempts` when constructing the provider in `server/aws/src/apps` (no environment variable yet). After the limit is reached the code is deleted, and further requests fail with `invalid_grant` even with the correct `tx_code`.
+
 ## Start the Servers
 
 Run each server in a separate terminal from `server/aws/src`:

--- a/server/google-cloud/README.ja.md
+++ b/server/google-cloud/README.ja.md
@@ -72,9 +72,10 @@ google-cloud/
    既存データの `tx_code` 検証に失敗するようになります）。
 
    誤った `tx_code` の試行は、pre-authorized code ごとに `firestorePreAuthorizedCodeStore` が制限します（既定 **5** 回）。
-   上限を変える場合は、`firestore()` など Google Cloud provider 生成時に `maxTxCodeAttempts` を渡してください
-   （`server/google-cloud` のアプリ配線側。環境変数は未対応です）。上限到達後はコードが削除され、
-   正しい `tx_code` でも以降のリクエストは `invalid_grant` になります。
+   上限を変える場合は、`firestore()` のオプションではなく、その provider に直接
+   `firestorePreAuthorizedCodeStore({ app, databaseId, namespace, maxTxCodeAttempts })` のように渡し、
+   `firestore()` が返す pre-authorized-code store の代わりに登録してください（環境変数は未対応です）。
+   上限到達後はコードが削除され、正しい `tx_code` でも以降のリクエストは `invalid_grant` になります。
 
    任意の環境変数:
 

--- a/server/google-cloud/README.ja.md
+++ b/server/google-cloud/README.ja.md
@@ -71,6 +71,11 @@ google-cloud/
    十分に長いランダム文字列を設定し、環境ごとに固定して運用してください（安易に変更すると、
    既存データの `tx_code` 検証に失敗するようになります）。
 
+   誤った `tx_code` の試行は、pre-authorized code ごとに `firestorePreAuthorizedCodeStore` が制限します（既定 **5** 回）。
+   上限を変える場合は、`firestore()` など Google Cloud provider 生成時に `maxTxCodeAttempts` を渡してください
+   （`server/google-cloud` のアプリ配線側。環境変数は未対応です）。上限到達後はコードが削除され、
+   正しい `tx_code` でも以降のリクエストは `invalid_grant` になります。
+
    任意の環境変数:
 
    - `FIRESTORE_DATABASE_ID`

--- a/server/google-cloud/README.md
+++ b/server/google-cloud/README.md
@@ -71,6 +71,11 @@ To start this server, follow the steps below.
    Use a sufficiently long random secret and keep it stable per environment (do not rotate casually, because
    previously stored `tx_code` hashes will no longer validate after changing it).
 
+   Failed `tx_code` attempts are limited per pre-authorized code (default **5**) by `firestorePreAuthorizedCodeStore`.
+   To change the limit, pass `maxTxCodeAttempts` when constructing the Firestore providers (for example via
+   `firestore()` / app wiring in `server/google-cloud`; no environment variable yet). After the limit is reached
+   the code is deleted, and further requests fail with `invalid_grant` even with the correct `tx_code`.
+
    Optional variables:
 
    - `FIRESTORE_DATABASE_ID`

--- a/server/google-cloud/README.md
+++ b/server/google-cloud/README.md
@@ -72,9 +72,11 @@ To start this server, follow the steps below.
    previously stored `tx_code` hashes will no longer validate after changing it).
 
    Failed `tx_code` attempts are limited per pre-authorized code (default **5**) by `firestorePreAuthorizedCodeStore`.
-   To change the limit, pass `maxTxCodeAttempts` when constructing the Firestore providers (for example via
-   `firestore()` / app wiring in `server/google-cloud`; no environment variable yet). After the limit is reached
-   the code is deleted, and further requests fail with `invalid_grant` even with the correct `tx_code`.
+   To change the limit, pass `maxTxCodeAttempts` to that provider directly, for example
+   `firestorePreAuthorizedCodeStore({ app, databaseId, namespace, maxTxCodeAttempts })`, and register it
+   in place of the pre-authorized-code store from `firestore()` (no environment variable yet).
+   After the limit is reached the code is deleted, and further requests fail with `invalid_grant`
+   even with the correct `tx_code`.
 
    Optional variables:
 

--- a/server/single/README.ja.md
+++ b/server/single/README.ja.md
@@ -57,6 +57,8 @@ single/
 
    DPoP の mode（`off` / `optional` / `required`）は、`server/samples/oauth-server.json` の `authorization_server.default_client` / `authorization_server.anonymous_client` で設定します。
 
+   Credential Offer に `tx_code` が含まれる場合、in-memory の pre-authorized-code store がコードごとに誤った試行を制限します（既定 **5** 回）。上限を変える場合は `inMemoryPreAuthorizedCodeStore({ maxTxCodeAttempts: ... })` を指定してください（サンプルの `inMemory()` は既定値のまま。環境変数は未対応です）。上限到達後はコードが削除され、正しい `tx_code` でも以降の token request は `invalid_grant` になります。
+
 2. **依存関係のインストール**（ルートディレクトリで実行）
 
    ```bash

--- a/server/single/README.md
+++ b/server/single/README.md
@@ -59,6 +59,8 @@ To start this server, follow the steps below.
 
    Configure the DPoP mode (`off` / `optional` / `required`) in `authorization_server.default_client` / `authorization_server.anonymous_client` in `server/samples/oauth-server.json`.
 
+   When Credential Offers include `tx_code`, the in-memory pre-authorized-code store limits failed guesses per code (default **5**). Pass `maxTxCodeAttempts` to `inMemoryPreAuthorizedCodeStore({ ... })` if you need a different limit (the sample `inMemory()` wiring uses the default; no environment variable yet). After the limit is reached the code is removed, and further token requests fail with `invalid_grant` even with the correct `tx_code`.
+
 2. **Install Dependencies** (Run from root directory)
 
    ```bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `tx_code` の誤入力試行に回数上限（デフォルト5回）を導入しました。
  * 上限到達後はコードが無効化され、正しい `tx_code` でも `invalid_grant` になります。
  * 上限は `maxTxCodeAttempts` で調整できます。
* **ドキュメント**
  * Credential Offer 作成／トークン要求／各ストア設定手順に、ロックアウト時の挙動と設定方法を追記しました（環境変数では未対応）。
* **テスト**
  * `tx_code` のバリデーション／ロックアウト挙動の検証を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->