### PR TITLE
chore: add slack notification on failure

### DIFF
--- a/.github/workflows/ci-create-tag-and-publish.yaml
+++ b/.github/workflows/ci-create-tag-and-publish.yaml
@@ -6,7 +6,6 @@ on:
       - main
   workflow_dispatch:
 
-
 permissions:
   contents: write
   id-token: write
@@ -63,3 +62,12 @@ jobs:
           git tag
           git show-ref --tags
           git push origin --tags
+
+      - name: Notify Slack on Workflow Failure
+        if: failure()
+        uses: slackapi/slack-github-action@v4.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "🚨 *GitHub Actions エラー発生*\n*リポジトリ:* ${{ github.repository }}\n*ワークフロー:* ${{ github.workflow }}\n*実行ログ:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|ログを確認する>"

--- a/.github/workflows/ci-create-tag-and-publish.yaml
+++ b/.github/workflows/ci-create-tag-and-publish.yaml
@@ -64,9 +64,10 @@ jobs:
           git push origin --tags
 
       - name: Notify Slack on Workflow Failure
-        if: failure()
+        if: ${{ failure() }}
         uses: slackapi/slack-github-action@v4.0.0
         with:
+          errors: true
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * タグのプッシュ後にワークフローが失敗した場合、実行情報へのリンクを含むSlack通知を送信するようになりました。
  * 既存のタグプッシュ処理は引き続き維持されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->