### PR TITLE
fix(wallet): parse long-form DER lengths in ConvertDERToRaw

### DIFF
--- a/wallet/common/jose/signer.go
+++ b/wallet/common/jose/signer.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/trustknots/vcknots/wallet/keystore"
+	"golang.org/x/crypto/cryptobyte"
+	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
 )
 
 // JWKSigner adapts KeyEntry to go-jose's signing interface
@@ -83,7 +85,7 @@ func (s *JWKSigner) SignPayload(payload []byte, alg jose.SignatureAlgorithm) ([]
 }
 
 // ConvertDERToRaw converts DER-encoded ECDSA signature to raw IEEE P1363 format
-// DER format: 0x30 [total-len] 0x02 [R-len] [R] 0x02 [S-len] [S]
+// DER format: SEQUENCE { INTEGER R, INTEGER S }
 // Raw format: [R-bytes][S-bytes] with fixed length per component
 //
 // keySize is the size in bytes of each component (r and s)
@@ -106,54 +108,29 @@ func ConvertDERToRaw(derSig []byte, keySize int) ([]byte, error) {
 		return nil, fmt.Errorf("signature is not in DER format and length (%d) doesn't match expected raw format (%d)", len(derSig), keySize*2)
 	}
 
-	// Parse DER format
-	offset := 2 // Skip sequence tag (0x30) and total length
-
-	// Parse R component
-	if offset >= len(derSig) || derSig[offset] != 0x02 {
-		return nil, fmt.Errorf("invalid DER format: expected integer tag for R at offset %d", offset)
+	// P-521 signatures exceed 127 bytes, so their SEQUENCE length is long-form.
+	// cryptobyte reads both length forms; a fixed 2-byte header skip cannot.
+	var r, s big.Int
+	var inner cryptobyte.String
+	input := cryptobyte.String(derSig)
+	if !input.ReadASN1(&inner, cryptobyte_asn1.SEQUENCE) || !input.Empty() ||
+		!inner.ReadASN1Integer(&r) || !inner.ReadASN1Integer(&s) || !inner.Empty() {
+		return nil, fmt.Errorf("invalid DER format: expected a SEQUENCE of exactly two INTEGERs")
 	}
-	offset++
 
-	if offset >= len(derSig) {
-		return nil, fmt.Errorf("invalid DER format: R length missing")
+	if r.Sign() <= 0 || s.Sign() <= 0 {
+		return nil, fmt.Errorf("invalid DER signature: R and S must be positive")
 	}
-	rLen := int(derSig[offset])
-	offset++
 
-	if offset+rLen > len(derSig) {
-		return nil, fmt.Errorf("invalid DER format: R length exceeds signature bounds")
+	// Get bytes (big.Int drops leading zeros) and pad with leading zeros if necessary
+	rRaw := r.Bytes()
+	sRaw := s.Bytes()
+	if len(rRaw) > keySize || len(sRaw) > keySize {
+		return nil, fmt.Errorf("DER signature components exceed key size %d: R=%d bytes, S=%d bytes", keySize, len(rRaw), len(sRaw))
 	}
-	rBytes := derSig[offset : offset+rLen]
-	offset += rLen
-
-	// Parse S component
-	if offset >= len(derSig) || derSig[offset] != 0x02 {
-		return nil, fmt.Errorf("invalid DER format: expected integer tag for S at offset %d", offset)
-	}
-	offset++
-
-	if offset >= len(derSig) {
-		return nil, fmt.Errorf("invalid DER format: S length missing")
-	}
-	sLen := int(derSig[offset])
-	offset++
-
-	if offset+sLen > len(derSig) {
-		return nil, fmt.Errorf("invalid DER format: S length exceeds signature bounds")
-	}
-	sBytes := derSig[offset : offset+sLen]
-
-	// Convert to big integers (removes leading zeros)
-	r := new(big.Int).SetBytes(rBytes)
-	s := new(big.Int).SetBytes(sBytes)
 
 	// Convert to fixed-length raw format
 	rawSig := make([]byte, keySize*2)
-
-	// Get bytes and pad with leading zeros if necessary
-	rRaw := r.Bytes()
-	sRaw := s.Bytes()
 
 	// Copy R to first half, S to second half (right-aligned with zero padding)
 	copy(rawSig[keySize-len(rRaw):keySize], rRaw)

--- a/wallet/common/jose/signer_test.go
+++ b/wallet/common/jose/signer_test.go
@@ -1,6 +1,7 @@
 package jose
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -173,6 +174,16 @@ func TestJWKSigner_SignPayload(t *testing.T) {
 	}
 }
 
+// derSignature encodes r and s as SEQUENCE { INTEGER, INTEGER }, short-form only.
+func derSignature(r, s []byte) []byte {
+	var body []byte
+	for _, component := range [][]byte{r, s} {
+		body = append(body, 0x02, byte(len(component)))
+		body = append(body, component...)
+	}
+	return append([]byte{0x30, byte(len(body))}, body...)
+}
+
 func TestConvertDERToRaw(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -221,6 +232,20 @@ func TestConvertDERToRaw(t *testing.T) {
 			expectedLen: 0,
 			wantErr:     true,
 		},
+		{
+			name:        "DER signature with trailing data",
+			input:       append(derSignature(bytes.Repeat([]byte{0x01}, 32), bytes.Repeat([]byte{0x02}, 32)), 0x00),
+			keySize:     32,
+			expectedLen: 0,
+			wantErr:     true,
+		},
+		{
+			name:        "DER component wider than the key size",
+			input:       derSignature(bytes.Repeat([]byte{0x01}, 33), bytes.Repeat([]byte{0x02}, 32)),
+			keySize:     32,
+			expectedLen: 0,
+			wantErr:     true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -232,6 +257,51 @@ func TestConvertDERToRaw(t *testing.T) {
 			}
 			if !tt.wantErr && len(rawSig) != tt.expectedLen {
 				t.Errorf("expected length %d, got %d", tt.expectedLen, len(rawSig))
+			}
+		})
+	}
+}
+
+func TestConvertDERToRawAcceptsASN1Signatures(t *testing.T) {
+	tests := []struct {
+		name    string
+		curve   elliptic.Curve
+		keySize int
+	}{
+		{"P-256 (ES256)", elliptic.P256(), 32},
+		{"P-384 (ES384)", elliptic.P384(), 48},
+		// P-521 DER runs past 127 bytes, so its SEQUENCE length is long-form.
+		{"P-521 (ES512)", elliptic.P521(), 66},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := ecdsa.GenerateKey(tt.curve, rand.Reader)
+			if err != nil {
+				t.Fatalf("GenerateKey() error = %v", err)
+			}
+			hash := sha256.Sum256([]byte("payload"))
+
+			// R and S differ per signature, so repeat to also hit short components.
+			for i := 0; i < 20; i++ {
+				derSig, err := ecdsa.SignASN1(rand.Reader, key, hash[:])
+				if err != nil {
+					t.Fatalf("SignASN1() error = %v", err)
+				}
+
+				rawSig, err := ConvertDERToRaw(derSig, tt.keySize)
+				if err != nil {
+					t.Fatalf("ConvertDERToRaw() error = %v (DER length %d)", err, len(derSig))
+				}
+				if len(rawSig) != tt.keySize*2 {
+					t.Fatalf("expected length %d, got %d", tt.keySize*2, len(rawSig))
+				}
+
+				r := new(big.Int).SetBytes(rawSig[:tt.keySize])
+				s := new(big.Int).SetBytes(rawSig[tt.keySize:])
+				if !ecdsa.Verify(&key.PublicKey, hash[:], r, s) {
+					t.Fatalf("converted signature failed verification")
+				}
 			}
 		})
 	}

