### PR TITLE
fix(wallet): replace deprecated x509.RevocationList.RevokedCertificates in CRL test

### DIFF
--- a/wallet/common/x509/verification_test.go
+++ b/wallet/common/x509/verification_test.go
@@ -102,12 +102,12 @@ func setupOCSPServer(t *testing.T, tc *testCerts, status int, stale bool) *httpt
 
 func setupCRLServer(t *testing.T, issuer *x509.Certificate, issuerKey *ecdsa.PrivateKey, revoked bool, stale bool, signWithOther bool, includeNonMatching bool) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		revokedEntries := []pkix.RevokedCertificate{}
+		revokedEntries := []x509.RevocationListEntry{}
 		if revoked {
-			revokedEntries = append(revokedEntries, pkix.RevokedCertificate{SerialNumber: big.NewInt(2), RevocationTime: time.Now()})
+			revokedEntries = append(revokedEntries, x509.RevocationListEntry{SerialNumber: big.NewInt(2), RevocationTime: time.Now()})
 		}
 		if includeNonMatching {
-			revokedEntries = append(revokedEntries, pkix.RevokedCertificate{SerialNumber: big.NewInt(9999), RevocationTime: time.Now()})
+			revokedEntries = append(revokedEntries, x509.RevocationListEntry{SerialNumber: big.NewInt(9999), RevocationTime: time.Now()})
 		}
 		nextUpdate := time.Now().Add(30 * time.Minute)
 		if stale {
@@ -119,11 +119,11 @@ func setupCRLServer(t *testing.T, issuer *x509.Certificate, issuerKey *ecdsa.Pri
 			signingKey = k
 		}
 		crlBytes, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
-			Issuer:              issuer.Subject,
-			ThisUpdate:          time.Now().Add(-5 * time.Minute),
-			NextUpdate:          nextUpdate,
-			RevokedCertificates: revokedEntries,
-			Number:              big.NewInt(1),
+			Issuer:                    issuer.Subject,
+			ThisUpdate:                time.Now().Add(-5 * time.Minute),
+			NextUpdate:                nextUpdate,
+			RevokedCertificateEntries: revokedEntries,
+			Number:                    big.NewInt(1),
 		}, issuer, signingKey)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
staticcheck SA1019 flags RevokedCertificates, deprecated since Go 1.21, in the CRL test server. The production code in common/x509/verification.go already reads RevokedCertificateEntries; only the test-side CRL builder was left on the old API.

CreateRevocationList prefers RevokedCertificateEntries when non-empty and copies only SerialNumber and RevocationTime.UTC(), so the generated CRL DER is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 証明書失効リスト（CRL）の生成処理を更新し、失効証明書情報を正しく扱えるよう改善しました。
  * CRL作成時の互換性と信頼性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->