### PR TITLE
docs: update wallet docs for SD-JWT VC support and current Go API

### DIFF
--- a/docs/en/wallet.md
+++ b/docs/en/wallet.md
@@ -100,7 +100,11 @@ go mod download
 The library exposes its top-level API in the `github.com/trustknots/vcknots/wallet` package. The simplest way to create a wallet is `wallet.NewWallet()`, which initializes every dispatcher component with its default plugin implementation:
 
 ```go
-import "github.com/trustknots/vcknots/wallet"
+import (
+    "log"
+
+    "github.com/trustknots/vcknots/wallet"
+)
 
 w, err := wallet.NewWallet()
 if err != nil {
@@ -124,6 +128,7 @@ package main
 
 import (
     "crypto/x509"
+    "fmt"
     "os"
 
     "github.com/trustknots/vcknots/wallet"
@@ -168,7 +173,9 @@ func newWallet(certPath string) (*wallet.Wallet, error) {
         return nil, err
     }
     certPool := x509.NewCertPool()
-    certPool.AppendCertsFromPEM(certFile)
+    if !certPool.AppendCertsFromPEM(certFile) {
+        return nil, fmt.Errorf("failed to parse certificate: %s", certPath)
+    }
 
     oid4vpPresenter := &oid4vp.Oid4vpPresenter{
         X509TrustChainRoots: certPool,
@@ -268,6 +275,9 @@ The offer URI has the form `openid-credential-offer://?credential_offer=...`. Pa
 
 ```go
 import (
+    "encoding/json"
+    "net/url"
+
     "github.com/trustknots/vcknots/wallet"
     "github.com/trustknots/vcknots/wallet/credential"
     "github.com/trustknots/vcknots/wallet/receiver"
@@ -323,7 +333,11 @@ Notes on `ReceiveCredentialRequest`:
 After receiving a request URI in the form `openid4vp://authorize?...` from the verifier (typically by scanning a QR code; with the local sample server, via `POST /request` or `POST /request-object`), call `PresentCredential`:
 
 ```go
-import sdjwtvc "github.com/trustknots/vcknots/wallet/serializer/plugins/sdjwtvc"
+import (
+    "log"
+
+    sdjwtvc "github.com/trustknots/vcknots/wallet/serializer/plugins/sdjwtvc"
+)
 
 func presentCredential(w *wallet.Wallet, key wallet.IKeyEntry, oid4vpURI string) error {
     // Options for SD-JWT VC presentations: selective disclosure and Key Binding JWT
@@ -343,10 +357,10 @@ func presentCredential(w *wallet.Wallet, key wallet.IKeyEntry, oid4vpURI string)
 }
 ```
 
-`PresentCredential` parses the OID4VP request (including JAR request objects referenced by `request_uri`, whose signatures are verified against `X509TrustChainRoots`), selects the most recently received credential from the store (matching against the presentation definition is not performed yet), serializes and signs the Verifiable Presentation with `key`, and posts it to the verifier's `response_uri` (for `response_mode=direct_post`) or `redirect_uri`. The returned string is the redirect URI provided by the verifier, or empty when there is none.
+`PresentCredential` parses the OID4VP request (including JAR request objects referenced by `request_uri`, whose signatures are verified against `X509TrustChainRoots`), selects the most recently received credential from the store (matching against the presentation definition is not performed yet), serializes and signs the Verifiable Presentation with `key`, and posts it to the verifier's `response_uri` (`response_mode=direct_post`). The wallet does not send anything to `redirect_uri`; when the verifier's response contains a `redirect_uri`, it is returned to the caller as the return value, or empty when there is none.
 
 * **Presentation options:** The third argument accepts a format-specific options value. For SD-JWT VC, `sdjwtvc.SdJwtVcPresentationOptions` controls which claims are disclosed (`SelectedClaims`) and whether a Key Binding JWT is attached (`RequireKeyBinding`). The KB-JWT audience and nonce are filled automatically from the OID4VP request (`client_id` and `nonce`), as are `transaction_data` hashes when the request contains transaction data. Pass `nil` to use the default options for the credential's format (for JWT-VC presentations, `nil` is typical).
-* **Redirect handling:** Use `PresentCredentialWithOptions` with `wallet.PresentCredentialOptions{OnRedirect: func(uri string) error {...}}` when you want a callback invoked with the verifier's redirect URI.
+* **Redirect handling:** Use `PresentCredentialWithOptions` with `&wallet.PresentCredentialOptions{OnRedirect: func(uri string) error {...}}` when you want a callback invoked with the verifier's redirect URI.
 
 ### 3-4. Referencing Saved Credentials
 
@@ -381,7 +395,12 @@ When receiving a credential, the wallet must access the issuer's `.well-known/op
 `ReceiveCredential` fetches this metadata implicitly, but you can also fetch it explicitly with `FetchCredentialIssuerMetadata` and pass the result via the `CachedIssuerMetadata` field of `ReceiveCredentialRequest`. This avoids re-fetching the metadata on every `ReceiveCredential` call.
 
 ```go
-import receiverTypes "github.com/trustknots/vcknots/wallet/receiver/types"
+import (
+    "log"
+    "net/url"
+
+    receiverTypes "github.com/trustknots/vcknots/wallet/receiver/types"
+)
 
 func fetchIssuerMetadata(w *wallet.Wallet) (*receiverTypes.CredentialIssuerMetadata, error) {
     // Note: pass the issuer's base URL; the /.well-known/... path is resolved internally
@@ -536,7 +555,7 @@ func (w *Wallet) GetCredentialEntry(id string) (*SavedCredential, error)
 - `id`: The credential entry ID
 
 **Return value**:
-- The stored credential ([SavedCredential](#SavedCredential)), or `nil` when not found
+- The stored credential ([SavedCredential](#SavedCredential)); with the default local store, an error is returned when the ID does not exist
 
 ### FetchCredentialIssuerMetadata
 

--- a/docs/en/wallet.md
+++ b/docs/en/wallet.md
@@ -4,18 +4,28 @@ sidebar_position: 5
 
 # How to Set Up and Use the Wallet Feature
 
-This tutorial explains how to set up the VCKnots wallet library, provides sample implementations of its main features, and describes important considerations for using it in production environments.
+This tutorial explains how to set up the VCKnots wallet library (a Go library), how to receive and present credentials with it, and what to consider before using it in production environments.
+
+The wallet implements the OpenID for Verifiable Credentials specifications:
+
+* **Receiving credentials (OID4VCI):** the wallet obtains a credential from an issuer using a credential offer and the pre-authorized code flow.
+* **Presenting credentials (OID4VP):** the wallet responds to an `openid4vp://` authorization request and submits a Verifiable Presentation to a verifier.
+
+Both **JWT-VC** (`application/vc+jwt`) and **SD-JWT VC** (`application/dc+sd-jwt`) are supported for receiving and presenting, including selective disclosure and Key Binding JWT for SD-JWT VC.
 
 ## 1. Prerequisites
 