--- a/wallet/common/jose/signer_test.go
+++ b/wallet/common/jose/signer_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
 )
 
 // mockKeyEntry implements keystore.KeyEntry for testing
@@ -251,13 +252,12 @@ func TestConvertDERToRaw(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rawSig, err := ConvertDERToRaw(tt.input, tt.keySize)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ConvertDERToRaw() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !tt.wantErr && len(rawSig) != tt.expectedLen {
-				t.Errorf("expected length %d, got %d", tt.expectedLen, len(rawSig))
-			}
+			require.NoError(t, err)
+			require.Len(t, rawSig, tt.expectedLen)
 		})
 	}
 }
@@ -277,31 +277,21 @@ func TestConvertDERToRawAcceptsASN1Signatures(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			key, err := ecdsa.GenerateKey(tt.curve, rand.Reader)
-			if err != nil {
-				t.Fatalf("GenerateKey() error = %v", err)
-			}
+			require.NoError(t, err)
 			hash := sha256.Sum256([]byte("payload"))
 
 			// R and S differ per signature, so repeat to also hit short components.
 			for i := 0; i < 20; i++ {
 				derSig, err := ecdsa.SignASN1(rand.Reader, key, hash[:])
-				if err != nil {
-					t.Fatalf("SignASN1() error = %v", err)
-				}
+				require.NoError(t, err)
 
 				rawSig, err := ConvertDERToRaw(derSig, tt.keySize)
-				if err != nil {
-					t.Fatalf("ConvertDERToRaw() error = %v (DER length %d)", err, len(derSig))
-				}
-				if len(rawSig) != tt.keySize*2 {
-					t.Fatalf("expected length %d, got %d", tt.keySize*2, len(rawSig))
-				}
+				require.NoError(t, err, "DER length %d", len(derSig))
+				require.Len(t, rawSig, tt.keySize*2)
 
 				r := new(big.Int).SetBytes(rawSig[:tt.keySize])
 				s := new(big.Int).SetBytes(rawSig[tt.keySize:])
-				if !ecdsa.Verify(&key.PublicKey, hash[:], r, s) {
-					t.Fatalf("converted signature failed verification")
-				}
+				require.True(t, ecdsa.Verify(&key.PublicKey, hash[:], r, s), "converted signature failed verification")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`wallet/common/jose.ConvertDERToRaw` rejected every ES512 (P-521) DER signature. This replaces the hand-rolled offset arithmetic with a real ASN.1 reader so both DER length forms parse.

Found while confirming that #260 was already fixed by #261 — the two share an error message, but this one is deterministic rather than intermittent.

## Root Cause

The parser skipped the SEQUENCE header with a fixed `offset := 2`, assuming the length field is a single byte. P-521 signatures are around 139 bytes, so the SEQUENCE uses the DER long form (`30 81 88 ...`) and offset 2 lands on the length byte `0x88` instead of the `0x02` INTEGER tag:

```
invalid DER format: expected integer tag for R at offset 2
```

`JWKSigner.SignPayload` routes `jose.ES512` to `ConvertDERToRaw(signature, 66)`, so a `KeyEntry.Sign` implementation returning DER (anything built on `ecdsa.SignASN1`) could never produce an ES512 JWS. ES256 and ES384 were unaffected: their DER stays under 128 bytes and uses the short form.

## Fix

Read the signature with `golang.org/x/crypto/cryptobyte`, which `crypto/ecdsa` itself uses. It handles both length forms, rejects trailing data, and drops ~40 lines of offset arithmetic. `golang.org/x/crypto` is already a direct dependency, so `go.mod` is unchanged.

Two behaviour changes beyond the parse fix:

- Components wider than `keySize` now return an error instead of panicking on a negative slice index.
- Non-positive R or S is rejected.

The raw IEEE P1363 shortcut added in #261 is untouched.

## Validation

The new `TestConvertDERToRawAcceptsASN1Signatures` signs 20 times per curve with `ecdsa.SignASN1` and verifies the converted `r||s` against the public key. Against the pre-fix code it reproduces the reported failure, and only for P-521:

```
--- FAIL: TestConvertDERToRawAcceptsASN1Signatures/P-521_(ES512)
    signer_test.go:294: ConvertDERToRaw() error = invalid DER format:
      expected integer tag for R at offset 2 (DER length 139)
```

After the fix:

```
$ gofmt -l common/jose/ && go vet ./common/jose/   # no output
$ go build ./... && go test ./...                  # no failures
```

Table cases were also added for trailing data after the SEQUENCE and for a component wider than the key size.

Fixes #333


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * P-256、P-384、P-521のECDSA署名を、DER形式からRaw形式へより正確に変換できるようになりました。
  * P-521の長い形式の署名に対応しました。
  * 不正な署名（余分なデータ、負の値、サイズ超過など）を適切に拒否するよう改善しました。
  * 署名の変換および暗号学的検証に関するテストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->