### PR TITLE
fix(wallet): cherry pick from oid4vci-1.0

### DIFF
--- a/wallet/receiver/plugins/oid4vci/oid4vci.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci.go
@@ -55,7 +55,7 @@ func (o *Oid4vciReceiver) doRequest(method string, endpoint common.URIField, pat
 		return fmt.Errorf("unsupported URL scheme for OID4VCI endpoint: %q (https required)", endpointURL.Scheme)
 	}
 
-	if path == "/.well-known/oauth-authorization-server" {
+	if path == "/.well-known/oauth-authorization-server" || path == "/.well-known/openid-credential-issuer" {
 		// Special handling for metadata discovery as per RFC 8414 §3
 		// The well-known string MUST be inserted between the host component and the path component.
 		originalPath := strings.TrimSuffix(endpointURL.Path, "/")

--- a/wallet/receiver/plugins/oid4vci/oid4vci_test.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci_test.go
@@ -985,7 +985,7 @@ func TestOid4vciReceiver_MetadataDiscovery_UrlPatterns(t *testing.T) {
 		{
 			name:         "Credential Issuer (With Path)",
 			identifier:   "/tenant2",
-			expectedPath: "/tenant2/.well-known/openid-credential-issuer",
+			expectedPath: "/.well-known/openid-credential-issuer/tenant2",
 			discovery: func(u common.URIField) error {
 				_, err := receiver.FetchIssuerMetadata(u, types.Oid4vci)
 				return err
@@ -994,7 +994,7 @@ func TestOid4vciReceiver_MetadataDiscovery_UrlPatterns(t *testing.T) {
 		{
 			name:         "Credential Issuer (With Trailing Slash)",
 			identifier:   "/tenant2/",
-			expectedPath: "/tenant2/.well-known/openid-credential-issuer",
+			expectedPath: "/.well-known/openid-credential-issuer/tenant2",
 			discovery: func(u common.URIField) error {
 				_, err := receiver.FetchIssuerMetadata(u, types.Oid4vci)
 				return err

--- a/wallet/receiver/types/types.go
+++ b/wallet/receiver/types/types.go
@@ -2,6 +2,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -98,6 +99,7 @@ func DPoPNonceFromError(err error) (string, bool) {
 }
 
 type SupportedReceivingTypes int
+type SignatureAlgorithm jose.SignatureAlgorithm
 
 const (
 	Oid4vci SupportedReceivingTypes = iota
@@ -119,7 +121,45 @@ type CredentialConfiguration struct {
 	CryptographicBindingMethodsSupported *[]string                         `json:"cryptographic_binding_methods_supported,omitempty"`
 	Format                               string                            `json:"format"`
 	CredentialDefinition                 *CredentialDefinition             `json:"credential_definition,omitempty"`
-	CredentialSigningAlgValuesSupported  []jose.SignatureAlgorithm         `json:"credential_signing_alg_values_supported,omitempty"`
+	CredentialSigningAlgValuesSupported  []SignatureAlgorithm              `json:"credential_signing_alg_values_supported,omitempty"`
+}
+
+var coseAlgToJWA = map[int64]jose.SignatureAlgorithm{
+	-8:   jose.EdDSA,
+	5:    jose.HS256,
+	6:    jose.HS384,
+	7:    jose.HS512,
+	-257: jose.RS256,
+	-258: jose.RS384,
+	-259: jose.RS512,
+	-7:   jose.ES256,
+	-9:   jose.ES256, // ESP256 (fully-specified ECDSA using P-256 and SHA-256)
+	-35:  jose.ES384,
+	-36:  jose.ES512,
+	-37:  jose.PS256,
+	-38:  jose.PS384,
+	-39:  jose.PS512,
+}
+
+func (c *SignatureAlgorithm) UnmarshalJSON(raw []byte) error {
+	var coseID int64
+	if err := json.Unmarshal(raw, &coseID); err == nil {
+		// COSE algorithm identifier
+		alg, ok := coseAlgToJWA[coseID]
+		if !ok {
+			return fmt.Errorf("unsupported COSE algorithm identifier %d", coseID)
+		}
+		*c = SignatureAlgorithm(alg)
+		return nil
+	}
+
+	// JWA name
+	var alg string
+	if err := json.Unmarshal(raw, &alg); err != nil {
+		return fmt.Errorf("invalid credential_signing_alg_values_supported entry: %w", err)
+	}
+	*c = SignatureAlgorithm(alg)
+	return nil
 }
 
 type CredentialIssuerMetadataDisplay struct {

--- a/wallet/receiver/types/types_test.go
+++ b/wallet/receiver/types/types_test.go
@@ -1,0 +1,100 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+func TestSignatureAlgorithmUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected SignatureAlgorithm
+		wantErr  bool
+	}{
+		{
+			name:     "JWA name",
+			raw:      `"ES256"`,
+			expected: SignatureAlgorithm(jose.ES256),
+		},
+		{
+			name:     "COSE identifier for ES256",
+			raw:      `-7`,
+			expected: SignatureAlgorithm(jose.ES256),
+		},
+		{
+			name:     "COSE identifier for EdDSA",
+			raw:      `-8`,
+			expected: SignatureAlgorithm(jose.EdDSA),
+		},
+		{
+			name:     "COSE identifier for ESP256 (fully-specified ES256)",
+			raw:      `-9`,
+			expected: SignatureAlgorithm(jose.ES256),
+		},
+		{
+			name:     "COSE identifier for PS512",
+			raw:      `-39`,
+			expected: SignatureAlgorithm(jose.PS512),
+		},
+		{
+			name:    "unsupported COSE identifier",
+			raw:     `999`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			raw:     `{}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var alg SignatureAlgorithm
+			err := json.Unmarshal([]byte(tt.raw), &alg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (alg=%v)", alg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if alg != tt.expected {
+				t.Fatalf("got %v, want %v", alg, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCredentialConfigurationUnmarshalJSONMixedAlgValues(t *testing.T) {
+	raw := `{
+		"format": "mso_mdoc",
+		"credential_signing_alg_values_supported": ["ES256", -7, -9, -8, -257]
+	}`
+
+	var cfg CredentialConfiguration
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []SignatureAlgorithm{
+		SignatureAlgorithm(jose.ES256),
+		SignatureAlgorithm(jose.ES256),
+		SignatureAlgorithm(jose.ES256),
+		SignatureAlgorithm(jose.EdDSA),
+		SignatureAlgorithm(jose.RS256),
+	}
+	if len(cfg.CredentialSigningAlgValuesSupported) != len(want) {
+		t.Fatalf("got %v, want %v", cfg.CredentialSigningAlgValuesSupported, want)
+	}
+	for i, alg := range want {
+		if cfg.CredentialSigningAlgValuesSupported[i] != alg {
+			t.Fatalf("index %d: got %v, want %v", i, cfg.CredentialSigningAlgValuesSupported[i], alg)
+		}
+	}
+}


### PR DESCRIPTION
**背景**
#323, #322 のコミットが、 [feat/oid4vci-1.0](https://github.com/trustknots/vcknots/tree/feat/oid4vci-1.0) ブランチへマージされてしまっていた。

**やったこと**
mainから新しいブランチを切り、[feat/oid4vci-1.0](https://github.com/trustknots/vcknots/tree/feat/oid4vci-1.0) へマージされてしまった以下の変更をcherry pickした。
- df1610906d0dfd1c04f3db4b7b6410ae9e4a633c
- 4a32b56c7fd473a1c501f867bcc0df85f1063f80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * パス付きエンドポイントのメタデータ検出を、RFC 8414 に準拠した形式で処理するよう改善しました。
  * 末尾スラッシュ付きのエンドポイントも正しく正規化されます。
* **機能改善**
  * 認証情報発行時の署名アルゴリズムについて、JWA 名と COSE 識別子の両方をJSONから認識できるようになりました。
  * 未対応の識別子や不正な値は適切にエラーとして扱われます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->