### PR TITLE
fix: serialize verifier transaction dcqlQuery for firestore

### DIFF
--- a/google-cloud/src/providers/firestore-verifier-transaction-store.provider.ts
+++ b/google-cloud/src/providers/firestore-verifier-transaction-store.provider.ts
@@ -34,7 +34,7 @@ export const firestoreVerifierTransactionDataStore = (
       await docRef.set({
         transaction_id: transactionId,
         transaction_data_expires_at: expiresAt,
-        dcqlQuery: record.dcqlQuery,
+        dcqlQuery: JSON.stringify(record.dcqlQuery),
         clientId: record.clientId,
         verifierId: record.verifierId,
         ...(record.state !== undefined ? { state: record.state } : {}),
@@ -52,7 +52,7 @@ export const firestoreVerifierTransactionDataStore = (
       const data = doc.data() as {
         transaction_id: string
         transaction_data_expires_at: Timestamp
-        dcqlQuery: Transaction['dcqlQuery']
+        dcqlQuery: string
         clientId: Transaction['clientId']
         verifierId: Transaction['verifierId']
         state?: string
@@ -67,7 +67,7 @@ export const firestoreVerifierTransactionDataStore = (
       return Transaction({
         transaction_id: transactionId,
         transaction_data_expires_at: data.transaction_data_expires_at.toMillis(),
-        dcqlQuery: data.dcqlQuery,
+        dcqlQuery: JSON.parse(data.dcqlQuery) as Transaction['dcqlQuery'],
         clientId: data.clientId,
         verifierId: data.verifierId,
         state: data.state,

--- a/google-cloud/test/providers/firestore-verifier-transaction-store.provider.spec.ts
+++ b/google-cloud/test/providers/firestore-verifier-transaction-store.provider.spec.ts
@@ -46,6 +46,23 @@ describe('firestoreVerifierTransactionDataStore', () => {
     assert.deepEqual(transaction?.dcqlQuery, transactionRecord.dcqlQuery)
   })
 
+  it('should store dcqlQuery as a string and restore it as Transaction dcqlQuery on fetch', async () => {
+    const provider = firestoreVerifierTransactionDataStore({ app: mockApp })
+    await provider.save(transactionId, transactionRecord)
+
+    const raw = store.get(`vcknots/v1/verifierTransactions/${transactionId}`)
+    if (raw === undefined) {
+      assert.fail('expected saved Firestore document')
+    }
+    assert.notEqual(raw, undefined)
+    assert.equal(typeof raw.dcqlQuery, 'string')
+    assert.equal(raw.dcqlQuery, JSON.stringify(transactionRecord.dcqlQuery))
+
+    const transaction = await provider.fetch(transactionId)
+    assert.notEqual(transaction, null)
+    assert.deepEqual(transaction?.dcqlQuery, transactionRecord.dcqlQuery)
+  })
+
   it('should return null when fetching an unknown transaction', async () => {
     const provider = firestoreVerifierTransactionDataStore({ app: mockApp })
     const transaction = await provider.fetch(TransactionId('unknown-transaction-id'))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **不具合修正**
  - Firestoreに保存した検証トランザクション情報の一部が、読み込み時にも正しい形式で復元されるようになりました。
  - `dcqlQuery`を含むトランザクションデータを保存・取得する際の互換性と安定性が向上しました。

- **品質改善**
  - トランザクション情報の保存および読み込み動作を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->