-This section outlines all the technical requirements needed to build the vcknots/wallet library and run the tutorial samples.
+* **Supported specifications:**
+    - Receiving: [OpenID for Verifiable Credential Issuance 1.0](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) (Pre-Authorized Code Flow)
+    - Presenting: [OpenID for Verifiable Presentations - draft 24](https://openid.net/specs/openid-4-verifiable-presentations-1_0-24.html) (cross-device flow, `response_mode=direct_post`)
+    - For the full implementation scope of each feature, see [VC Knots Coverage](./support-matrix.md).
 
 ### 1-1. Go Environment Requirements
 
-* **Go version:** The vcknots/wallet library requires Go 1.24.5.
+* **Go version:** The vcknots/wallet library requires the Go version pinned in `wallet/mise.toml` (currently Go 1.26.5).
 * **Development environment management (mise):**
-    - For this project, we strongly recommend using mise ([https://mise.jdx.dev/](https://mise.jdx.dev/)) to manage the development environment.
-    - For example, by running `mise install` as shown below, the required Go version will be installed automatically and environment variables will be configured.
+    - We recommend using [mise](https://mise.jdx.dev/) to manage the development environment.
+    - Running `mise install` in the `wallet` directory installs the required Go version and sets the necessary environment variables automatically.
 
 ```bash
 # macOS
@@ -30,458 +40,593 @@ mise install
 ```
 
 * **GOPRIVATE environment variable:**
-    - If you are not using mise, `go mod download` will fail.
-    - To work around this, you need to set the following environment variable manually.
+    - If you are not using mise, set the following environment variable manually. Without it, `go mod download` fails.
 
 ```bash
 export GOPRIVATE="github.com/trustknots/vcknots/wallet"
 ```
 
-### 1-2. Requirements for the Sample Execution Environment (Verifier/Issuer Server)
+### 1-2. Requirements for the Sample Execution Environment (Issuer/Verifier Server)
 
-The sample code in this tutorial for the Wallet library (especially for receiving and presenting Credentials) assumes that counterpart services (an Issuer and a Verifier) are available.
+The sample code in this tutorial (receiving and presenting credentials) assumes that counterpart services (an Issuer and a Verifier) are available. The Node.js-based sample server (`server/`) in this repository provides both.
 
-* **Node.js server:** The sample code in this tutorial requires that the Node.js-based sample server (`vcknots/server`), referenced in `README.md` and `package.json`, is running at http://localhost:8080.  
-
-* **Server setup:** This server uses the Hono framework and `@trustknots/vcknots`, and provides Issuer and Verifier endpoints defined in `example.ts` (for example: `/issue/credentials`, `/verifiers/:verifier/callback`).  
-
-* **Server startup steps:**
-    - Setting up this Node.js server is not optional; it is **required**.
-    - The `receiveMockCredential` and `presentation` functions in `server_integration.go` implicitly trigger HTTP requests to localhost:8080. If this server is not running, the code in “3. Sample Implementation” will fail with a `connection refused` error.
-
-Before running the Wallet Go code, **be sure** to start the server by executing the commands below.
-
-
+Start the server before running any wallet sample code:
 
 ```bash
-# From the wallet directory, move to the server directory
-cd ../server
+# From the root of the vcknots repository
 pnpm install
-pnpm -F server start
+
+# Build the issuer+verifier module, the server-core module, and the server module
+pnpm -F @trustknots/vcknots build
+pnpm -F @trustknots/server-core build
+pnpm -F @trustknots/server build
+
+# Start the server (listens on http://localhost:8080)
+pnpm -F @trustknots/server start
 ```
+
+The server exposes the endpoints used in this tutorial:
+
+* `POST /configurations/:configurationId/offer` — creates a credential offer
+* `POST /token`, `POST /nonce`, `POST /credentials` — OID4VCI token, nonce, and credential endpoints
+* `POST /request`, `POST /request-object` — creates an OID4VP authorization request
+* `POST /callback` — the verifier's response endpoint
+* `GET /.well-known/openid-credential-issuer`, `GET /.well-known/oauth-authorization-server` — metadata endpoints
+
+* **Allowing HTTP for local testing:** The wallet rejects non-HTTPS issuer and verifier endpoints by default. Because the local sample server runs on plain HTTP, enable HTTP explicitly when testing locally:
+
+```bash
+export VCKNOTS_WALLET_HTTP_ALLOWED=true
+```
+
+Alternatively, call `env.SetHTTPAllowed(true)` (package `github.com/trustknots/vcknots/wallet/env`) from your test code.
+
+> ⚠️ **Security warning:** Do not enable `VCKNOTS_WALLET_HTTP_ALLOWED` in production. Keep HTTPS-only validation active.
 
 ## 2. Initial Setup
 
-This section explains how to install the library dependencies and initialize the Controller instance, which aggregates the core Wallet features.
+This section explains how to install the library dependencies and initialize the `Wallet` instance, which aggregates the core wallet features.
 
 ### 2-1. Installing Dependencies
 
-After setting GOPRIVATE as a prerequisite, run the following command at the project root (the wallet directory) to download the dependencies listed in `go.mod` (such as `github.com/go-jose/go-jose/v4`, `go.etcd.io/bbolt`, `golang.org/x/crypto`, etc.).
-
+After setting GOPRIVATE, run the following command in the `wallet` directory to download the dependencies listed in `go.mod` (such as `github.com/go-jose/go-jose/v4`, `go.etcd.io/bbolt`, `golang.org/x/crypto`, etc.).
 
 ```bash
 go mod download
 ```
 
-### 2-2. Initializing the Wallet Controller
+### 2-2. Initializing the Wallet
 
-- The vcknots/wallet library uses a highly modular, dispatcher-based architecture.
-- The core logic (`controller.go`) depends on interfaces that handle specific tasks such as credstore (persistence), receiver (receiving), presenter (presentation), and verifier (verification).
+The library exposes its top-level API in the `github.com/trustknots/vcknots/wallet` package. The simplest way to create a wallet is `wallet.NewWallet()`, which initializes every dispatcher component with its default plugin implementation:
 
-- The `main` function in `server_integration.go` provides a standard recipe for instantiating the Controller.
-- This shows that the library heavily relies on a dependency injection (DI) pattern using a combination of default settings (`WithDefaultConfig()`) and plugins (`WithPlugin(presenter.Oid4vp, ...)`).
+```go
+import "github.com/trustknots/vcknots/wallet"
 
-The following code represents the standard Controller initialization process based on `server_integration.go`.
-This controller instance is required to run the tutorial sample code.
+w, err := wallet.NewWallet()
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+Internally, the `Wallet` coordinates six dispatcher components, each responsible for one aspect of wallet functionality:
+
+* `credstore.CredStoreDispatcher` — credential persistence (bbolt-backed local storage by default)
+* `receiver.ReceivingDispatcher` — credential issuance protocols (OID4VCI)
+* `presenter.PresentationDispatcher` — credential presentation protocols (OID4VP)
+* `serializer.SerializationDispatcher` — credential serialization (JWT-VC, SD-JWT VC)
+* `verifier.VerificationDispatcher` — cryptographic signature verification
+* `idprof.IdentityProfileDispatcher` — DIDs and identity profiles (`did:key`)
+
+When you need custom configuration (for example, to set the trust roots used for verifying OID4VP request objects), construct the dispatchers yourself and pass them to `wallet.NewWalletWithConfig`. Every dispatcher constructor returns an error, and any field left `nil` in `wallet.Config` falls back to its default implementation. The following code is the initialization used by the samples under `wallet/examples/`:
 
 ```go
 package main
 
 import (
-	"log"
-	"net/url"
-	
-	// Dispatcher packages inside vcknots/wallet
-	vcknots_wallet "github.com/trustknots/vcknots/wallet/pkg/controller"
-	"github.com/trustknots/vcknots/wallet/pkg/credstore"
-	"github.com/trustknots/vcknots/wallet/pkg/dispatcher/idprof"
-	receiverTypes "github.com/trustknots/vcknots/wallet/pkg/dispatcher/receiver"
-	"github.com/trustknots/vcknots/wallet/pkg/dispatcher/serializer"
-	"github.com/trustknots/vcknots/wallet/pkg/dispatcher/verifier"
-	"github.com/trustknots/vcknots/wallet/pkg/presenter"
-	oid4vp "github.com/trustknots/vcknots/wallet/pkg/presenter/oid4vp" // OpenID4VP plugin
-	"github.com/trustknots/vcknots/wallet/pkg/util"
-	
-	// Standard library for key generation and signing
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/sha256"
-	"github.com/go-jose/go-jose/v4"
-	"github.com/google/uuid"
+    "crypto/x509"
+    "os"
 
-	// Libraries used in the sample implementation
-	"io"
-	"net/http"
-	"github.com/trustknots/vcknots/wallet/pkg/types"
+    "github.com/trustknots/vcknots/wallet"
+    "github.com/trustknots/vcknots/wallet/credstore"
+    "github.com/trustknots/vcknots/wallet/idprof"
+    "github.com/trustknots/vcknots/wallet/presenter"
+    "github.com/trustknots/vcknots/wallet/presenter/plugins/oid4vp"
+    "github.com/trustknots/vcknots/wallet/receiver"
+    "github.com/trustknots/vcknots/wallet/serializer"
+    "github.com/trustknots/vcknots/wallet/verifier"
 )
 
-// NewController initializes all dispatchers
-// and returns the integrated Wallet controller.
-func NewController() *vcknots_wallet.Controller {
-    logger := util.NewLogger()
-
-    // 1. Initialize each dispatcher with default settings
-    credStoreDispatcher := credstore.NewCredStoreDispatcher(credstore.WithDefaultConfig())
-    receiverDispatcher := receiverTypes.NewReceivingDispatcher(receiverTypes.WithDefaultConfig())
-    serializationDispatcher := serializer.NewSerializationDispatcher(serializer.WithDefaultConfig())
-    verificationDispatcher := verifier.NewVerificationDispatcher(verifier.WithDefaultConfig())
-    idProfileDispatcher := idprof.NewIdentityProfileDispatcher(idprof.WithDefaultConfig())
-
-    // 2. Initialize the OpenID4VP plugin
-    // (the presentation logic is implemented as a plugin)
-    oid4vpPlugin, err := oid4vp.New(
-        oid4vp.WithLogger(logger),
-        oid4vp.WithVerificationDispatcher(verificationDispatcher),
-    )
-    if err!= nil {
-        panic(err)
+func newWallet(certPath string) (*wallet.Wallet, error) {
+    credStore, err := credstore.NewCredStoreDispatcher(credstore.WithDefaultConfig())
+    if err != nil {
+        return nil, err
     }
 
-    // 3. Register the OpenID4VP plugin with the presentation dispatcher
-    presentationDispatcher := presenter.NewPresentationDispatcher(
-        presenter.WithPlugin(presenter.Oid4vp, oid4vpPlugin),
-    )
-
-    // 4. Aggregate all dispatchers into the controller configuration
-    config := vcknots_wallet.ControllerConfig{
-        CredStore:  credStoreDispatcher,
-        IdProf:     idProfileDispatcher,
-        Receiver:   receiverDispatcher,
-        Serializer: serializationDispatcher,
-        Verifier:   verificationDispatcher,
-        Presenter:  presentationDispatcher,
-        Logger:     logger,
+    receiverDisp, err := receiver.NewReceivingDispatcher(receiver.WithDefaultConfig())
+    if err != nil {
+        return nil, err
     }
 
-    // 5. Instantiate the controller
-    return vcknots_wallet.NewController(config)
+    serializerDisp, err := serializer.NewSerializationDispatcher(serializer.WithDefaultConfig())
+    if err != nil {
+        return nil, err
+    }
+
+    verifierDisp, err := verifier.NewVerificationDispatcher(verifier.WithDefaultConfig())
+    if err != nil {
+        return nil, err
+    }
+
+    idProf, err := idprof.NewIdentityProfileDispatcher(idprof.WithDefaultConfig())
+    if err != nil {
+        return nil, err
+    }
+
+    // Trust roots for verifying the x5c certificate chain of OID4VP request objects
+    certFile, err := os.ReadFile(certPath)
+    if err != nil {
+        return nil, err
+    }
+    certPool := x509.NewCertPool()
+    certPool.AppendCertsFromPEM(certFile)
+
+    oid4vpPresenter := &oid4vp.Oid4vpPresenter{
+        X509TrustChainRoots: certPool,
+    }
+    presenterDisp, err := presenter.NewPresentationDispatcher(
+        presenter.WithPlugin(presenter.Oid4vp, oid4vpPresenter),
+    )
+    if err != nil {
+        return nil, err
+    }
+
+    return wallet.NewWalletWithConfig(wallet.Config{
+        CredStore:  credStore,
+        IDProfiler: idProf,
+        Receiver:   receiverDisp,
+        Serializer: serializerDisp,
+        Verifier:   verifierDisp,
+        Presenter:  presenterDisp,
+    })
 }
-
-var (
-    // This controller will be used later in the tutorial
-    controller = NewController()
-)
 ```
+
+* **Storage location:** The default credential store persists credentials with `go.etcd.io/bbolt` to `<user config dir>/vcknots/wallet/.local_credstore.db` (for example `~/.config/vcknots/wallet/.local_credstore.db` on Linux, `~/Library/Application Support/vcknots/wallet/.local_credstore.db` on macOS).
 
 ## 3. Sample Implementation of Wallet Features
 
-Using the Controller instance, this section provides concrete Go code samples that perform the main Wallet functions (key preparation, receiving Credentials, and presenting Credentials).
-These samples are based on the logic in `server_integration.go`.
+Using the `Wallet` instance, this section provides concrete Go code samples for the main wallet functions: key preparation, receiving credentials, and presenting credentials. These samples are based on `wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go` and `wallet/examples/common/common.go`.
 
 ### 3-1. Preparing Test Keys (IKeyEntry Interface)
 
-The main methods in `controller.go` (`ReceiveCredential`, `PresentCredential`) require the `IKeyEntry` interface for signing operations.
-This allows library users to freely swap out key management implementations (for example: in-memory, HSM, secure enclave).
+The main workflow methods (`ReceiveCredential`, `PresentCredential`) require the `IKeyEntry` interface for signing operations. This allows library users to swap out key management implementations (for example: in-memory, HSM, secure enclave).
 
 The `IKeyEntry` interface is defined as follows:
 
 ```go
-// IKeyEntry is an interface that encapsulates a key and its operations.
+// IKeyEntry represents a key entry interface for signing operations.
 type IKeyEntry interface {
     ID() string
     PublicKey() jose.JSONWebKey
-    Sign(databyte) (byte, error)
+    Sign(data []byte) ([]byte, error)
 }
 ```
 
-For this tutorial, we use the in-memory mock implementation (`MockKeyEntry`) provided in `server_integration.go`.
+* **Signature format:** ECDSA implementations of `Sign` may return either DER-encoded ASN.1 signatures or raw IEEE P1363 (`R || S`) signatures. The library normalizes DER-encoded signatures to IEEE P1363 internally (via `JWKSigner`), so both formats work.
 
-The `Sign` method of this `MockKeyEntry` is not just a simple wrapper around `ecdsa.Sign`.
-It includes the logic to generate ES256 signatures (SHA-256 hash) commonly required in OpenID4VP, and to serialize the result into IEEE P1363 format (a 64-byte byte string consisting of the concatenation of r and s).
-
+For this tutorial, we use an in-memory implementation equivalent to `MockKeyEntry` in `wallet/examples/common/common.go`:
 
 ```go
-// MockKeyEntry is a test implementation of IKeyEntry
+// MockKeyEntry is a test implementation of IKeyEntry.
 type MockKeyEntry struct {
     id         string
     privateKey *ecdsa.PrivateKey
+}
+
+func NewMockKeyEntry() (*MockKeyEntry, error) {
+    privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+    if err != nil {
+        return nil, err
+    }
+    return &MockKeyEntry{
+        id:         "test-key-id-" + uuid.NewString(),
+        privateKey: privKey,
+    }, nil
 }
 
 func (m *MockKeyEntry) ID() string { return m.id }
 
 func (m *MockKeyEntry) PublicKey() jose.JSONWebKey {
     return jose.JSONWebKey{
-        Key:       m.privateKey.PublicKey,
+        Key:       &m.privateKey.PublicKey,
         Algorithm: "ES256", // P-256 curve
         Use:       "sig",
     }
 }
 
-// Sign performs SHA-256 hashing -> ECDSA signing -> conversion to IEEE P1363 format
-func (m *MockKeyEntry) Sign(payloadbyte) (byte, error) {
+// Sign performs SHA-256 hashing -> ECDSA signing -> IEEE P1363 serialization.
+func (m *MockKeyEntry) Sign(payload []byte) ([]byte, error) {
     hash := sha256.Sum256(payload)
     r, s, err := ecdsa.Sign(rand.Reader, m.privateKey, hash[:])
-    if err!= nil {
+    if err != nil {
         return nil, err
     }
 
-    // P-256 (256 bits / 8 = 32 bytes)
-    const keySize = 32
-    // Serialize r and s into 64-byte (IEEE P1363) format
-    signature := make(byte, 2*keySize)
-    r.FillBytes(signature)
-    s.FillBytes(signature)
+    const keySize = 32 // P-256: 256 bits / 8
+    signature := make([]byte, 2*keySize)
+    r.FillBytes(signature[:keySize])
+    s.FillBytes(signature[keySize:])
     return signature, nil
 }
-
-// NewMockKeyEntry generates a new test key
-func NewMockKeyEntry() (*MockKeyEntry, error) {
-    // Generate a new key on the P-256 curve
-    privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-    if err!= nil {
-        return nil, err
-    }
-    
-    return &MockKeyEntry{
-        id:         "test-key-id-" + uuid.NewString(), // A unique ID for each execution
-        privateKey: privKey,
-    }, nil
-}
-
-// Prepare the key that will be used later in the tutorial
-var testKey, _ = NewMockKeyEntry()
 ```
 
-### 3-2. Receiving a Credential
+### 3-2. Receiving a Credential (OID4VCI)
 
-- This feature calls the Controller’s `ReceiveCredential` method based on a `CredentialOffer` from the Issuer (Node.js server).
-- The `ReceiveCredential` method takes a `ReceiveCredentialRequest` struct as its argument.
-- Referring to the `receiveMockCredential` function in `server_integration.go`, the following shows the process for receiving a mock Credential (issued by a test Issuer).
+The wallet receives a credential by calling `ReceiveCredential` with a `CredentialOffer` obtained from the issuer. In a real deployment the offer URI comes from a QR code or deep link; with the local sample server you can create one via `POST /configurations/:configurationId/offer`.
+
+The offer URI has the form `openid-credential-offer://?credential_offer=...`. Parse it into a `wallet.CredentialOffer` and pass it to `ReceiveCredential`:
 
 ```go
-func receiveTestCredential(key *MockKeyEntry) (*vcknots_wallet.SavedCredential, error) {
-    // 1. Simulate a Credential Offer (Mock)
-    // In a real scenario, the offer URL would be obtained from a QR code or deep link
-    issuerURL, _ := url.Parse("http://localhost:8080/issuers/test_issuer/configurations/test_config")
+import (
+    "github.com/trustknots/vcknots/wallet"
+    "github.com/trustknots/vcknots/wallet/credential"
+    "github.com/trustknots/vcknots/wallet/receiver"
+)
 
-    offer := &vcknots_wallet.CredentialOffer{
-        CredentialIssuer:         issuerURL,
-        CredentialConfigurationIDs:string{"UniversityDegree_jwt_vc_json-ld"}, // Match with the server side
-        Grants: map[string]*vcknots_wallet.CredentialOfferGrant{
-            "pre-authorized_code": {
-                PreAuthorizedCode: "test_code", // Fixed code for mock use
-            },
-        },
-    }
-
-    // 2. Create the receive request
-    receiveReq := vcknots_wallet.ReceiveCredentialRequest{
-        CredentialOffer:      offer,
-        Type:                 receiverTypes.Mock, // Mock type that does not communicate with the server side
-        Key:                  key,                // Key used for signing (e.g. PoP)
-        CachedIssuerMetadata: nil,                // Specify nil when there is no metadata
-    }
-
-    // 3. Call the Controller's ReceiveCredential
-    log.Println("Attempting to receive credential...")
-    savedCred, err := controller.ReceiveCredential(receiveReq)
-    if err!= nil {
-        log.Printf("Error receiving credential: %v\n", err)
+func receiveSDJwtCredential(w *wallet.Wallet, key wallet.IKeyEntry, offerURI string) (*wallet.SavedCredential, error) {
+    // 1. Parse the openid-credential-offer:// URI
+    parsed, err := url.Parse(offerURI)
+    if err != nil {
         return nil, err
     }
 
-    log.Printf("Successfully received and saved credential. ID: %s\n", savedCred.Entry.ID)
-    return savedCred, nil
+    var offerJSON struct {
+        CredentialIssuer           string                                  `json:"credential_issuer"`
+        CredentialConfigurationIDs []string                                `json:"credential_configuration_ids"`
+        Grants                     map[string]*wallet.CredentialOfferGrant `json:"grants"`
+    }
+    if err := json.Unmarshal([]byte(parsed.Query().Get("credential_offer")), &offerJSON); err != nil {
+        return nil, err
+    }
+
+    issuerURL, err := url.Parse(offerJSON.CredentialIssuer)
+    if err != nil {
+        return nil, err
+    }
+
+    offer := &wallet.CredentialOffer{
+        CredentialIssuer:           issuerURL,
+        CredentialConfigurationIDs: offerJSON.CredentialConfigurationIDs,
+        Grants:                     offerJSON.Grants, // key: "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+    }
+
+    // 2. Receive the credential via OID4VCI (pre-authorized code flow)
+    return w.ReceiveCredential(wallet.ReceiveCredentialRequest{
+        CredentialOffer: offer,
+        Type:            receiver.Oid4vci,
+        Key:             key,                 // used to sign the JWT proof (key binding)
+        RequestedFormat: credential.SDJwtVC,  // "application/dc+sd-jwt"
+    })
 }
 ```
+
+Notes on `ReceiveCredentialRequest`:
+
+* **RequestedFormat:** Set `credential.SDJwtVC` to receive an SD-JWT VC, or `credential.JwtVc` for a JWT-VC. When omitted, the format is resolved from the issuer metadata for the first credential configuration ID (falling back to JWT-VC).
+* **TxCode:** When the offer requires a transaction code, set `TxCode`; it is sent to the token endpoint as `tx_code`.
+* **CachedIssuerMetadata:** When set, `ReceiveCredential` skips fetching the issuer metadata (see section 4).
+
+`ReceiveCredential` fetches the issuer and authorization server metadata, obtains an access token with the pre-authorized code, generates a JWT proof signed with `Key`, requests the credential, and stores the result in the credential store. It returns a `*wallet.SavedCredential` containing both the parsed credential and its storage entry.
 
 ### 3-3. Presenting a Credential (OpenID4VP)
 
-- After receiving a request URI in the form `openid4vp://authorize?...` from the Verifier (Node.js server), the Controller’s `PresentCredential` method is called.
-- This method parses the `uriString` (OpenID4VP request), analyzes the request content (`presentation_definition`), searches the `credstore` for matching Credentials, uses `IKeyEntry` to sign a Verifiable Presentation (VP), and sends it to the Verifier’s `callback` endpoint via `HTTP POST`.
-- Based on the `presentation` function in `server_integration.go`, it processes the request URI obtained from the Node.js server (`/verifiers/test_verifier/request` endpoint).
-
+After receiving a request URI in the form `openid4vp://authorize?...` from the verifier (typically by scanning a QR code; with the local sample server, via `POST /request` or `POST /request-object`), call `PresentCredential`:
 
 ```go
-func presentTestCredential(key *MockKeyEntry) error {
-    // 1. Obtain the OpenID4VP request URI from the Verifier (Node.js server)
-    // This URI is usually obtained by scanning a QR code
-    // Here, we directly call /verifiers/test_verifier/request
-    resp, err := http.Get("http://localhost:8080/verifiers/test_verifier/request")
-    if err!= nil {
-        log.Printf("Failed to get OID4VP request URI from server: %v\n", err)
-        return err
-    }
-    defer resp.Body.Close()
+import sdjwtvc "github.com/trustknots/vcknots/wallet/serializer/plugins/sdjwtvc"
 
-    body, err := io.ReadAll(resp.Body)
-    if err!= nil {
-        return err
+func presentCredential(w *wallet.Wallet, key wallet.IKeyEntry, oid4vpURI string) error {
+    // Options for SD-JWT VC presentations: selective disclosure and Key Binding JWT
+    options := &sdjwtvc.SdJwtVcPresentationOptions{
+        SelectedClaims:    []string{"given_name", "family_name"},
+        RequireKeyBinding: true,
     }
 
-    oid4vpRequestURI := string(body)
-    log.Printf("Received OID4VP Request URI: %s\n", oid4vpRequestURI)
-
-    // 2. Call the Controller's PresentCredential
-    // Parsing, searching, signing, and HTTP POST are all performed internally
-    log.Println("Attempting to present credential...")
-    redirectURI, err := controller.PresentCredential(oid4vpRequestURI, key, nil)
-    if err!= nil {
-        log.Printf("Error presenting credential: %v\n", err)
+    redirectURI, err := w.PresentCredential(oid4vpURI, key, options)
+    if err != nil {
         return err
     }
-
     if redirectURI != "" {
         log.Printf("Verifier requested redirect: %s\n", redirectURI)
     }
-
-    log.Println("Successfully presented credential to the verifier.")
     return nil
 }
 ```
 
+`PresentCredential` parses the OID4VP request (including JAR request objects referenced by `request_uri`, whose signatures are verified against `X509TrustChainRoots`), selects the most recently received credential from the store (matching against the presentation definition is not performed yet), serializes and signs the Verifiable Presentation with `key`, and posts it to the verifier's `response_uri` (for `response_mode=direct_post`) or `redirect_uri`. The returned string is the redirect URI provided by the verifier, or empty when there is none.
+
+* **Presentation options:** The third argument accepts a format-specific options value. For SD-JWT VC, `sdjwtvc.SdJwtVcPresentationOptions` controls which claims are disclosed (`SelectedClaims`) and whether a Key Binding JWT is attached (`RequireKeyBinding`). The KB-JWT audience and nonce are filled automatically from the OID4VP request (`client_id` and `nonce`), as are `transaction_data` hashes when the request contains transaction data. Pass `nil` to use the default options for the credential's format (for JWT-VC presentations, `nil` is typical).
+* **Redirect handling:** Use `PresentCredentialWithOptions` with `wallet.PresentCredentialOptions{OnRedirect: func(uri string) error {...}}` when you want a callback invoked with the verifier's redirect URI.
+
 ### 3-4. Referencing Saved Credentials
 
-- Credentials saved via `ReceiveCredential` can be searched and listed using the Controller’s `GetCredentialEntries` method.
-- This request allows pagination (`Offset`, `Limit`) and advanced filtering using a `Filter` function.
-
+Credentials saved via `ReceiveCredential` can be listed with `GetCredentialEntries`, which supports pagination (`Offset`, `Limit`) and filtering with a Go function (`Filter`). A single entry can be fetched by ID with `GetCredentialEntry`.
 
 ```go
-func listSavedCredentials() (*vcknots_wallet.SavedCredential, error) {
+func listSavedCredentials(w *wallet.Wallet) ([]*wallet.SavedCredential, error) {
     limit := 10
-    getEntriesReq := vcknots_wallet.GetCredentialEntriesRequest{
+    entries, total, err := w.GetCredentialEntries(wallet.GetCredentialEntriesRequest{
         Offset: 0,
         Limit:  &limit,
-        Filter: func(sc *vcknots_wallet.SavedCredential) bool {
-            // Example: filter only 'UniversityDegree'
-            // return sc.Credential.HasType("UniversityDegree")
-            return true // In this example, retrieve all
+        Filter: func(sc *wallet.SavedCredential) bool {
+            return true // Example: return sc.Entry.MimeType == string(credential.SDJwtVC)
         },
-    }
-
-    log.Println("Fetching saved credential entries...")
-    entries, total, err := controller.GetCredentialEntries(getEntriesReq)
-    if err!= nil {
-        log.Printf("Error getting credential entries: %v\n", err)
+    })
+    if err != nil {
         return nil, err
     }
 
     log.Printf("Found %d matching entries (Total: %d)\n", len(entries), total)
     for _, entry := range entries {
-        log.Printf(" - Entry ID: %s, Credential Type: %v\n", entry.Entry.ID, entry.Credential.Types)
+        log.Printf(" - Entry ID: %s, MimeType: %s\n", entry.Entry.Id, entry.Entry.MimeType)
     }
     return entries, nil
 }
 ```
 
-## 4. Registering Wallet Metadata
+## 4. Fetching Issuer Metadata
 
-- This section does **not** describe a feature for the Wallet to register its **own** metadata, but rather explains the capability to **retrieve and process** the metadata of the **Issuer** with which the Wallet interacts.
+When receiving a credential, the wallet must access the issuer's `.well-known/openid-credential-issuer` endpoint to obtain the issuer's configuration (credential endpoint, supported credential configurations, and so on).
 
-- When receiving a Credential, the Wallet must first access the Issuer’s `.well-known/openid-credential-issuer` endpoint and obtain that Issuer’s configuration (such as public keys, supported Credential types, endpoints, etc.).
-
-- The Controller provides the `FetchCredentialIssuerMetadata` method specifically for this task.
-- This method is implicitly called within the internal flow of `ReceiveCredential`, or can be explicitly called beforehand to set the `CachedIssuerMetadata` field of `ReceiveCredentialRequest`.
-
-- By providing `CachedIssuerMetadata` when calling `ReceiveCredential`, you can avoid the network overhead of re-fetching the metadata every time `ReceiveCredential` is executed.
-
+`ReceiveCredential` fetches this metadata implicitly, but you can also fetch it explicitly with `FetchCredentialIssuerMetadata` and pass the result via the `CachedIssuerMetadata` field of `ReceiveCredentialRequest`. This avoids re-fetching the metadata on every `ReceiveCredential` call.
 
 ```go
-func fetchIssuerMetadata() (*receiverTypes.CredentialIssuerMetadata, error) {
-    // Note: This URL is the Issuer's base URL and does not include the /.well-known/... path
-    // FetchCredentialIssuerMetadata resolves the path internally
-    issuerURL, _ := url.Parse("http://localhost:8080") // Issuer base URL
+import receiverTypes "github.com/trustknots/vcknots/wallet/receiver/types"
 
-    log.Println("Fetching issuer metadata from:", issuerURL.String())
-    
-    // Call the method defined in the controller
-    metadata, err := controller.FetchCredentialIssuerMetadata(
-        issuerURL,
-        receiverTypes.OpenID4VCI, // Specify the protocol type
-    )
+func fetchIssuerMetadata(w *wallet.Wallet) (*receiverTypes.CredentialIssuerMetadata, error) {
+    // Note: pass the issuer's base URL; the /.well-known/... path is resolved internally
+    issuerURL, _ := url.Parse("http://localhost:8080")
 
-    if err!= nil {
-        log.Printf("Failed to fetch issuer metadata: %v\n", err)
+    metadata, err := w.FetchCredentialIssuerMetadata(issuerURL, receiverTypes.Oid4vci)
+    if err != nil {
         return nil, err
     }
 
-    log.Printf("Successfully fetched metadata for issuer: %s\n", metadata.CredentialIssuer)
-    // metadata.CredentialEndpoint, metadata.JWKS...
+    log.Printf("Fetched metadata for issuer: %s\n", metadata.CredentialIssuer)
+    // metadata.CredentialEndpoint, metadata.CredentialConfigurationSupported, ...
     return metadata, nil
 }
 ```
 
 ## 5. Explanation of Type Definitions
 
-This section explains the main Go type definitions used when interacting with the Controller in the vcknots/wallet library.
+This section explains the main Go type definitions used when interacting with the `Wallet` in the vcknots/wallet library.
 
-| Type / Interface | Description |
-| :---- | :---- |
-| **IKeyEntry** | Core interface for key management. Defines three methods: `ID()`, `PublicKey()`, and `Sign()`. Library users must implement this to integrate with HSMs, secure enclaves, and similar systems. |
-| **DIDCreateOptions** | Options passed to the `GenerateDID` method. Specifies the type of DID to generate (`TypeID`) and the associated public key (`PublicKey`). |
-| **ReceiveCredentialRequest** | Main input for the `ReceiveCredential` method. Encapsulates the `CredentialOffer`, the key (`IKeyEntry`) used for signing, and the optional `CachedIssuerMetadata`. |
-| **CredentialOffer** | Details of the offer received from the Issuer. Includes the Issuer URL (`CredentialIssuer`), the IDs of the requested Credentials (`CredentialConfigurationIDs`), and the authorization grants (`Grants`). |
-| **SavedCredential** | The actual Credential stored in the `credstore`. Wraps `\*credential.Credential` (VC raw data) and `\*types.CredentialEntry` (metadata). Returned by `GetCredentialEntries`. |
-| **GetCredentialEntriesRequest** | Search conditions for the `GetCredentialEntries` method. Supports pagination (`Offset`, `Limit`) and dynamic filtering via a Go function (`Filter`). |
+### IKeyEntry {#IKeyEntry}
 
-## 6. Notes
+Core interface for key management. Defines three methods: `ID()`, `PublicKey()`, and `Sign()`. Library users implement this to integrate with HSMs, secure enclaves, and similar systems.
 
-1. **MockKeyEntry must not be used in production (CRITICAL):**  
-    - `MockKeyEntry` provided in `server_integration.go` is intended only for testing and demonstration.
-    - **Reason:** It keeps the private key (`*ecdsa.PrivateKey`) in plaintext on the Go heap memory.
-    - **Production implementation:** In a production environment, you must implement the `IKeyEntry` interface yourself. This implementation should delegate the `Sign` operation to an OS keystore (`iOS Secure Enclave`, `Android Keystore`) or an HSM (`Hardware Security Module`), and be designed so that the private key itself is never loaded into the application’s memory space (`Non-exportable`).  
+For the definition, see [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go).
 
-2. **GOPRIVATE configuration:**  
-    - If `go mod download` or `go build` fails, the most likely cause is a missing GOPRIVATE environment variable configuration. 
+### Config {#Config}
 
-3. **Signature format compatibility:**  
-    - When implementing your own `IKeyEntry`, pay close attention to the signature format produced by the `Sign` method.
-    - `MockKeyEntry` serializes ES256 (SHA-256 with P-256) signatures in **IEEE P1363** format (fixed 64-byte length).
-    - If the Verifier expects a different format (for example, ASN.1 DER), `PresentCredential` will fail with a signature verification error.  
+Input for `NewWalletWithConfig`. Holds the six dispatcher components and the optional DPoP configuration ([DPoPConfig](#DPoPConfig)). `nil` fields fall back to default implementations.
 
-4. **Persistent storage (bbolt):**  
-    - `credstore.NewCredStoreDispatcher(credstore.WithDefaultConfig())` uses `go.etcd.io/bbolt` (an embedded KVS) by default and attempts to persist data to a local file such as `wallet.db`.
-    - Make sure that you have write permissions for the execution directory.
+For the definition, see [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go).
 
-5. **Strict validation of OpenID4VP `client_id`:**
-    - This Wallet implements strict validation of `client_id` to conform to OpenID4VP conformance tests.
-    - Duplicate prefixes (for example, `x509_san_dns:x509_san_dns:...`) and malformed values are automatically rejected.
+### ReceiveCredentialRequest {#ReceiveCredentialRequest}
+
+Main input for `ReceiveCredential`. Encapsulates the [CredentialOffer](#CredentialOffer), the receiving protocol (`Type`), the key used for proof signing ([IKeyEntry](#IKeyEntry)), the requested credential format (`RequestedFormat`), the optional `CachedIssuerMetadata`, and the optional `TxCode`.
+
+For the definition, see [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go).
+
+### CredentialOffer {#CredentialOffer}
+
+Details of the offer received from the issuer. Includes the issuer URL (`CredentialIssuer`), the credential configuration IDs (`CredentialConfigurationIDs`), and the authorization grants (`Grants`).
+
+For the definition, see [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go).
+
+### SavedCredential {#SavedCredential}
+
+A credential stored in the credential store. Wraps `*credential.Credential` (the parsed credential) and `*types.CredentialEntry` (storage metadata: ID, raw bytes, MIME type, received time). Returned by `ReceiveCredential`, `GetCredentialEntries`, and `GetCredentialEntry`.
+
+For the definition, see [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go).
+
+### GetCredentialEntriesRequest {#GetCredentialEntriesRequest}
+
+Search conditions for `GetCredentialEntries`. Supports pagination (`Offset`, `Limit`) and dynamic filtering via a Go function (`Filter`).
+
+For the definition, see [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go).
+
+### PresentCredentialOptions {#PresentCredentialOptions}
+
+Input for `PresentCredentialWithOptions`. Holds the format-specific `SerializeOptions` and an optional `OnRedirect` callback.
+
+For the definition, see [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go).
+
+### SdJwtVcPresentationOptions {#SdJwtVcPresentationOptions}
+
+Options for SD-JWT VC presentations: `SelectedClaims`, `RequireKeyBinding`, `Audience`, `Nonce`, and `TransactionData`. Audience and nonce are filled from the OID4VP request automatically.
+
+For the definition, see [wallet/serializer/plugins/sdjwtvc/sdjwtvc.go](https://github.com/trustknots/vcknots/blob/main/wallet/serializer/plugins/sdjwtvc/sdjwtvc.go).
+
+### DIDCreateOptions {#DIDCreateOptions}
+
+Options for `GenerateDID`. Specifies the DID type (`TypeID`, e.g. `"did:key"`) and the associated public key (`PublicKey`).
+
+For the definition, see [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go).
+
+### DPoPConfig {#DPoPConfig}
+
+Enables DPoP proofs for the token and credential endpoints (`Enabled`), with an optional dedicated key (`Key`). When enabled without a key, an in-memory P-256 key is generated.
+
+For the definition, see [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go).
+
+## 6. Methods of Wallet
+
+### ReceiveCredential
+
+Receives a credential from an issuer via OID4VCI (pre-authorized code flow) and stores it in the credential store.
+
+```go
+func (w *Wallet) ReceiveCredential(req ReceiveCredentialRequest) (*SavedCredential, error)
+```
+
+**Parameters**:
+- `req`: Receive request ([ReceiveCredentialRequest](#ReceiveCredentialRequest))
+
+**Return value**:
+- The received and stored credential ([SavedCredential](#SavedCredential))
+
+### PresentCredential
+
+Responds to an OID4VP authorization request and submits a Verifiable Presentation to the verifier.
+
+```go
+func (w *Wallet) PresentCredential(uriString string, key IKeyEntry, options serializerTypes.SerializePresentationOptions) (string, error)
+```
+
+**Parameters**:
+- `uriString`: The OID4VP request URI (`openid4vp://authorize?...`)
+- `key`: The key used to sign the presentation ([IKeyEntry](#IKeyEntry))
+- `options`: Format-specific presentation options (for SD-JWT VC, [SdJwtVcPresentationOptions](#SdJwtVcPresentationOptions)); pass `nil` to use the defaults for the credential's format
+
+**Return value**:
+- The redirect URI provided by the verifier, or an empty string when there is none
+
+### PresentCredentialWithOptions
+
+Same as `PresentCredential`, and additionally invokes a callback when the verifier returns a redirect URI.
+
+```go
+func (w *Wallet) PresentCredentialWithOptions(uriString string, key IKeyEntry, options *PresentCredentialOptions) (string, error)
+```
+
+**Parameters**:
+- `uriString`: The OID4VP request URI (`openid4vp://authorize?...`)
+- `key`: The key used to sign the presentation ([IKeyEntry](#IKeyEntry))
+- `options`: Serialization options and redirect callback ([PresentCredentialOptions](#PresentCredentialOptions))
+
+**Return value**:
+- The redirect URI provided by the verifier, or an empty string when there is none
+
+### GetCredentialEntries
+
+Retrieves stored credentials with optional pagination and filtering.
+
+```go
+func (w *Wallet) GetCredentialEntries(req GetCredentialEntriesRequest) ([]*SavedCredential, int, error)
+```
+
+**Parameters**:
+- `req`: Search conditions ([GetCredentialEntriesRequest](#GetCredentialEntriesRequest))
+
+**Return value**:
+- The matching credentials ([SavedCredential](#SavedCredential)) and the total number of matches
+
+### GetCredentialEntry
+
+Retrieves a single stored credential by ID.
+
+```go
+func (w *Wallet) GetCredentialEntry(id string) (*SavedCredential, error)
+```
+
+**Parameters**:
+- `id`: The credential entry ID
+
+**Return value**:
+- The stored credential ([SavedCredential](#SavedCredential)), or `nil` when not found
+
+### FetchCredentialIssuerMetadata
+
+Fetches the issuer metadata from the issuer's `.well-known/openid-credential-issuer` endpoint.
+
+```go
+func (w *Wallet) FetchCredentialIssuerMetadata(endpoint *url.URL, receivingType receiverTypes.SupportedReceivingTypes) (*receiverTypes.CredentialIssuerMetadata, error)
+```
+
+**Parameters**:
+- `endpoint`: The issuer's base URL (the `/.well-known/...` path is resolved internally)
+- `receivingType`: The receiving protocol (`receiver.Oid4vci`)
+
+**Return value**:
+- The issuer metadata (`receiverTypes.CredentialIssuerMetadata`)
+
+### GenerateDID
+
+Generates a DID from a public key.
+
+```go
+func (w *Wallet) GenerateDID(options DIDCreateOptions) (*idprofTypes.IdentityProfile, error)
+```
+
+**Parameters**:
+- `options`: The DID type and public key ([DIDCreateOptions](#DIDCreateOptions))
+
+**Return value**:
+- The generated identity profile (`idprofTypes.IdentityProfile`)
+
+## 7. Notes
+
+1. **Mock key entries must not be used in production (CRITICAL):**
+    - The in-memory key implementation shown in this tutorial (and `MockKeyEntry` in `wallet/examples/common/`) is intended only for testing and demonstration, because it keeps the private key in plaintext on the Go heap.
+    - In a production environment, implement `IKeyEntry` so that the `Sign` operation is delegated to an OS keystore (iOS Secure Enclave, Android Keystore) or an HSM, and the private key itself is never loaded into the application's memory space (non-exportable).
+
+2. **GOPRIVATE configuration:**
+    - If `go mod download` or `go build` fails, the most likely cause is a missing GOPRIVATE environment variable.
+
+3. **Signature format compatibility:**
+    - `Sign` may return either DER-encoded ASN.1 or raw IEEE P1363 signatures for ES256; the library normalizes DER to P1363 before embedding signatures in JWS structures.
+
+4. **Persistent storage (bbolt):**
+    - `credstore.WithDefaultConfig()` persists credentials with `go.etcd.io/bbolt` to `<user config dir>/vcknots/wallet/.local_credstore.db`. Make sure the process can create and write to this directory.
+
+5. **HTTPS enforcement and runtime environment variables (`wallet/env/env.go`):**
+    - The wallet requires HTTPS for issuer and verifier endpoints by default.
+    - `VCKNOTS_WALLET_HTTP_ALLOWED=true` allows HTTP endpoints (intended for local development/testing only).
+    - `VCKNOTS_WALLET_DEBUG=true` enables debug mode and also enables the HTTP allowance behavior.
+    - **Production guidance:** keep both variables unset (or `false`) so HTTPS-only validation remains active.
+
+6. **Strict validation of OpenID4VP `client_id`:**
+    - The wallet validates `client_id` strictly, in line with the OpenID4VP conformance tests. Duplicate prefixes (for example, `x509_san_dns:x509_san_dns:...`) and malformed values are rejected.
     - For the `x509_san_dns:` scheme, the certificate is extracted from the `x5c` header of the request JWT, and the Subject Alternative Name (SAN) DNS field of the certificate is matched against the `client_id` value.
-    - See the `parseOID4VPClientID()` function and `x509_san_dns` validation logic in `wallet/presenter/plugins/oid4vp/oid4vp.go` for details.
+    - See `wallet/presenter/plugins/oid4vp/` for the validation logic.
 
-6. **Test configuration for certificate validation (`InsecureSkipX509Verify`):**
+7. **Test configuration for certificate validation (`InsecureSkipX509Verify`):**
     - The `Oid4vpPresenter` struct provides the `InsecureSkipX509Verify` option for test environments.
-    - **Default behavior (production):** Full certificate chain validation is performed. Certificates must chain to a trusted root CA.
-    - **Test configuration (`InsecureSkipX509Verify: true`):** Skips certificate chain validation and extracts the certificate directly from the `x5c` header. Only SAN-to-`client_id` matching is performed.
-    - ⚠️ **Critical warning:** `InsecureSkipX509Verify: true` should only be used for conformance testing or local development environments. **Never** use this in production. It introduces a security risk.
-    - Conformance tests may intentionally use non-standard certificates (self-signed, CA:TRUE settings, etc.), which is why this option is necessary.
+    - **Default behavior (production):** full certificate chain validation is performed against `X509TrustChainRoots`.
+    - **Test configuration (`InsecureSkipX509Verify: true`):** skips certificate chain validation and extracts the certificate directly from the `x5c` header; only SAN-to-`client_id` matching is performed.
+    - ⚠️ **Critical warning:** use `InsecureSkipX509Verify: true` only for conformance testing or local development. **Never** use this in production.
 
-7. **Wallet runtime environment variables (`wallet/env/env.go`):**
-    - The wallet uses the prefix `VCKNOTS_WALLET_` for runtime flags.
-    - `VCKNOTS_WALLET_HTTP_ALLOWED=true` allows HTTP endpoints for wallet HTTP calls (intended for local development/testing only).
-    - `VCKNOTS_WALLET_DEBUG=true` enables debug mode and also enables HTTP allowance behavior.
-    - `IsHTTPAllowed()` returns `true` if either of the above values is `true`; otherwise it returns `false`.
-    - **Production guidance:** Keep both variables unset (or `false`) so HTTPS-only validation remains active.
+8. **DPoP support (optional):**
+    - Setting `wallet.Config{DPoP: wallet.DPoPConfig{Enabled: true}}` makes the wallet attach DPoP proofs to token and credential requests, and handle DPoP nonce challenges from the server.
 
-## 7. Troubleshooting
+## 8. Troubleshooting
 
-* **Q: `go mod download` fails with `package... is private` or `404 Not Found`.**  
-  * **A:** The GOPRIVATE environment variable is not configured correctly. Go back to “1. Prerequisites” and make sure `export GOPRIVATE="github.com/trustknots/vcknots/wallet"` has been executed.  
+* **Q: `go mod download` fails with `package ... is private` or `404 Not Found`.**
+  * **A:** The GOPRIVATE environment variable is not configured. Go back to "1. Prerequisites" and make sure `export GOPRIVATE="github.com/trustknots/vcknots/wallet"` has been executed (or use mise).
 
-* **Q: `ReceiveCredential` or `PresentCredential` fails with `connection refused` or `timeout`.**  
-  * **A:** The Issuer/Verifier server that the vcknots/wallet Go code is trying to communicate with is not running. Follow “1. Prerequisites”, run `pnpm start` in the `packages/server` directory, and confirm that http://localhost:8080 responds.  
+* **Q: `ReceiveCredential` or `PresentCredential` fails with `connection refused` or `timeout`.**
+  * **A:** The Issuer/Verifier server is not running. Follow "1. Prerequisites", start the server with `pnpm -F @trustknots/server start`, and confirm that http://localhost:8080 responds.
 
-* **Q: `PresentCredential` succeeds, but the Verifier (Node.js server logs) shows `Invalid signature` or `Presentation verification failed`.**  
-  * **A:** This indicates a mismatch in the signature algorithm or format between the `IKeyEntry` used by the Wallet and the Verifier.  
-    1. Check whether you are using `MockKeyEntry`.  
-    2. If you are using a custom `IKeyEntry`, make sure the `Sign` method, like `MockKeyEntry`, uses a SHA-256 hash and IEEE P1363 serialization.  
+* **Q: `ReceiveCredential` fails with `credential issuer must use https scheme`.**
+  * **A:** The wallet enforces HTTPS by default. For local testing against the HTTP sample server, set `VCKNOTS_WALLET_HTTP_ALLOWED=true` (or call `env.SetHTTPAllowed(true)`).
 
-* **Q: `controller.ReceiveCredential` fails with `issuer metadata not found`.**  
-  * **A:** The Node.js server may be running, but the `/.well-known/openid-credential-issuer` endpoint might not be functioning correctly. Run `curl http://localhost:8080/.well-known/openid-credential-issuer` (or the Issuer base URL specified in “4. Registering Wallet Metadata”) and confirm that JSON metadata is returned.
+* **Q: `ReceiveCredential` fails with `failed to fetch issuer metadata`.**
+  * **A:** The server may be running, but the `/.well-known/openid-credential-issuer` endpoint might not be functioning. Run `curl http://localhost:8080/.well-known/openid-credential-issuer` and confirm that JSON metadata is returned.
+
 * **Q: A `client_id` validation error occurs during OpenID4VP conformance testing.**
-  * **A:** Conformance tests intentionally send malformed `client_id` values (such as duplicate prefixes or trailing whitespace) to test the Wallet's validation logic. The updated Wallet correctly rejects such invalid `client_id` values.
-  * Example errors: `"invalid client_id: duplicate prefix detected"` or `"SAN of the certificate and client_id did not match"`
-  * These errors are **expected behavior** and indicate that the Wallet is correctly enforcing its security checks.
+  * **A:** Conformance tests intentionally send malformed `client_id` values (such as duplicate prefixes) to test the wallet's validation logic. Errors like `invalid client_id: duplicate prefix detected` or `SAN of the certificate and client_id did not match` are **expected behavior** and indicate that the wallet is correctly enforcing its security checks.
 
 * **Q: An `x509: certificate is not standards compliant` error occurs during OpenID4VP conformance testing.**
-  * **A:** Conformance test servers may use self-signed certificates or non-standard certificate structures for testing purposes.
-  * **Solution:** Set `InsecureSkipX509Verify: true` only in test environments:
+  * **A:** Conformance test servers may use self-signed or non-standard certificates. Set `InsecureSkipX509Verify: true` only in test environments:
     ```go
     p := &oid4vp.Oid4vpPresenter{
         X509TrustChainRoots:    systemRoots,
-        InsecureSkipX509Verify: true,  // Test environments only
+        InsecureSkipX509Verify: true, // Test environments only
     }
     ```
-  * ⚠️ **Warning:** Always set this to `false` (or leave the field unset) in production.
-  * See the "Conformance Test Troubleshooting" section of [examples/README.md](https://github.com/trustknots/vcknots/blob/main/wallet/examples/README.md) for details.
+  * ⚠️ **Warning:** always leave this `false` (or unset) in production.
+
+For runnable end-to-end samples (JWT-VC, SD-JWT VC, and SD-JWT VC with KB-JWT), see [wallet/examples/README.md](https://github.com/trustknots/vcknots/blob/main/wallet/examples/README.md).

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/wallet.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/wallet.md
@@ -4,18 +4,29 @@ sidebar_position: 5
 
 # Wallet機能のセットアップと使用方法
 
-このチュートリアルは、VCKnotsのwallet ライブラリのセットアップ、主要機能のサンプル実装、および本番環境での利用に向けた重要な考慮事項について解説します。
+このチュートリアルは、VCKnots の wallet ライブラリ（Go ライブラリ）のセットアップ、Credential の受領と提示のサンプル実装、本番環境での利用に向けた考慮事項を説明します。
+
+wallet は OpenID for Verifiable Credentials の各仕様を実装しています。
+
+* **Credential の受領（OID4VCI）:** Credential Offer と pre-authorized code フローを使って、Issuer から Credential を受け取ります。
+* **Credential の提示（OID4VP）:** `openid4vp://` 形式の Authorization Request に応答し、Verifiable Presentation を Verifier に送信します。
+
+受領と提示のどちらも **JWT-VC**（`application/vc+jwt`）と **SD-JWT VC**（`application/dc+sd-jwt`）に対応しています。
+SD-JWT VC では選択的開示と Key Binding JWT も利用できます。
 
 ## 1. 前提条件
 
-このセクションでは、vcknots/wallet ライブラリのビルドと、チュートリアルサンプルの実行に必要なすべての技術的要件を概説します。
+* **対応している仕様:**
+    - 受領: [OpenID for Verifiable Credential Issuance 1.0](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)（Pre-Authorized Code フロー）
+    - 提示: [OpenID for Verifiable Presentations - draft 24](https://openid.net/specs/openid-4-verifiable-presentations-1_0-24.html)（クロスデバイスフロー、`response_mode=direct_post`）
+    - 各機能の実装範囲の詳細は [VC Knots Coverage](./support-matrix.md) を参照してください。
 
 ### 1-1. Go環境の要件
 
-* **Goのバージョン:** vcknots/wallet ライブラリは、Go 1.24.5 を要求します。  
-* **開発環境管理 (mise):** 
-    - プロジェクトでは、開発環境の管理に mise ([https://mise.jdx.dev/](https://mise.jdx.dev/)) の使用を強く推奨しています。
-    - 例えば、以下のような手順で `mise install` を実行すると、必要なGoバージョンが自動的にインストールされ、環境変数が設定されます。  
+* **Goのバージョン:** vcknots/wallet ライブラリは、`wallet/mise.toml` に固定されたバージョンの Go（現在は Go 1.26.5）を要求します。
+* **開発環境管理 (mise):**
+    - 開発環境の管理には [mise](https://mise.jdx.dev/) の使用を推奨します。
+    - `wallet` ディレクトリで `mise install` を実行すると、必要な Go バージョンがインストールされ、環境変数も設定されます。
 
 ```bash
 # macOS
@@ -29,459 +40,616 @@ cd wallet
 mise install
 ```
 
-* **GOPRIVATE 環境変数:** 
-    - もしmise を使用しない場合、`go mod download` が失敗します。
-    - これを回避するため、以下の環境変数を手動で設定する必要があります。
+* **GOPRIVATE 環境変数:**
+    - mise を使用しない場合は、以下の環境変数を手動で設定してください。設定しないと `go mod download` が失敗します。
 
 ```bash
 export GOPRIVATE="github.com/trustknots/vcknots/wallet"
 ```
 
-### 1-2. サンプル実行環境の要件 (Verifier/Issuerサーバー)
+### 1-2. サンプル実行環境の要件 (Issuer/Verifierサーバー)
 
-本ライブラリのWalletのチュートリアルのサンプルコード（特にCredentialの受領と提示）は、対話する相手（IssuerおよびVerifier）が存在することを前提としています。
+このチュートリアルのサンプルコード（Credential の受領と提示）は、対話する相手（Issuer と Verifier）が存在することを前提としています。
+このリポジトリの Node.js ベースのサンプルサーバー（`server/`）が両方の役割を提供します。
 
-* **Node.jsサーバー:** チュートリアルのサンプルコード は、`README.md` および `package.json` で参照されているNode.jsベースのサンプルサーバー（`vcknots/server`）が http://localhost:8080 で動作している必要があります。  
-
-* **サーバーのセットアップ:** このサーバーは Hono フレームワーク と `@trustknots/vcknots` を使用し、`example.ts` に定義されたIssuerおよびVerifierのエンドポイント（例: `/issue/credentials`, `/verifiers/:verifier/callback`）を提供します。  
-
-* **サーバーの起動手順:** 
-    - このNode.jsサーバーのセットアップはオプションではなく、**必須**です。
-    - `server_integration.go` 内の `receiveMockCredential` や `presentation` 関数は、localhost:8080 への暗黙的なHTTPリクエストをトリガーします。このサーバーが稼働していない場合、「3. サンプル実装」のコードは `connection refused` エラーで失敗します。
-
-wallet のGoコードを実行する **前に**、必ず以下のコマンドを実行してサーバーを起動してください 
+wallet のサンプルコードを実行する前に、サーバーを起動してください。
 
 ```bash
-# walletディレクトリから、serverディレクトリへ移動
-cd ../server
+# vcknotsリポジトリのルートから
 pnpm install
-pnpm -F server start
+
+# issuer+verifierモジュール、server-coreモジュール、serverモジュールをbuild
+pnpm -F @trustknots/vcknots build
+pnpm -F @trustknots/server-core build
+pnpm -F @trustknots/server build
+
+# サーバーを起動（http://localhost:8080 で待ち受け）
+pnpm -F @trustknots/server start
 ```
 
-## 2. 初期設定 
+サーバーは、このチュートリアルで使用する以下のエンドポイントを提供します。
 
-このセクションでは、ライブラリの依存関係をインストールし、wallet のコア機能を集約する Controller インスタンスを初期化する手順を説明します。
+* `POST /configurations/:configurationId/offer`：Credential Offer の作成
+* `POST /token`, `POST /nonce`, `POST /credentials`：OID4VCI の token エンドポイント、nonce エンドポイント、credential エンドポイント
+* `POST /request`, `POST /request-object`：OID4VP の Authorization Request の作成
+* `POST /callback`：Verifier の応答受け取りエンドポイント
+* `GET /.well-known/openid-credential-issuer`, `GET /.well-known/oauth-authorization-server`：メタデータエンドポイント
+
+* **ローカルテストでの HTTP 許可:** wallet はデフォルトで、Issuer と Verifier のエンドポイントに HTTPS を要求します。
+ローカルのサンプルサーバーは HTTP で動作するため、ローカルテスト時は明示的に HTTP を許可してください。
+
+```bash
+export VCKNOTS_WALLET_HTTP_ALLOWED=true
+```
+
+テストコードから `env.SetHTTPAllowed(true)`（パッケージ `github.com/trustknots/vcknots/wallet/env`）を呼び出す方法もあります。
+
+> ⚠️ **セキュリティ警告**: 本番環境では `VCKNOTS_WALLET_HTTP_ALLOWED` を有効化しないでください。HTTPS 必須の検証を維持してください。
+
+## 2. 初期設定
+
+このセクションでは、ライブラリの依存関係をインストールし、wallet のコア機能を集約する `Wallet` インスタンスを初期化する手順を説明します。
 
 ### 2-1. 依存関係のインストール
 
-前提条件で GOPRIVATE を設定した後、プロジェクトのルート（wallet ディレクトリ）で以下のコマンドを実行し、`go.mod` にリストされている依存ライブラリ（`github.com/go-jose/go-jose/v4`, `go.etcd.io/bbolt`, `golang.org/x/crypto` など）をダウンロードします。
-
+GOPRIVATE を設定した後、`wallet` ディレクトリで以下のコマンドを実行し、`go.mod` にリストされている依存ライブラリ（`github.com/go-jose/go-jose/v4`, `go.etcd.io/bbolt`, `golang.org/x/crypto` など）をダウンロードします。
 
 ```bash
 go mod download
 ```
 
-### 2-2. Walletコントローラの初期化
+### 2-2. Walletの初期化
 
-- vcknots/wallet ライブラリは、モジュール性の高いディスパッチャベースのアーキテクチャを採用しています。
-- コアロジック（`controller.go`）は、credstore (永続化), receiver (受領), presenter (提示), verifier (検証) といった特定のタスクを処理するインターフェースに依存しています。
+ライブラリのトップレベル API は `github.com/trustknots/vcknots/wallet` パッケージにあります。
+最も簡単な初期化は `wallet.NewWallet()` で、すべてのディスパッチャコンポーネントをデフォルトのプラグイン実装で初期化します。
 
-- `server_integration.go` の `main` 関数は、Controller をインスタンス化するための標準的なレシピを提供します。
-- これは、ライブラリがデフォルト設定 (`WithDefaultConfig()`) とプラグイン （`WithPlugin(presenter.Oid4vp,...)`）の組み合わせによる依存性注入（DI）パターンに大きく依存していることを示しています。
+```go
+import "github.com/trustknots/vcknots/wallet"
 
-以下のコードは、`server_integration.go` に基づく Controller の標準的な初期化プロセスです。
-チュートリアルのサンプルコードを実行するために、この controller インスタンスが必要になります。
+w, err := wallet.NewWallet()
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+`Wallet` は内部で 6 つのディスパッチャコンポーネントを協調させます。
+それぞれが wallet 機能の一つの側面を担当します。
+
+* `credstore.CredStoreDispatcher`：Credential の永続化（デフォルトは bbolt を使うローカルストレージ）
+* `receiver.ReceivingDispatcher`：Credential 発行プロトコル（OID4VCI）
+* `presenter.PresentationDispatcher`：Credential 提示プロトコル（OID4VP）
+* `serializer.SerializationDispatcher`：Credential のシリアライズ（JWT-VC, SD-JWT VC）
+* `verifier.VerificationDispatcher`：署名の暗号学的検証
+* `idprof.IdentityProfileDispatcher`：DID とアイデンティティプロファイル（`did:key`）
+
+カスタム設定が必要な場合（たとえば OID4VP の Request Object 検証に使うトラストルートを設定する場合）は、ディスパッチャを自分で構築して `wallet.NewWalletWithConfig` に渡します。
+各ディスパッチャのコンストラクタはエラーを返します。
+`wallet.Config` で `nil` のままにしたフィールドには、デフォルト実装が自動的に補われます。
+以下のコードは、`wallet/examples/` 配下のサンプルで使われている初期化です。
 
 ```go
 package main
 
 import (
-	"log"
-	"net/url"
-	
-	// vcknots/wallet 内の各ディスパッチャパッケージ
-	vcknots_wallet "github.com/trustknots/vcknots/wallet/pkg/controller"
-	"github.com/trustknots/vcknots/wallet/pkg/credstore"
-	"github.com/trustknots/vcknots/wallet/pkg/dispatcher/idprof"
-	receiverTypes "github.com/trustknots/vcknots/wallet/pkg/dispatcher/receiver"
-	"github.com/trustknots/vcknots/wallet/pkg/dispatcher/serializer"
-	"github.com/trustknots/vcknots/wallet/pkg/dispatcher/verifier"
-	"github.com/trustknots/vcknots/wallet/pkg/presenter"
-	oid4vp "github.com/trustknots/vcknots/wallet/pkg/presenter/oid4vp" // OpenID4VPプラグイン
-	"github.com/trustknots/vcknots/wallet/pkg/util"
-	
-	// 鍵生成と署名のための標準ライブラリ
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/sha256"
-	"github.com/go-jose/go-jose/v4"
-	"github.com/google/uuid"
+    "crypto/x509"
+    "os"
 
-	// サンプル実装で使用するライブラリ
-	"io"
-	"net/http"
-	"github.com/trustknots/vcknots/wallet/pkg/types"
+    "github.com/trustknots/vcknots/wallet"
+    "github.com/trustknots/vcknots/wallet/credstore"
+    "github.com/trustknots/vcknots/wallet/idprof"
+    "github.com/trustknots/vcknots/wallet/presenter"
+    "github.com/trustknots/vcknots/wallet/presenter/plugins/oid4vp"
+    "github.com/trustknots/vcknots/wallet/receiver"
+    "github.com/trustknots/vcknots/wallet/serializer"
+    "github.com/trustknots/vcknots/wallet/verifier"
 )
 
-// NewController は、すべてのディスパッチャを初期化し、
-// 統合されたWalletコントローラを返します。
-func NewController() *vcknots_wallet.Controller {
-    logger := util.NewLogger()
-
-    // 1. 各ディスパッチャをデフォルト設定で初期化
-    credStoreDispatcher := credstore.NewCredStoreDispatcher(credstore.WithDefaultConfig())
-    receiverDispatcher := receiverTypes.NewReceivingDispatcher(receiverTypes.WithDefaultConfig())
-    serializationDispatcher := serializer.NewSerializationDispatcher(serializer.WithDefaultConfig())
-    verificationDispatcher := verifier.NewVerificationDispatcher(verifier.WithDefaultConfig())
-    idProfileDispatcher := idprof.NewIdentityProfileDispatcher(idprof.WithDefaultConfig())
-
-    // 2. OpenID4VPプラグインの初期化
-    // (プレゼンテーションのロジックはプラグイン化されている)
-    oid4vpPlugin, err := oid4vp.New(
-        oid4vp.WithLogger(logger),
-        oid4vp.WithVerificationDispatcher(verificationDispatcher),
-    )
-    if err!= nil {
-        panic(err)
+func newWallet(certPath string) (*wallet.Wallet, error) {
+    credStore, err := credstore.NewCredStoreDispatcher(credstore.WithDefaultConfig())
+    if err != nil {
+        return nil, err
     }
 
-    // 3. 提示ディスパッチャにOpenID4VPプラグインを登録
-    presentationDispatcher := presenter.NewPresentationDispatcher(
-        presenter.WithPlugin(presenter.Oid4vp, oid4vpPlugin),
-    )
-
-    // 4. すべてのディスパッチャをコントローラ設定に集約
-    config := vcknots_wallet.ControllerConfig{
-        CredStore:  credStoreDispatcher,
-        IdProf:     idProfileDispatcher,
-        Receiver:   receiverDispatcher,
-        Serializer: serializationDispatcher,
-        Verifier:   verificationDispatcher,
-        Presenter:  presentationDispatcher,
-        Logger:     logger,
+    receiverDisp, err := receiver.NewReceivingDispatcher(receiver.WithDefaultConfig())
+    if err != nil {
+        return nil, err
     }
 
-    // 5. コントローラのインスタンス化
-    return vcknots_wallet.NewController(config)
+    serializerDisp, err := serializer.NewSerializationDispatcher(serializer.WithDefaultConfig())
+    if err != nil {
+        return nil, err
+    }
+
+    verifierDisp, err := verifier.NewVerificationDispatcher(verifier.WithDefaultConfig())
+    if err != nil {
+        return nil, err
+    }
+
+    idProf, err := idprof.NewIdentityProfileDispatcher(idprof.WithDefaultConfig())
+    if err != nil {
+        return nil, err
+    }
+
+    // OID4VP Request Objectのx5c証明書チェーン検証に使うトラストルート
+    certFile, err := os.ReadFile(certPath)
+    if err != nil {
+        return nil, err
+    }
+    certPool := x509.NewCertPool()
+    certPool.AppendCertsFromPEM(certFile)
+
+    oid4vpPresenter := &oid4vp.Oid4vpPresenter{
+        X509TrustChainRoots: certPool,
+    }
+    presenterDisp, err := presenter.NewPresentationDispatcher(
+        presenter.WithPlugin(presenter.Oid4vp, oid4vpPresenter),
+    )
+    if err != nil {
+        return nil, err
+    }
+
+    return wallet.NewWalletWithConfig(wallet.Config{
+        CredStore:  credStore,
+        IDProfiler: idProf,
+        Receiver:   receiverDisp,
+        Serializer: serializerDisp,
+        Verifier:   verifierDisp,
+        Presenter:  presenterDisp,
+    })
 }
-
-var (
-    // このコントローラをチュートリアルの後半で使用します
-    controller = NewController()
-)
 ```
+
+* **保存先:** デフォルトの Credential ストアは、`go.etcd.io/bbolt` を使って `<ユーザー設定ディレクトリ>/vcknots/wallet/.local_credstore.db` に永続化します（Linux では `~/.config/vcknots/wallet/.local_credstore.db`、macOS では `~/Library/Application Support/vcknots/wallet/.local_credstore.db` など）。
 
 ## 3. Wallet機能のサンプル実装
 
-Controller インスタンスを使用して、Walletの主要な機能（鍵の準備、Credentialの受領、Credentialの提示）を実行する具体的なGoコードサンプルを示します。
-これらのサンプルは `server_integration.go` のロジックに基づいています。
+`Wallet` インスタンスを使用して、wallet の主要な機能（鍵の準備、Credential の受領、Credential の提示）を実行する具体的な Go コードサンプルを示します。
+これらのサンプルは `wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go` と `wallet/examples/common/common.go` に基づいています。
 
 ### 3-1. テスト用の鍵の準備 (IKeyEntryインターフェース)
 
-`controller.go` の主要なメソッド（`ReceiveCredential`, `PresentCredential`）は、署名操作のために `IKeyEntry`インターフェースを要求します。
-これにより、ライブラリ利用者は鍵管理の実装（例: メモリ、HSM、セキュアエンクレーブ）を自由に差し替えることができます。
+主要なワークフローメソッド（`ReceiveCredential`, `PresentCredential`）は、署名操作のために `IKeyEntry` インターフェースを要求します。
+これにより、ライブラリ利用者は鍵管理の実装（例: メモリ、HSM、セキュアエンクレーブ）を差し替えることができます。
 
-`IKeyEntry` インターフェースは以下のように定義されています:
+`IKeyEntry` インターフェースは以下のように定義されています。
 
 ```go
-// IKeyEntry は、鍵とその操作をカプセル化するインターフェースです。
+// IKeyEntry は、署名操作のための鍵エントリを表すインターフェースです。
 type IKeyEntry interface {
     ID() string
     PublicKey() jose.JSONWebKey
-    Sign(databyte) (byte, error)
+    Sign(data []byte) ([]byte, error)
 }
 ```
 
-チュートリアル用に、`server_integration.go` で提供されているインメモリのモック実装（`MockKeyEntry`）を使用します。
+* **署名フォーマット:** ECDSA 実装の `Sign` は、DER エンコードされた ASN.1 署名と、生の IEEE P1363（`R || S`）署名のどちらを返しても構いません。
+ライブラリが内部で（`JWKSigner` により）DER 署名を IEEE P1363 に正規化するため、両方の形式が動作します。
 
-この `MockKeyEntry` の `Sign` メソッド は、単なる `ecdsa.Sign` のラッパーではありません。
-これは、OpenID4VPで一般的に要求される ES256 署名（SHA-256ハッシュ）と、その結果をIEEE P1363形式（r と s を連結した64バイトのバイト列）にシリアライズするロジックを含んでいます。
-
+チュートリアル用に、`wallet/examples/common/common.go` の `MockKeyEntry` と同等のインメモリ実装を使用します。
 
 ```go
-// MockKeyEntry は IKeyEntry のテスト用実装です
+// MockKeyEntry は IKeyEntry のテスト用実装です。
 type MockKeyEntry struct {
     id         string
     privateKey *ecdsa.PrivateKey
+}
+
+func NewMockKeyEntry() (*MockKeyEntry, error) {
+    privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+    if err != nil {
+        return nil, err
+    }
+    return &MockKeyEntry{
+        id:         "test-key-id-" + uuid.NewString(),
+        privateKey: privKey,
+    }, nil
 }
 
 func (m *MockKeyEntry) ID() string { return m.id }
 
 func (m *MockKeyEntry) PublicKey() jose.JSONWebKey {
     return jose.JSONWebKey{
-        Key:       m.privateKey.PublicKey,
+        Key:       &m.privateKey.PublicKey,
         Algorithm: "ES256", // P-256曲線
         Use:       "sig",
     }
 }
 
-// Sign は SHA-256 ハッシュ -> ECDSA署名 -> IEEE P1363 形式への変換 を行います
-func (m *MockKeyEntry) Sign(payloadbyte) (byte, error) {
+// Sign は SHA-256 ハッシュ -> ECDSA署名 -> IEEE P1363 形式へのシリアライズ を行います。
+func (m *MockKeyEntry) Sign(payload []byte) ([]byte, error) {
     hash := sha256.Sum256(payload)
     r, s, err := ecdsa.Sign(rand.Reader, m.privateKey, hash[:])
-    if err!= nil {
+    if err != nil {
         return nil, err
     }
 
-    // P-256 (256 bits / 8 = 32 bytes)
-    const keySize = 32
-    // r と s を 64-byte (IEEE P1363) 形式にシリアライズ
-    signature := make(byte, 2*keySize)
-    r.FillBytes(signature)
-    s.FillBytes(signature)
+    const keySize = 32 // P-256: 256 bits / 8
+    signature := make([]byte, 2*keySize)
+    r.FillBytes(signature[:keySize])
+    s.FillBytes(signature[keySize:])
     return signature, nil
 }
-
-// NewMockKeyEntry は新しいテスト鍵を生成します
-func NewMockKeyEntry() (*MockKeyEntry, error) {
-    // P-256曲線で新しい鍵を生成します
-    privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-    if err!= nil {
-        return nil, err
-    }
-    
-    return &MockKeyEntry{
-        id:         "test-key-id-" + uuid.NewString(), // 実行ごとに一意のID
-        privateKey: privKey,
-    }, nil
-}
-
-// チュートリアルの後半で使用する鍵を準備します
-var testKey, _ = NewMockKeyEntry()
 ```
 
-### 3-2. Credentialの受領
+### 3-2. Credentialの受領 (OID4VCI)
 
-- この機能は、Issuer (Node.jsサーバー) からの `CredentialOffer` に基づき、Controller の `ReceiveCredential` メソッドを呼び出します。
-- `ReceiveCredential` メソッド は、`ReceiveCredentialRequest` 構造体を引数に取ります。
-- `server_integration.go` の `receiveMockCredential` 関数を参考に、Mock タイプのCredential（テスト用Issuerから発行される）を受領するプロセスを示します。
+wallet は、Issuer から取得した `CredentialOffer` を `ReceiveCredential` に渡して Credential を受領します。
+実際の運用では offer URI は QR コードやディープリンクから取得します。
+ローカルのサンプルサーバーでは `POST /configurations/:configurationId/offer` で作成できます。
 
+offer URI は `openid-credential-offer://?credential_offer=...` という形式です。
+これを `wallet.CredentialOffer` にパースして `ReceiveCredential` に渡します。
 
 ```go
-func receiveTestCredential(key *MockKeyEntry) (*vcknots_wallet.SavedCredential, error) {
-    // 1. Credential Offer をシミュレート (Mock)
-    // 実際のオファーURLは QRコードやディープリンクから取得されます
-    issuerURL, _ := url.Parse("http://localhost:8080/issuers/test_issuer/configurations/test_config")
+import (
+    "github.com/trustknots/vcknots/wallet"
+    "github.com/trustknots/vcknots/wallet/credential"
+    "github.com/trustknots/vcknots/wallet/receiver"
+)
 
-    offer := &vcknots_wallet.CredentialOffer{
-        CredentialIssuer:         issuerURL,
-        CredentialConfigurationIDs:string{"UniversityDegree_jwt_vc_json-ld"}, // サーバー側 と一致
-        Grants: map[string]*vcknots_wallet.CredentialOfferGrant{
-            "pre-authorized_code": {
-                PreAuthorizedCode: "test_code", // モック用の固定コード
-            },
-        },
-    }
-
-    // 2. 受領リクエストを作成
-    receiveReq := vcknots_wallet.ReceiveCredentialRequest{
-        CredentialOffer:    offer,
-        Type:               receiverTypes.Mock, // サーバー側と通信しないモックタイプ
-        Key:                key,                // 署名に使用する鍵 (PoPなど)
-        CachedIssuerMetadata: nil,              // メタデータがない場合は nil を指定
-    }
-
-    // 3. Controller の ReceiveCredential を呼び出す
-    log.Println("Attempting to receive credential...")
-    savedCred, err := controller.ReceiveCredential(receiveReq)
-    if err!= nil {
-        log.Printf("Error receiving credential: %v\n", err)
+func receiveSDJwtCredential(w *wallet.Wallet, key wallet.IKeyEntry, offerURI string) (*wallet.SavedCredential, error) {
+    // 1. openid-credential-offer:// URIをパース
+    parsed, err := url.Parse(offerURI)
+    if err != nil {
         return nil, err
     }
 
-    log.Printf("Successfully received and saved credential. ID: %s\n", savedCred.Entry.ID)
-    return savedCred, nil
+    var offerJSON struct {
+        CredentialIssuer           string                                  `json:"credential_issuer"`
+        CredentialConfigurationIDs []string                                `json:"credential_configuration_ids"`
+        Grants                     map[string]*wallet.CredentialOfferGrant `json:"grants"`
+    }
+    if err := json.Unmarshal([]byte(parsed.Query().Get("credential_offer")), &offerJSON); err != nil {
+        return nil, err
+    }
+
+    issuerURL, err := url.Parse(offerJSON.CredentialIssuer)
+    if err != nil {
+        return nil, err
+    }
+
+    offer := &wallet.CredentialOffer{
+        CredentialIssuer:           issuerURL,
+        CredentialConfigurationIDs: offerJSON.CredentialConfigurationIDs,
+        Grants:                     offerJSON.Grants, // キー: "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+    }
+
+    // 2. OID4VCI (pre-authorized codeフロー) でCredentialを受領
+    return w.ReceiveCredential(wallet.ReceiveCredentialRequest{
+        CredentialOffer: offer,
+        Type:            receiver.Oid4vci,
+        Key:             key,                 // JWT proof (key binding) の署名に使用
+        RequestedFormat: credential.SDJwtVC,  // "application/dc+sd-jwt"
+    })
 }
 ```
+
+`ReceiveCredentialRequest` の補足:
+
+* **RequestedFormat:** SD-JWT VC を受領する場合は `credential.SDJwtVC`、JWT-VC を受領する場合は `credential.JwtVc` を指定します。
+省略した場合は、先頭の credential configuration ID について Issuer メタデータからフォーマットを解決します（解決できない場合は JWT-VC にフォールバックします）。
+* **TxCode:** offer が transaction code を要求する場合は `TxCode` を設定します。token エンドポイントに `tx_code` として送信されます。
+* **CachedIssuerMetadata:** 設定すると、`ReceiveCredential` は Issuer メタデータの取得をスキップします（セクション 4 を参照）。
+
+`ReceiveCredential` は、Issuer と Authorization Server のメタデータを取得し、pre-authorized code でアクセストークンを取得し、`Key` で署名した JWT proof を生成して Credential を要求し、結果を Credential ストアに保存します。
+戻り値の `*wallet.SavedCredential` には、パース済みの Credential とストレージエントリの両方が含まれます。
 
 ### 3-3. Credentialの提示 (OpenID4VP)
 
-- Verifier (Node.jsサーバー) から `openid4vp://authorize?...` 形式のリクエストURIを受け取った後、Controller の `PresentCredential` メソッドを呼び出します。
-- このメソッド は、`uriString`（OpenID4VPリクエスト）をパースし、リクエスト内容（`presentation_definition`）を解析し、`credstore` から適合するCredentialを検索し、`IKeyEntry` を使ってVerifiable Presentation (VP) に署名し、Verifierの`callback` エンドポイント に`HTTP POST`します。
-- `server_integration.go` の `presentation` 関数に基づき、Node.jsサーバー（`/verifiers/test_verifier/request` エンドポイント）から取得したリクエストURIを処理します。
-
+Verifier から `openid4vp://authorize?...` 形式のリクエスト URI を受け取ったら（通常は QR コードのスキャンで取得します。ローカルのサンプルサーバーでは `POST /request` または `POST /request-object` で作成できます）、`PresentCredential` を呼び出します。
 
 ```go
-func presentTestCredential(key *MockKeyEntry) error {
-    // 1. Verifier (Node.js サーバー) から OpenID4VP リクエストURIを取得
-    // このURIは通常、QRコードのスキャンによって取得されます
-    // ここでは の /verifiers/test_verifier/request を直接呼び出します
-    resp, err := http.Get("http://localhost:8080/verifiers/test_verifier/request")
-    if err!= nil {
-        log.Printf("Failed to get OID4VP request URI from server: %v\n", err)
-        return err
-    }
-    defer resp.Body.Close()
+import sdjwtvc "github.com/trustknots/vcknots/wallet/serializer/plugins/sdjwtvc"
 
-    body, err := io.ReadAll(resp.Body)
-    if err!= nil {
-        return err
+func presentCredential(w *wallet.Wallet, key wallet.IKeyEntry, oid4vpURI string) error {
+    // SD-JWT VC提示のオプション: 選択的開示とKey Binding JWT
+    options := &sdjwtvc.SdJwtVcPresentationOptions{
+        SelectedClaims:    []string{"given_name", "family_name"},
+        RequireKeyBinding: true,
     }
 
-    oid4vpRequestURI := string(body)
-    log.Printf("Received OID4VP Request URI: %s\n", oid4vpRequestURI)
-
-    // 2. Controller の PresentCredential を呼び出す
-    // 内部でパース、検索、署名、HTTP POST が実行されます
-    log.Println("Attempting to present credential...")
-    redirectURI, err := controller.PresentCredential(oid4vpRequestURI, key, nil)
-    if err!= nil {
-        log.Printf("Error presenting credential: %v\n", err)
+    redirectURI, err := w.PresentCredential(oid4vpURI, key, options)
+    if err != nil {
         return err
     }
-
     if redirectURI != "" {
         log.Printf("Verifier requested redirect: %s\n", redirectURI)
     }
-
-    log.Println("Successfully presented credential to the verifier.")
     return nil
 }
 ```
 
+`PresentCredential` は、OID4VP リクエストをパースし（`request_uri` で参照される JAR Request Object も含み、その署名は `X509TrustChainRoots` に対して検証されます）、保存済みの Credential のうち最も新しく受領した 1 件を選択し（presentation definition との照合は現時点では行いません）、`key` で Verifiable Presentation をシリアライズして署名し、Verifier の `response_uri`（`response_mode=direct_post` の場合）または `redirect_uri` に POST します。
+戻り値の文字列は Verifier が提示したリダイレクト URI で、リダイレクトがない場合は空文字列です。
+
+* **提示オプション:** 第 3 引数にはフォーマット固有のオプションを渡します。
+SD-JWT VC では `sdjwtvc.SdJwtVcPresentationOptions` により、開示するクレーム（`SelectedClaims`）と Key Binding JWT の付与（`RequireKeyBinding`）を制御します。
+KB-JWT の audience と nonce は OID4VP リクエスト（`client_id` と `nonce`）から自動的に設定されます。リクエストに transaction data が含まれる場合の `transaction_data` ハッシュも同様です。
+`nil` を渡すと、その Credential のフォーマットに応じたデフォルトのオプションが使われます（JWT-VC の提示では `nil` が典型的です）。
+* **リダイレクト処理:** Verifier のリダイレクト URI をコールバックで受け取りたい場合は、`PresentCredentialWithOptions` に `wallet.PresentCredentialOptions{OnRedirect: func(uri string) error {...}}` を渡します。
+
 ### 3-4. 保存されたCredentialの参照
 
-- `ReceiveCredential` で保存されたCredentialは、Controller の `GetCredentialEntries` メソッドで検索・一覧取得できます。
-- このリクエスト により、ページネーション（`Offset`, `Limit`）や、`Filter` 関数による高度な絞り込みが可能です。
-
+`ReceiveCredential` で保存された Credential は、`GetCredentialEntries` で一覧取得できます。
+ページネーション（`Offset`, `Limit`）と Go 関数によるフィルタリング（`Filter`）をサポートします。
+ID を指定して 1 件だけ取得する場合は `GetCredentialEntry` を使います。
 
 ```go
-func listSavedCredentials() (*vcknots_wallet.SavedCredential, error) {
+func listSavedCredentials(w *wallet.Wallet) ([]*wallet.SavedCredential, error) {
     limit := 10
-    getEntriesReq := vcknots_wallet.GetCredentialEntriesRequest{
+    entries, total, err := w.GetCredentialEntries(wallet.GetCredentialEntriesRequest{
         Offset: 0,
         Limit:  &limit,
-        Filter: func(sc *vcknots_wallet.SavedCredential) bool {
-            // (例: 'UniversityDegree' のみフィルタリング)
-            // return sc.Credential.HasType("UniversityDegree")
-            return true // この例ではすべて取得
+        Filter: func(sc *wallet.SavedCredential) bool {
+            return true // 例: return sc.Entry.MimeType == string(credential.SDJwtVC)
         },
-    }
-
-    log.Println("Fetching saved credential entries...")
-    entries, total, err := controller.GetCredentialEntries(getEntriesReq)
-    if err!= nil {
-        log.Printf("Error getting credential entries: %v\n", err)
+    })
+    if err != nil {
         return nil, err
     }
 
     log.Printf("Found %d matching entries (Total: %d)\n", len(entries), total)
     for _, entry := range entries {
-        log.Printf(" - Entry ID: %s, Credential Type: %v\n", entry.Entry.ID, entry.Credential.Types)
+        log.Printf(" - Entry ID: %s, MimeType: %s\n", entry.Entry.Id, entry.Entry.MimeType)
     }
     return entries, nil
 }
 ```
 
-## 4. Walletメタデータの登録
+## 4. Issuerメタデータの取得
 
-- このセクションは、Walletが **自身の** メタデータを登録する機能ではなく、Walletが対話する **Issuer** のメタデータを **取得・処理** する機能について説明します。
+Credential を受領する際、wallet は Issuer の `.well-known/openid-credential-issuer` エンドポイントにアクセスし、Issuer の設定（credential エンドポイント、サポートする credential configuration など）を取得する必要があります。
 
-- Credentialを受領する際、WalletはまずIssuerの `.well-known/openid-credential-issuer` エンドポイント にアクセスし、そのIssuerの設定（公開鍵、サポートするCredentialタイプ、エンドポイントなど）を取得する必要があります。
-
-- Controller は、このタスク専用の `FetchCredentialIssuerMetadata` メソッドを提供します。
-- これは `ReceiveCredential` の内部フローで暗黙的に呼び出されるか、`ReceiveCredentialRequest` の `CachedIssuerMetadata` フィールド に設定するために事前に明示的に呼び出すことができます。
-
-- `ReceiveCredential` を呼び出す際に `CachedIssuerMetadata` を提供することで、`ReceiveCredential` が実行されるたびにメタデータを再フェッチするネットワークオーバーヘッドを回避できます。
-
+`ReceiveCredential` はこのメタデータを内部で取得しますが、`FetchCredentialIssuerMetadata` で明示的に取得し、`ReceiveCredentialRequest` の `CachedIssuerMetadata` フィールドに渡すこともできます。
+これにより、`ReceiveCredential` を呼び出すたびにメタデータを再取得するオーバーヘッドを回避できます。
 
 ```go
-func fetchIssuerMetadata() (*receiverTypes.CredentialIssuerMetadata, error) {
-    // 注意: このURLはIssuerのベースURLであり、/.well-known/... パス自体を含みません
-    // FetchCredentialIssuerMetadata が内部でパスを解決します
-    issuerURL, _ := url.Parse("http://localhost:8080") // IssuerのベースURL
+import receiverTypes "github.com/trustknots/vcknots/wallet/receiver/types"
 
-    log.Println("Fetching issuer metadata from:", issuerURL.String())
-    
-    // で定義されたメソッドを呼び出す
-    metadata, err := controller.FetchCredentialIssuerMetadata(
-        issuerURL,
-        receiverTypes.OpenID4VCI, // プロトコルタイプを指定
-    )
+func fetchIssuerMetadata(w *wallet.Wallet) (*receiverTypes.CredentialIssuerMetadata, error) {
+    // 注意: IssuerのベースURLを渡します。/.well-known/... パスは内部で解決されます
+    issuerURL, _ := url.Parse("http://localhost:8080")
 
-    if err!= nil {
-        log.Printf("Failed to fetch issuer metadata: %v\n", err)
+    metadata, err := w.FetchCredentialIssuerMetadata(issuerURL, receiverTypes.Oid4vci)
+    if err != nil {
         return nil, err
     }
 
-    log.Printf("Successfully fetched metadata for issuer: %s\n", metadata.CredentialIssuer)
-    // metadata.CredentialEndpoint, metadata.JWKS...
+    log.Printf("Fetched metadata for issuer: %s\n", metadata.CredentialIssuer)
+    // metadata.CredentialEndpoint, metadata.CredentialConfigurationSupported, ...
     return metadata, nil
 }
 ```
 
 ## 5. 型定義の説明
 
-vcknots/wallet ライブラリの Controller とのインタラクションに使用される主要なGoの型定義について説明します。
+vcknots/wallet ライブラリの `Wallet` とのインタラクションに使用される主要な Go の型定義について説明します。
 
-| 型 / インターフェース | 説明 |
-| :---- | :---- |
-| **IKeyEntry** | 鍵管理のコア・インターフェース。`ID()`, `PublicKey()`, `Sign()` の3つのメソッドを定義します。ライブラリ利用者は、HSMやセキュアエンクレーブと連携するためにこれを実装する必要があります。 |
-| **DIDCreateOptions** | `GenerateDID` メソッドに渡すオプション。生成するDIDのタイプ (`TypeID`) と、関連付ける公開鍵 (`PublicKey`) を指定します。 |
-| **ReceiveCredentialRequest** | `ReceiveCredential` メソッドの主要な入力。`CredentialOffer`、署名に使用する Key (`IKeyEntry`)、およびオプションの `CachedIssuerMetadata` をカプセル化します。 |
-| **CredentialOffer** | Issuerから受け取るオファーの詳細。IssuerのURL (`CredentialIssuer`)、要求するCredentialのID (`CredentialConfigurationIDs`)、および認可グラント (`Grants`) を含みます。 |
-| **SavedCredential** | `credstore` に保存されたCredentialの実体。`\*credential.Credential`（VCの生データ）と `\*types.CredentialEntry`（メタデータ）をラップします。`GetCredentialEntries` の戻り値です。 |
-| **GetCredentialEntriesRequest** | `GetCredentialEntries` メソッドでの検索条件。ページネーション (`Offset`, `Limit`) と、動的なGo関数によるフィルタリング (`Filter`) をサポートします。 |
+### IKeyEntry {#IKeyEntry}
 
-## 6. 注意事項
+鍵管理のコアインターフェース。`ID()`, `PublicKey()`, `Sign()` の 3 つのメソッドを定義します。ライブラリ利用者は、HSM やセキュアエンクレーブと連携するためにこれを実装します。
 
-1. **MockKeyEntry は本番環境で使用禁止 (CRITICAL):**  
-    - `server_integration.go` で提供されている `MockKeyEntry` は、テストとデモンストレーションのみを目的としています。
-    - **理由:** これは秘密鍵（`*ecdsa.PrivateKey`）をGoのヒープメモリ上に平文で保持します。
-    - **本番実装:** 本番環境では、`IKeyEntry` インターフェースを独自に実装する必要があります。この実装は、`Sign` オペレーションをOSのキーストア（`iOS Secure Enclave`, `Android Keystore`）やHSM（`Hardware Security Module`）に委譲し、秘密鍵自体がアプリケーションのメモリ空間にロードされないように（`Non-exportable`）設計する必要があります。  
+定義は [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go) を参照してください。
 
-2. **GOPRIVATE の設定:**  
-    - `go mod download` または `go build` が失敗する場合、GOPRIVATE 環境変数の設定 が欠落している可能性が最も高いです。 
+### Config {#Config}
 
-3. **署名フォーマットの互換性:**  
-    - 独自の `IKeyEntry` を実装する場合、`Sign` メソッド が生成する署名フォーマットに注意してください。
-    - `MockKeygit Entry` は、ES256（SHA-256 with P-256）署名を **IEEE P1363** 形式（64バイト固定長）でシリアライズします。
-    - Verifier が異なる形式（例: ASN.1 DER）を期待している場合、`PresentCredential` は署名検証エラーで失敗します。  
+`NewWalletWithConfig` の入力。6 つのディスパッチャコンポーネントと、オプションの DPoP 設定（[DPoPConfig](#DPoPConfig)）を保持します。`nil` のフィールドにはデフォルト実装が補われます。
 
-4. **永続化ストレージ (bbolt):**  
-    - `credstore.NewCredStoreDispatcher(credstore.WithDefaultConfig())` は、デフォルトで `go.etcd.io/bbolt` （組み込みKVS）を `wallet.db` のようなローカルファイルに永続化しようと試みます。
-    - 実行ディレクトリに書き込み権限があることを確認してください。
+定義は [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go) を参照してください。
 
-5. **OpenID4VP `client_id` の厳格な検証:**
-    - このWalletは、OpenID4VPコンフォーマンステストに準拠するため、`client_id`の厳格な検証を実装しています。
-    - 重複プレフィックス（例: `x509_san_dns:x509_san_dns:...`）や不正な形式は自動的に拒否されます。
-    - `x509_san_dns:`スキームの場合、リクエストJWTの`x5c`ヘッダーから証明書を抽出し、証明書のSubject Alternative Name (SAN) DNSフィールドと`client_id`の値を照合します。
-    - 詳細は `wallet/presenter/plugins/oid4vp/oid4vp.go` の `parseOID4VPClientID()` 関数と `x509_san_dns` 検証ロジックを参照してください。
+### ReceiveCredentialRequest {#ReceiveCredentialRequest}
 
-6. **証明書検証のテスト設定（`InsecureSkipX509Verify`）:**
-    - `Oid4vpPresenter`構造体は、テスト環境用に`InsecureSkipX509Verify`オプションを提供しています。
-    - **デフォルト動作（本番環境）**: 完全な証明書チェーン検証を実行します。証明書は信頼されたルートCAにチェーンされている必要があります。
-    - **テスト設定（`InsecureSkipX509Verify: true`）**: 証明書チェーンの検証をスキップし、x5cヘッダーから証明書を直接抽出します。SANと`client_id`の照合のみを実行します。
-    - ⚠️ **重大な警告**: `InsecureSkipX509Verify: true`は、コンフォーマンステストやローカル開発環境でのみ使用してください。本番環境では**絶対に**使用しないでください。これはセキュリティリスクを招きます。
-    - コンフォーマンステストでは、意図的に非標準的な証明書（自己署名、CA:TRUE設定など）を使用することがあるため、このオプションが必要になります。
+`ReceiveCredential` の主要な入力。[CredentialOffer](#CredentialOffer)、受領プロトコル（`Type`）、proof の署名に使用する鍵（[IKeyEntry](#IKeyEntry)）、要求する Credential フォーマット（`RequestedFormat`）、オプションの `CachedIssuerMetadata` と `TxCode` をカプセル化します。
 
-7. **Wallet 実行時の環境変数（`wallet/env/env.go`）:**
-    - Wallet の実行時フラグは `VCKNOTS_WALLET_` プレフィックスで管理されます。
-    - `VCKNOTS_WALLET_HTTP_ALLOWED=true` を設定すると、Wallet の HTTP 通信で HTTP エンドポイントを許可します（ローカル開発/テスト用途）。
+定義は [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go) を参照してください。
+
+### CredentialOffer {#CredentialOffer}
+
+Issuer から受け取るオファーの詳細。Issuer の URL（`CredentialIssuer`）、credential configuration ID（`CredentialConfigurationIDs`）、認可グラント（`Grants`）を含みます。
+
+定義は [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go) を参照してください。
+
+### SavedCredential {#SavedCredential}
+
+Credential ストアに保存された Credential。`*credential.Credential`（パース済みの Credential）と `*types.CredentialEntry`（ストレージメタデータ: ID、生データ、MIME タイプ、受領時刻）をラップします。`ReceiveCredential`, `GetCredentialEntries`, `GetCredentialEntry` の戻り値です。
+
+定義は [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go) を参照してください。
+
+### GetCredentialEntriesRequest {#GetCredentialEntriesRequest}
+
+`GetCredentialEntries` の検索条件。ページネーション（`Offset`, `Limit`）と、Go 関数による動的なフィルタリング（`Filter`）をサポートします。
+
+定義は [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go) を参照してください。
+
+### PresentCredentialOptions {#PresentCredentialOptions}
+
+`PresentCredentialWithOptions` の入力。フォーマット固有の `SerializeOptions` と、オプションの `OnRedirect` コールバックを保持します。
+
+定義は [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go) を参照してください。
+
+### SdJwtVcPresentationOptions {#SdJwtVcPresentationOptions}
+
+SD-JWT VC 提示のオプション: `SelectedClaims`, `RequireKeyBinding`, `Audience`, `Nonce`, `TransactionData`。audience と nonce は OID4VP リクエストから自動的に設定されます。
+
+定義は [wallet/serializer/plugins/sdjwtvc/sdjwtvc.go](https://github.com/trustknots/vcknots/blob/main/wallet/serializer/plugins/sdjwtvc/sdjwtvc.go) を参照してください。
+
+### DIDCreateOptions {#DIDCreateOptions}
+
+`GenerateDID` のオプション。DID のタイプ（`TypeID`、例: `"did:key"`）と、関連付ける公開鍵（`PublicKey`）を指定します。
+
+定義は [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go) を参照してください。
+
+### DPoPConfig {#DPoPConfig}
+
+token エンドポイントと credential エンドポイントへの DPoP proof 付与を有効化します（`Enabled`）。専用の鍵（`Key`）も指定できます。有効化時に鍵を指定しない場合は、インメモリの P-256 鍵が生成されます。
+
+定義は [wallet/wallet.go](https://github.com/trustknots/vcknots/blob/main/wallet/wallet.go) を参照してください。
+
+## 6. Walletのメソッド
+
+### ReceiveCredential
+
+OID4VCI（Pre-Authorized Code フロー）で Issuer から Credential を受領し、Credential ストアに保存します。
+
+```go
+func (w *Wallet) ReceiveCredential(req ReceiveCredentialRequest) (*SavedCredential, error)
+```
+
+**パラメータ**:
+- `req`: 受領リクエスト（[ReceiveCredentialRequest](#ReceiveCredentialRequest)）
+
+**戻り値**:
+- 受領し保存された Credential（[SavedCredential](#SavedCredential)）
+
+### PresentCredential
+
+OID4VP の Authorization Request に応答し、Verifiable Presentation を Verifier に送信します。
+
+```go
+func (w *Wallet) PresentCredential(uriString string, key IKeyEntry, options serializerTypes.SerializePresentationOptions) (string, error)
+```
+
+**パラメータ**:
+- `uriString`: OID4VP リクエスト URI（`openid4vp://authorize?...`）
+- `key`: Presentation の署名に使用する鍵（[IKeyEntry](#IKeyEntry)）
+- `options`: フォーマット固有の提示オプション（SD-JWT VC では [SdJwtVcPresentationOptions](#SdJwtVcPresentationOptions)）。`nil` を渡すと、その Credential のフォーマットのデフォルトが使われます
+
+**戻り値**:
+- Verifier が提示したリダイレクト URI（リダイレクトがない場合は空文字列）
+
+### PresentCredentialWithOptions
+
+`PresentCredential` と同じ動作に加えて、Verifier がリダイレクト URI を返した場合にコールバックを呼び出します。
+
+```go
+func (w *Wallet) PresentCredentialWithOptions(uriString string, key IKeyEntry, options *PresentCredentialOptions) (string, error)
+```
+
+**パラメータ**:
+- `uriString`: OID4VP リクエスト URI（`openid4vp://authorize?...`）
+- `key`: Presentation の署名に使用する鍵（[IKeyEntry](#IKeyEntry)）
+- `options`: シリアライズオプションとリダイレクトコールバック（[PresentCredentialOptions](#PresentCredentialOptions)）
+
+**戻り値**:
+- Verifier が提示したリダイレクト URI（リダイレクトがない場合は空文字列）
+
+### GetCredentialEntries
+
+保存された Credential を、ページネーションとフィルタリング付きで取得します。
+
+```go
+func (w *Wallet) GetCredentialEntries(req GetCredentialEntriesRequest) ([]*SavedCredential, int, error)
+```
+
+**パラメータ**:
+- `req`: 検索条件（[GetCredentialEntriesRequest](#GetCredentialEntriesRequest)）
+
+**戻り値**:
+- 条件に一致した Credential（[SavedCredential](#SavedCredential)）と、一致件数の合計
+
+### GetCredentialEntry
+
+ID を指定して、保存された Credential を 1 件取得します。
+
+```go
+func (w *Wallet) GetCredentialEntry(id string) (*SavedCredential, error)
+```
+
+**パラメータ**:
+- `id`: Credential エントリの ID
+
+**戻り値**:
+- 保存された Credential（[SavedCredential](#SavedCredential)）。見つからない場合は `nil`
+
+### FetchCredentialIssuerMetadata
+
+Issuer の `.well-known/openid-credential-issuer` エンドポイントから Issuer メタデータを取得します。
+
+```go
+func (w *Wallet) FetchCredentialIssuerMetadata(endpoint *url.URL, receivingType receiverTypes.SupportedReceivingTypes) (*receiverTypes.CredentialIssuerMetadata, error)
+```
+
+**パラメータ**:
+- `endpoint`: Issuer のベース URL（`/.well-known/...` パスは内部で解決されます）
+- `receivingType`: 受領プロトコル（`receiver.Oid4vci`）
+
+**戻り値**:
+- Issuer メタデータ（`receiverTypes.CredentialIssuerMetadata`）
+
+### GenerateDID
+
+公開鍵から DID を生成します。
+
+```go
+func (w *Wallet) GenerateDID(options DIDCreateOptions) (*idprofTypes.IdentityProfile, error)
+```
+
+**パラメータ**:
+- `options`: DID のタイプと公開鍵（[DIDCreateOptions](#DIDCreateOptions)）
+
+**戻り値**:
+- 生成されたアイデンティティプロファイル（`idprofTypes.IdentityProfile`）
+
+## 7. 注意事項
+
+1. **モック鍵は本番環境で使用禁止 (CRITICAL):**
+    - このチュートリアルで示したインメモリの鍵実装（および `wallet/examples/common/` の `MockKeyEntry`）は、秘密鍵を Go のヒープメモリ上に平文で保持するため、テストとデモンストレーションのみを目的としています。
+    - 本番環境では、`Sign` オペレーションを OS のキーストア（iOS Secure Enclave, Android Keystore）や HSM に委譲し、秘密鍵自体がアプリケーションのメモリ空間にロードされない（non-exportable な）形で `IKeyEntry` を実装してください。
+
+2. **GOPRIVATE の設定:**
+    - `go mod download` または `go build` が失敗する場合、GOPRIVATE 環境変数の設定が欠落している可能性が最も高いです。
+
+3. **署名フォーマットの互換性:**
+    - `Sign` は ES256 について、DER エンコードされた ASN.1 署名と生の IEEE P1363 署名のどちらを返しても構いません。ライブラリが JWS 構造に埋め込む前に DER を P1363 に正規化します。
+
+4. **永続化ストレージ (bbolt):**
+    - `credstore.WithDefaultConfig()` は、`go.etcd.io/bbolt` を使って `<ユーザー設定ディレクトリ>/vcknots/wallet/.local_credstore.db` に Credential を永続化します。プロセスがこのディレクトリを作成し書き込めることを確認してください。
+
+5. **HTTPS の強制と実行時の環境変数（`wallet/env/env.go`）:**
+    - wallet はデフォルトで、Issuer と Verifier のエンドポイントに HTTPS を要求します。
+    - `VCKNOTS_WALLET_HTTP_ALLOWED=true` を設定すると、HTTP エンドポイントを許可します（ローカル開発とテスト用途のみ）。
     - `VCKNOTS_WALLET_DEBUG=true` はデバッグモードを有効化し、同時に HTTP 許可動作も有効化します。
-    - `IsHTTPAllowed()` は、上記いずれかが `true` のとき `true` を返し、それ以外は `false` を返します。
-    - **本番運用の指針:** 本番環境では両方未設定（または `false`）のままにし、HTTPS 必須検証を維持してください。
+    - **本番運用の指針:** 本番環境では両方とも未設定（または `false`）のままにし、HTTPS 必須の検証を維持してください。
 
-## 7. トラブルシューティング
+6. **OpenID4VP `client_id` の厳格な検証:**
+    - この wallet は、OpenID4VP コンフォーマンステストに準拠するため、`client_id` を厳格に検証します。重複プレフィックス（例: `x509_san_dns:x509_san_dns:...`）や不正な形式は拒否されます。
+    - `x509_san_dns:` スキームの場合、リクエスト JWT の `x5c` ヘッダーから証明書を抽出し、証明書の Subject Alternative Name (SAN) DNS フィールドと `client_id` の値を照合します。
+    - 検証ロジックは `wallet/presenter/plugins/oid4vp/` を参照してください。
 
-* **Q: `go mod download` が `package... is private` または `404 Not Found` で失敗する。**  
-  * **A:** GOPRIVATE 環境変数が正しく設定されていません。「1. 前提条件」 に戻り、`export GOPRIVATE="github.com/trustknots/vcknots/wallet"` が実行されていることを確認してください。  
+7. **証明書検証のテスト設定（`InsecureSkipX509Verify`）:**
+    - `Oid4vpPresenter` 構造体は、テスト環境用に `InsecureSkipX509Verify` オプションを提供しています。
+    - **デフォルト動作（本番環境）:** `X509TrustChainRoots` に対する完全な証明書チェーン検証を実行します。
+    - **テスト設定（`InsecureSkipX509Verify: true`）:** 証明書チェーンの検証をスキップし、`x5c` ヘッダーから証明書を直接抽出します。SAN と `client_id` の照合のみを実行します。
+    - ⚠️ **重大な警告**: `InsecureSkipX509Verify: true` は、コンフォーマンステストやローカル開発環境でのみ使用してください。本番環境では**絶対に**使用しないでください。
 
-* **Q: `ReceiveCredential` または `PresentCredential` が `connection refused` または `timeout` で失敗する。**  
-  * **A:** vcknots/wallet のGoコードが通信しようとしているIssuer/Verifierサーバーが起動していません。「1. 前提条件」 に従い、`packages/server` ディレクトリで `pnpm start` を実行し、http://localhost:8080 が応答することを確認してください。  
+8. **DPoP サポート（オプション）:**
+    - `wallet.Config{DPoP: wallet.DPoPConfig{Enabled: true}}` を設定すると、wallet は token リクエストと credential リクエストに DPoP proof を付与し、サーバーからの DPoP nonce チャレンジも処理します。
 
-* **Q: `PresentCredential` は成功するが、Verifier側（Node.jsサーバーのログ）で `Invalid signature` や `Presentation verification failed` と表示される。**  
-  * **A:** これは、Walletが使用した `IKeyEntry` と Verifier の間で署名アルゴリズムまたはフォーマットの不一致があることを示します。  
-    1. `MockKeyEntry` を使用しているか確認してください。  
-    2. 独自の `IKeyEntry` を使用している場合、`Sign` メソッドが `MockKeyEntry` と同様に、SHA-256ハッシュとIEEE P1363シリアライゼーションを使用しているか確認してください。  
+## 8. トラブルシューティング
 
-* **Q: `controller.ReceiveCredential` が `issuer metadata not found` で失敗する。**  
-  * **A:** Node.jsサーバー は起動しているかもしれませんが、`/.well-known/openid-credential-issuer` エンドポイントが正しく機能していない可能性があります。`curl http://localhost:8080/.well-known/openid-credential-issuer` （または「4. Walletメタデータの登録」で指定されたIssuerのベースURL）を実行して、JSONメタデータが返されることを確認してください。
+* **Q: `go mod download` が `package ... is private` または `404 Not Found` で失敗する。**
+  * **A:** GOPRIVATE 環境変数が設定されていません。「1. 前提条件」に戻り、`export GOPRIVATE="github.com/trustknots/vcknots/wallet"` が実行されていること（または mise を使用していること）を確認してください。
 
-* **Q: OpenID4VPコンフォーマンステストで `client_id` 検証エラーが発生する。**
-  * **A:** コンフォーマンステストは、意図的に不正な`client_id`（重複プレフィックス、末尾の空白など）を送信してWalletの検証ロジックをテストします。修正後のWalletは、このような不正な`client_id`を正しく拒否します。
-  * エラー例: `"invalid client_id: duplicate prefix detected"` または `"SAN of the certificate and client_id did not match"`
-  * これらのエラーは**期待される動作**であり、Walletが正しくセキュリティチェックを実施していることを示します。
+* **Q: `ReceiveCredential` または `PresentCredential` が `connection refused` または `timeout` で失敗する。**
+  * **A:** Issuer/Verifier サーバーが起動していません。「1. 前提条件」に従い、`pnpm -F @trustknots/server start` でサーバーを起動し、http://localhost:8080 が応答することを確認してください。
 
-* **Q: OpenID4VPコンフォーマンステストで `x509: certificate is not standards compliant` エラーが発生する。**
-  * **A:** コンフォーマンステストサーバーは、テスト目的で自己署名証明書や非標準的な証明書構造を使用することがあります。
-  * **解決策**: テスト環境でのみ`InsecureSkipX509Verify: true`を設定してください：
+* **Q: `ReceiveCredential` が `credential issuer must use https scheme` で失敗する。**
+  * **A:** wallet はデフォルトで HTTPS を強制します。HTTP のサンプルサーバーに対してローカルテストする場合は、`VCKNOTS_WALLET_HTTP_ALLOWED=true` を設定してください（または `env.SetHTTPAllowed(true)` を呼び出してください）。
+
+* **Q: `ReceiveCredential` が `failed to fetch issuer metadata` で失敗する。**
+  * **A:** サーバーは起動していても、`/.well-known/openid-credential-issuer` エンドポイントが正しく機能していない可能性があります。`curl http://localhost:8080/.well-known/openid-credential-issuer` を実行して、JSON メタデータが返されることを確認してください。
+
+* **Q: OpenID4VP コンフォーマンステストで `client_id` 検証エラーが発生する。**
+  * **A:** コンフォーマンステストは、意図的に不正な `client_id`（重複プレフィックスなど）を送信して wallet の検証ロジックをテストします。`invalid client_id: duplicate prefix detected` や `SAN of the certificate and client_id did not match` のようなエラーは**期待される動作**であり、wallet が正しくセキュリティチェックを実施していることを示します。
+
+* **Q: OpenID4VP コンフォーマンステストで `x509: certificate is not standards compliant` エラーが発生する。**
+  * **A:** コンフォーマンステストサーバーは、自己署名証明書や非標準的な証明書を使用することがあります。テスト環境でのみ `InsecureSkipX509Verify: true` を設定してください。
     ```go
     p := &oid4vp.Oid4vpPresenter{
         X509TrustChainRoots:    systemRoots,
-        InsecureSkipX509Verify: true,  // テスト環境のみ
+        InsecureSkipX509Verify: true, // テスト環境のみ
     }
     ```
-  * ⚠️ **警告**: 本番環境では必ず`false`（またはこのフィールドを設定しない）にしてください。
-  * 詳細は [examples/README.ja.md](https://github.com/trustknots/vcknots/blob/main/wallet/examples/README.ja.md) の「コンフォーマンステストのトラブルシューティング」セクションを参照してください。
+  * ⚠️ **警告**: 本番環境では必ず `false`（または未設定）にしてください。
+
+実行可能なエンドツーエンドのサンプル（JWT-VC、SD-JWT VC、KB-JWT 付き SD-JWT VC）は [wallet/examples/README.ja.md](https://github.com/trustknots/vcknots/blob/main/wallet/examples/README.ja.md) を参照してください。

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/wallet.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/wallet.md
@@ -104,7 +104,11 @@ go mod download
 最も簡単な初期化は `wallet.NewWallet()` で、すべてのディスパッチャコンポーネントをデフォルトのプラグイン実装で初期化します。
 
 ```go
-import "github.com/trustknots/vcknots/wallet"
+import (
+    "log"
+
+    "github.com/trustknots/vcknots/wallet"
+)
 
 w, err := wallet.NewWallet()
 if err != nil {
@@ -132,6 +136,7 @@ package main
 
 import (
     "crypto/x509"
+    "fmt"
     "os"
 
     "github.com/trustknots/vcknots/wallet"
@@ -176,7 +181,9 @@ func newWallet(certPath string) (*wallet.Wallet, error) {
         return nil, err
     }
     certPool := x509.NewCertPool()
-    certPool.AppendCertsFromPEM(certFile)
+    if !certPool.AppendCertsFromPEM(certFile) {
+        return nil, fmt.Errorf("failed to parse certificate: %s", certPath)
+    }
 
     oid4vpPresenter := &oid4vp.Oid4vpPresenter{
         X509TrustChainRoots: certPool,
@@ -282,6 +289,9 @@ offer URI は `openid-credential-offer://?credential_offer=...` という形式�
 
 ```go
 import (
+    "encoding/json"
+    "net/url"
+
     "github.com/trustknots/vcknots/wallet"
     "github.com/trustknots/vcknots/wallet/credential"
     "github.com/trustknots/vcknots/wallet/receiver"
@@ -339,7 +349,11 @@ func receiveSDJwtCredential(w *wallet.Wallet, key wallet.IKeyEntry, offerURI str
 Verifier から `openid4vp://authorize?...` 形式のリクエスト URI を受け取ったら（通常は QR コードのスキャンで取得します。ローカルのサンプルサーバーでは `POST /request` または `POST /request-object` で作成できます）、`PresentCredential` を呼び出します。
 
 ```go
-import sdjwtvc "github.com/trustknots/vcknots/wallet/serializer/plugins/sdjwtvc"
+import (
+    "log"
+
+    sdjwtvc "github.com/trustknots/vcknots/wallet/serializer/plugins/sdjwtvc"
+)
 
 func presentCredential(w *wallet.Wallet, key wallet.IKeyEntry, oid4vpURI string) error {
     // SD-JWT VC提示のオプション: 選択的開示とKey Binding JWT
@@ -359,14 +373,15 @@ func presentCredential(w *wallet.Wallet, key wallet.IKeyEntry, oid4vpURI string)
 }
 ```
 
-`PresentCredential` は、OID4VP リクエストをパースし（`request_uri` で参照される JAR Request Object も含み、その署名は `X509TrustChainRoots` に対して検証されます）、保存済みの Credential のうち最も新しく受領した 1 件を選択し（presentation definition との照合は現時点では行いません）、`key` で Verifiable Presentation をシリアライズして署名し、Verifier の `response_uri`（`response_mode=direct_post` の場合）または `redirect_uri` に POST します。
-戻り値の文字列は Verifier が提示したリダイレクト URI で、リダイレクトがない場合は空文字列です。
+`PresentCredential` は、OID4VP リクエストをパースし（`request_uri` で参照される JAR Request Object も含み、その署名は `X509TrustChainRoots` に対して検証されます）、保存済みの Credential のうち最も新しく受領した 1 件を選択し（presentation definition との照合は現時点では行いません）、`key` で Verifiable Presentation をシリアライズして署名し、Verifier の `response_uri`（`response_mode=direct_post`）に POST します。
+Wallet が `redirect_uri` に送信することはありません。
+Verifier の応答に `redirect_uri` が含まれる場合、その値が戻り値として呼び出し側に返されます（含まれない場合は空文字列です）。
 
 * **提示オプション:** 第 3 引数にはフォーマット固有のオプションを渡します。
 SD-JWT VC では `sdjwtvc.SdJwtVcPresentationOptions` により、開示するクレーム（`SelectedClaims`）と Key Binding JWT の付与（`RequireKeyBinding`）を制御します。
 KB-JWT の audience と nonce は OID4VP リクエスト（`client_id` と `nonce`）から自動的に設定されます。リクエストに transaction data が含まれる場合の `transaction_data` ハッシュも同様です。
 `nil` を渡すと、その Credential のフォーマットに応じたデフォルトのオプションが使われます（JWT-VC の提示では `nil` が典型的です）。
-* **リダイレクト処理:** Verifier のリダイレクト URI をコールバックで受け取りたい場合は、`PresentCredentialWithOptions` に `wallet.PresentCredentialOptions{OnRedirect: func(uri string) error {...}}` を渡します。
+* **リダイレクト処理:** Verifier のリダイレクト URI をコールバックで受け取りたい場合は、`PresentCredentialWithOptions` に `&wallet.PresentCredentialOptions{OnRedirect: func(uri string) error {...}}` を渡します。
 
 ### 3-4. 保存されたCredentialの参照
 
@@ -404,7 +419,12 @@ Credential を受領する際、wallet は Issuer の `.well-known/openid-creden
 これにより、`ReceiveCredential` を呼び出すたびにメタデータを再取得するオーバーヘッドを回避できます。
 
 ```go
-import receiverTypes "github.com/trustknots/vcknots/wallet/receiver/types"
+import (
+    "log"
+    "net/url"
+
+    receiverTypes "github.com/trustknots/vcknots/wallet/receiver/types"
+)
 
 func fetchIssuerMetadata(w *wallet.Wallet) (*receiverTypes.CredentialIssuerMetadata, error) {
     // 注意: IssuerのベースURLを渡します。/.well-known/... パスは内部で解決されます
@@ -559,7 +579,7 @@ func (w *Wallet) GetCredentialEntry(id string) (*SavedCredential, error)
 - `id`: Credential エントリの ID
 
 **戻り値**:
-- 保存された Credential（[SavedCredential](#SavedCredential)）。見つからない場合は `nil`
+- 保存された Credential（[SavedCredential](#SavedCredential)）。デフォルトのローカルストアでは、ID が存在しない場合はエラーを返します
 
 ### FetchCredentialIssuerMetadata
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * ウォレットの英語・日本語チュートリアルを現行の Go API と実行手順に全面更新しました。
  * Go 1.26.5、mise、GOPRIVATE、Issuer／Verifier のセットアップ手順を追加しました。
  * `Wallet` による Credential の受領・提示、保存済み Credential の参照例を追加しました。
  * OID4VCI・OID4VP、SD-JWT VC、選択的開示、DPoP、Key Binding JWT の説明を拡充しました。
  * HTTPS、`client_id` 検証、証明書検証、環境変数、トラブルシューティングを追加しました。
  * 古い API、サーバー手順、モックフローの説明を削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->