### PR TITLE
fix(wallet): update handling of pre-authorized grant anonymous access

### DIFF
--- a/wallet/internal/testutil/mockserver/oid4vci.go
+++ b/wallet/internal/testutil/mockserver/oid4vci.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"net/url"
+	"slices"
+	"sync"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -12,11 +15,15 @@ import (
 
 // OID4VCIIssuerConfig holds configuration for an OID4VCI issuer mock server
 type OID4VCIIssuerConfig struct {
-	KeyPair                     *KeyPair
-	IssuerID                    string
-	CredentialConfigurations    map[string]interface{}
-	TokenResponse               map[string]interface{}
-	PreAuthorizedGrantAnonymous bool
+	KeyPair                  *KeyPair
+	IssuerID                 string
+	CredentialConfigurations map[string]interface{}
+	TokenResponse            map[string]interface{}
+	// PreAuthorizedGrantAnonymous controls the OPTIONAL authorization server
+	// metadata parameter pre-authorized_grant_anonymous_access_supported. A nil
+	// value omits the parameter from the metadata entirely, which is what real
+	// issuers commonly do and what a plain bool cannot express.
+	PreAuthorizedGrantAnonymous *bool
 	CustomCredentials           map[string]string
 	OmitAuthorizationServers    bool
 	EmptyAuthorizationServers   bool
@@ -56,16 +63,25 @@ func DefaultOID4VCIIssuerConfig() *OID4VCIIssuerConfig {
 			"expires_in":   3600,
 			"c_nonce":      "mock-nonce",
 		},
-		PreAuthorizedGrantAnonymous: true,
+		PreAuthorizedGrantAnonymous: BoolPtr(true),
 		CustomCredentials:           make(map[string]string),
 	}
 }
+
+// BoolPtr returns a pointer to v, for the optional metadata parameters whose
+// absence and explicit false mean different things.
+func BoolPtr(v bool) *bool { return &v }
 
 // OID4VCIIssuerServer is a mock OID4VCI issuer server
 type OID4VCIIssuerServer struct {
 	server     *MockServer
 	config     *OID4VCIIssuerConfig
 	jwtBuilder *JWTBuilder
+
+	// mu guards tokenRequests, which the handler writes from the server's
+	// goroutine while the test reads it from its own.
+	mu            sync.Mutex
+	tokenRequests []url.Values
 }
 
 // NewOID4VCIIssuerServer creates a new OID4VCI issuer mock server
@@ -130,10 +146,13 @@ func (is *OID4VCIIssuerServer) handleAuthServerMetadata(w http.ResponseWriter, r
 	baseURL := "http://" + r.Host
 
 	metadata := map[string]interface{}{
-		"issuer":         baseURL,
-		"token_endpoint": baseURL + "/token",
-		"pre-authorized_grant_anonymous_access_supported": is.config.PreAuthorizedGrantAnonymous,
-		"response_types_supported":                        []string{"code"},
+		"issuer":                   baseURL,
+		"token_endpoint":           baseURL + "/token",
+		"response_types_supported": []string{"code"},
+	}
+
+	if is.config.PreAuthorizedGrantAnonymous != nil {
+		metadata["pre-authorized_grant_anonymous_access_supported"] = *is.config.PreAuthorizedGrantAnonymous
 	}
 
 	if len(is.config.TokenEndpointAuthMethodsSupported) > 0 {
@@ -146,12 +165,29 @@ func (is *OID4VCIIssuerServer) handleAuthServerMetadata(w http.ResponseWriter, r
 	JSONResponse(w, http.StatusOK, metadata)
 }
 
+// TokenRequests returns the form of every token request the server has received,
+// so a test can assert on what the wallet actually sent rather than only on
+// whether the call succeeded.
+func (is *OID4VCIIssuerServer) TokenRequests() []url.Values {
+	is.mu.Lock()
+	defer is.mu.Unlock()
+	return slices.Clone(is.tokenRequests)
+}
+
 // handleToken handles the token endpoint
 func (is *OID4VCIIssuerServer) handleToken(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		ErrorResponse(w, http.StatusMethodNotAllowed, "Only POST method is allowed")
 		return
 	}
+
+	if err := r.ParseForm(); err != nil {
+		ErrorResponse(w, http.StatusBadRequest, "failed to parse token request form")
+		return
+	}
+	is.mu.Lock()
+	is.tokenRequests = append(is.tokenRequests, r.PostForm)
+	is.mu.Unlock()
 
 	if is.config.RequireClientAssertion {
 		if err := is.validateClientAssertion(r); err != nil {

--- a/wallet/receiver/plugins/oid4vci/oid4vci.go
+++ b/wallet/receiver/plugins/oid4vci/oid4vci.go
@@ -192,9 +192,14 @@ func (o *Oid4vciReceiver) FetchAccessToken(
 		if strings.TrimSpace(requestConfig.ClientID) == "" {
 			return nil, fmt.Errorf("client_id is required when a client assertion is sent")
 		}
-		formData.Set("client_id", requestConfig.ClientID)
 		formData.Set("client_assertion", requestConfig.ClientAssertion)
 		formData.Set("client_assertion_type", types.ClientAssertionTypeJWTBearer)
+	}
+	// Sent for both authenticated and unauthenticated requests: client_id is
+	// OPTIONAL for the pre-authorized code grant, so it is included whenever the
+	// caller configured one.
+	if strings.TrimSpace(requestConfig.ClientID) != "" {
+		formData.Set("client_id", requestConfig.ClientID)
 	}
 	endpointURLString := types.ResolveTokenEndpointURL(endpoint)
 	endpointURL, err := url.Parse(endpointURLString)

--- a/wallet/receiver/types/types.go
+++ b/wallet/receiver/types/types.go
@@ -339,6 +339,16 @@ func WithClientAssertion(clientID, assertion string) TokenRequestOption {
 	}
 }
 
+// WithClientID sets the client_id sent with the token request without any
+// client authentication. client_id is OPTIONAL for the pre-authorized code
+// grant, so this identifies the client to an authorization server that expects
+// to know who is asking without requiring the client to authenticate.
+func WithClientID(clientID string) TokenRequestOption {
+	return func(cfg *TokenRequestConfig) {
+		cfg.ClientID = clientID
+	}
+}
+
 // ResolveTokenEndpointURL returns the canonical token endpoint URL string.
 // Metadata token_endpoint values are complete endpoint URLs, so this only
 // normalizes trailing slashes and does not append "/token".

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -752,6 +752,13 @@ func (w *Wallet) generateClientAssertion(key IKeyEntry, clientID, audience strin
 // clientAssertionLifetime is the validity window of a generated client_assertion.
 const clientAssertionLifetime = 5 * time.Minute
 
+// errNoUsableClientAuthMethod reports that neither anonymous access nor the
+// configured client authentication method can be used at the token endpoint.
+var errNoUsableClientAuthMethod = errors.New(
+	"no usable client authentication method for the authorization server token endpoint; " +
+		"the authorization server declares pre-authorized_grant_anonymous_access_supported as false, " +
+		"or it does not support the configured client authentication method")
+
 // resolveClientAuthMethod checks whether the configured client authentication
 // method can be used at the authorization server token endpoint.
 //
@@ -769,9 +776,18 @@ func resolveClientAuthMethod(clientAuth ClientAuthConfig, authMetadata *receiver
 func clientAuthMethodAvailable(method receiverTypes.TokenEndpointAuthMethod, clientAuth ClientAuthConfig, authMetadata *receiverTypes.AuthorizationServerMetadata) bool {
 	switch method {
 	case receiverTypes.None:
-		return authMetadata != nil &&
-			authMetadata.PreAuthorizedGrantAnonymousAccessSupported != nil &&
-			*authMetadata.PreAuthorizedGrantAnonymousAccessSupported
+		// pre-authorized_grant_anonymous_access_supported is an OPTIONAL
+		// authorization server metadata parameter, so an absent value means
+		// "unknown", not "unsupported". Issuers commonly omit it entirely — the
+		// OpenID conformance suite among them — and treating that as a refusal
+		// stops the pre-authorized code flow before a single token request goes
+		// out. Only an explicit false states that the authorization server
+		// rejects the grant without client authentication.
+		if authMetadata == nil {
+			return false
+		}
+		anonymousAccess := authMetadata.PreAuthorizedGrantAnonymousAccessSupported
+		return anonymousAccess == nil || *anonymousAccess
 
 	case receiverTypes.PrivateKeyJwt:
 		if strings.TrimSpace(clientAuth.ClientID) == "" || clientAuth.Key == nil {
@@ -1160,10 +1176,7 @@ func (w *Wallet) fetchCredentialMetadata(req ReceiveCredentialRequest) (*receive
 	}
 
 	if _, ok := resolveClientAuthMethod(w.clientAuth, authMetadata); !ok {
-		return nil, nil, fmt.Errorf(
-			"no usable client authentication method for the authorization server token endpoint; " +
-				"either advertise pre-authorized_grant_anonymous_access_supported or configure a client authentication method",
-		)
+		return nil, nil, errNoUsableClientAuthMethod
 	}
 
 	return issuerMetadata, authMetadata, nil
@@ -1181,15 +1194,13 @@ func (w *Wallet) obtainAccessToken(receivingType receiverTypes.SupportedReceivin
 
 	authMethod, ok := resolveClientAuthMethod(w.clientAuth, authMetadata)
 	if !ok {
-		return nil, fmt.Errorf(
-			"no usable client authentication method for the authorization server token endpoint; " +
-				"either advertise pre-authorized_grant_anonymous_access_supported or configure a client authentication method",
-		)
+		return nil, errNoUsableClientAuthMethod
 	}
 
 	fetchAccessToken := func(dpopNonce *string) (*receiverTypes.CredentialIssuanceAccessToken, error) {
 		var tokenReqOptions []receiverTypes.TokenRequestOption
-		if authMethod == receiverTypes.PrivateKeyJwt {
+		switch authMethod {
+		case receiverTypes.PrivateKeyJwt:
 			assertion, err := w.generateClientAssertion(
 				w.clientAuth.Key,
 				w.clientAuth.ClientID,
@@ -1200,6 +1211,16 @@ func (w *Wallet) obtainAccessToken(receivingType receiverTypes.SupportedReceivin
 				return nil, fmt.Errorf("failed to generate client assertion: %w", err)
 			}
 			tokenReqOptions = append(tokenReqOptions, receiverTypes.WithClientAssertion(w.clientAuth.ClientID, assertion))
+
+		case receiverTypes.None:
+			// client_id is OPTIONAL for the pre-authorized code grant, but an
+			// authorization server that never advertised
+			// pre-authorized_grant_anonymous_access_supported has told us nothing
+			// about whether it serves anonymous clients. Naming the client when
+			// one is configured is what lets such a server accept the request.
+			if strings.TrimSpace(w.clientAuth.ClientID) != "" {
+				tokenReqOptions = append(tokenReqOptions, receiverTypes.WithClientID(w.clientAuth.ClientID))
+			}
 		}
 		if w.dpop.Enabled {
 			proof, err := w.generateDPoPProof(

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1865,7 +1865,7 @@ func TestWallet_obtainAccessToken_PrivateKeyJwtEndToEndWithMockServer(t *testing
 	issuerConfig := &mockserver.OID4VCIIssuerConfig{
 		KeyPair:                           mockserver.MustGenerateKeyPair("issuer-key-id"),
 		IssuerID:                          "test-issuer",
-		PreAuthorizedGrantAnonymous:       false,
+		PreAuthorizedGrantAnonymous:       mockserver.BoolPtr(false),
 		TokenEndpointAuthMethodsSupported: []string{"private_key_jwt"},
 		TokenEndpointAuthSigningAlgs:      []string{"ES256"},
 		RequireClientAssertion:            true,
@@ -1933,7 +1933,7 @@ func TestWallet_fetchCredentialMetadata_UsesCredentialIssuerAsAuthorizationServe
 	issuer := mockserver.NewOID4VCIIssuerServer(&mockserver.OID4VCIIssuerConfig{
 		KeyPair:                           mockserver.MustGenerateKeyPair("issuer-key-id"),
 		IssuerID:                          "test-issuer",
-		PreAuthorizedGrantAnonymous:       false,
+		PreAuthorizedGrantAnonymous:       mockserver.BoolPtr(false),
 		OmitAuthorizationServers:          true,
 		TokenEndpointAuthMethodsSupported: []string{"private_key_jwt"},
 		TokenEndpointAuthSigningAlgs:      []string{"ES256"},
@@ -1985,7 +1985,7 @@ func TestWallet_fetchCredentialMetadata_RejectsEmptyAuthorizationServers(t *test
 
 	issuer := mockserver.NewOID4VCIIssuerServer(&mockserver.OID4VCIIssuerConfig{
 		KeyPair:                     mockserver.MustGenerateKeyPair("issuer-key-id"),
-		PreAuthorizedGrantAnonymous: true,
+		PreAuthorizedGrantAnonymous: mockserver.BoolPtr(true),
 		EmptyAuthorizationServers:   true,
 		CredentialConfigurations: map[string]interface{}{
 			"test-config": map[string]interface{}{
@@ -2025,7 +2025,7 @@ func TestWallet_fetchCredentialMetadata_RejectsWhenNoUsableMethod(t *testing.T) 
 	issuer := mockserver.NewOID4VCIIssuerServer(&mockserver.OID4VCIIssuerConfig{
 		KeyPair:                     mockserver.MustGenerateKeyPair("issuer-key-id"),
 		IssuerID:                    "test-issuer",
-		PreAuthorizedGrantAnonymous: false,
+		PreAuthorizedGrantAnonymous: mockserver.BoolPtr(false),
 		CredentialConfigurations: map[string]interface{}{
 			"test-config": map[string]interface{}{
 				"format": "jwt_vc_json",
@@ -2058,6 +2058,132 @@ func TestWallet_fetchCredentialMetadata_RejectsWhenNoUsableMethod(t *testing.T) 
 	_, _, err = w.fetchCredentialMetadata(req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no usable client authentication method")
+}
+
+// TestWallet_fetchCredentialMetadata_PreAuthorizedGrantAnonymousAccess pins the three
+// states of the OPTIONAL pre-authorized_grant_anonymous_access_supported metadata
+// parameter. Omitting it means "unknown", not "unsupported" — issuers commonly leave it
+// out, the OpenID conformance suite among them — so only an explicit false may stop the
+// pre-authorized code flow.
+func TestWallet_fetchCredentialMetadata_PreAuthorizedGrantAnonymousAccess(t *testing.T) {
+	httpAllowed := env.IsHTTPAllowed()
+	defer env.SetHTTPAllowed(httpAllowed)
+	env.SetHTTPAllowed(true)
+
+	tests := []struct {
+		name            string
+		anonymousAccess *bool
+		wantErr         bool
+	}{
+		{name: "omitted", anonymousAccess: nil, wantErr: false},
+		{name: "explicit true", anonymousAccess: mockserver.BoolPtr(true), wantErr: false},
+		{name: "explicit false", anonymousAccess: mockserver.BoolPtr(false), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer := mockserver.NewOID4VCIIssuerServer(&mockserver.OID4VCIIssuerConfig{
+				KeyPair:                     mockserver.MustGenerateKeyPair("issuer-key-id"),
+				IssuerID:                    "test-issuer",
+				PreAuthorizedGrantAnonymous: tt.anonymousAccess,
+				CredentialConfigurations: map[string]interface{}{
+					"test-config": map[string]interface{}{
+						"format": "jwt_vc_json",
+						"credential_definition": map[string]interface{}{
+							"type": []string{"VerifiableCredential"},
+						},
+					},
+				},
+				CustomCredentials: make(map[string]string),
+			})
+			defer issuer.Close()
+
+			issuerURL, err := url.Parse(issuer.URL())
+			require.NoError(t, err)
+
+			d, err := receiver.NewReceivingDispatcher(receiver.WithDefaultConfig())
+			require.NoError(t, err)
+			w := &Wallet{receiver: d}
+
+			_, authMetadata, err := w.fetchCredentialMetadata(ReceiveCredentialRequest{
+				CredentialOffer: &CredentialOffer{
+					CredentialIssuer:           issuerURL,
+					CredentialConfigurationIDs: []string{"test-config"},
+					Grants:                     map[string]*CredentialOfferGrant{"urn:ietf:params:oauth:grant-type:pre-authorized_code": {}},
+				},
+				Type: receiverTypes.Oid4vci,
+			})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "no usable client authentication method")
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, authMetadata)
+		})
+	}
+}
+
+// TestWallet_obtainAccessToken_OmittedAnonymousAccessSendsClientID checks that an issuer
+// which never advertises pre-authorized_grant_anonymous_access_supported still receives a
+// token request, and that the request names the configured client. The assertion is on
+// what reached the server rather than on the returned token, because the failure this
+// guards against stopped the wallet before any request went out.
+func TestWallet_obtainAccessToken_OmittedAnonymousAccessSendsClientID(t *testing.T) {
+	httpAllowed := env.IsHTTPAllowed()
+	defer env.SetHTTPAllowed(httpAllowed)
+	env.SetHTTPAllowed(true)
+
+	issuer := mockserver.NewOID4VCIIssuerServer(&mockserver.OID4VCIIssuerConfig{
+		KeyPair:                     mockserver.MustGenerateKeyPair("issuer-key-id"),
+		IssuerID:                    "test-issuer",
+		PreAuthorizedGrantAnonymous: nil,
+		CredentialConfigurations: map[string]interface{}{
+			"test-config": map[string]interface{}{
+				"format": "jwt_vc_json",
+				"credential_definition": map[string]interface{}{
+					"type": []string{"VerifiableCredential"},
+				},
+			},
+		},
+		TokenResponse: map[string]interface{}{
+			"access_token": "mock-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		},
+		CustomCredentials: make(map[string]string),
+	})
+	defer issuer.Close()
+
+	issuerURL, err := url.Parse(issuer.URL())
+	require.NoError(t, err)
+
+	d, err := receiver.NewReceivingDispatcher(receiver.WithDefaultConfig())
+	require.NoError(t, err)
+	w := &Wallet{
+		receiver: d,
+		clientAuth: ClientAuthConfig{
+			Method:   receiverTypes.None,
+			ClientID: "wallet-id",
+		},
+	}
+
+	authMetadata, err := d.FetchAuthorizationServerMetadata(common.URIField(*issuerURL), receiverTypes.Oid4vci)
+	require.NoError(t, err)
+	require.Nil(t, authMetadata.PreAuthorizedGrantAnonymousAccessSupported,
+		"the mock must omit the parameter for this test to mean anything")
+
+	token, err := w.obtainAccessToken(receiverTypes.Oid4vci, authMetadata, "pre-auth-code", "")
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "mock-access-token", token.Token)
+
+	tokenRequests := issuer.TokenRequests()
+	require.Len(t, tokenRequests, 1, "the wallet must reach the token endpoint")
+	assert.Equal(t, "urn:ietf:params:oauth:grant-type:pre-authorized_code", tokenRequests[0].Get("grant_type"))
+	assert.Equal(t, "wallet-id", tokenRequests[0].Get("client_id"))
+	assert.Empty(t, tokenRequests[0].Get("client_assertion"), "no client authentication is configured")
 }
 
 func TestController_generateJWTProof_NonAnonymousFlow_EmptyClientIDReturnsError(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * クライアント認証なしのトークン取得時も、設定されたクライアントIDを送信できるようになりました。
  * トークンリクエストにクライアントIDのみを指定するオプションを追加しました。
  * トークンリクエストの内容を確認できるようになりました。

* **バグ修正**
  * 認証方式が利用できない場合のエラー処理を改善しました。
  * 認可サーバーのメタデータが省略されている場合でも、適切に匿名アクセスを判定できるようになりました。
  * 不正なトークンリクエストに対して、正しいエラー応答を返すようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->