### PR TITLE
fix(tests): ensure allowedAlgs are passed correctly to credential verifier

### DIFF
--- a/issuer+verifier/test/providers/verify-presentation-jwt-vp-json.provider.spec.ts
+++ b/issuer+verifier/test/providers/verify-presentation-jwt-vp-json.provider.spec.ts
@@ -481,12 +481,19 @@ describe('verifyVerifiablePresentation provider', () => {
   test('should pass allowedAlgs to credential verifier', async () => {
     const vpJwt = await createVpJwt({
       nonce: 'test-nonce',
-      vp: { type: ['VerifiablePresentation'], verifiableCredential: [vcJwt] },
+      vp: { type: ['VerifiablePresentation'], verifiableCredential: [vcJwt, vcJwt] },
     })
     await provider.verify(vpJwt, { kind: 'jwt_vp_json', expectedAud, allowedAlgs: ['ES256'] })
-    assert.deepEqual(mockCredentialVerifier.verify.mock.calls[0].arguments[1], {
-      allowedAlgs: ['ES256'],
-    })
+  const verifyCalls = mockCredentialVerifier.verify.mock.calls
+
+  assert.equal(verifyCalls.length, 2)
+  assert.deepEqual(
+    verifyCalls.map((call) => call.arguments[1]),
+    [
+      { allowedAlgs: ['ES256'] },
+      { allowedAlgs: ['ES256'] },
+    ]
+  )
   })
 
   test('should throw VERIFIER_VP_FORMATS_NOT_SUPPORTED when VP alg is not in allowedAlgs', async () => {

--- a/issuer+verifier/test/providers/verify-presentation-jwt-vp-json.provider.spec.ts
+++ b/issuer+verifier/test/providers/verify-presentation-jwt-vp-json.provider.spec.ts
@@ -484,16 +484,13 @@ describe('verifyVerifiablePresentation provider', () => {
       vp: { type: ['VerifiablePresentation'], verifiableCredential: [vcJwt, vcJwt] },
     })
     await provider.verify(vpJwt, { kind: 'jwt_vp_json', expectedAud, allowedAlgs: ['ES256'] })
-  const verifyCalls = mockCredentialVerifier.verify.mock.calls
+    const verifyCalls = mockCredentialVerifier.verify.mock.calls
 
-  assert.equal(verifyCalls.length, 2)
-  assert.deepEqual(
-    verifyCalls.map((call) => call.arguments[1]),
-    [
-      { allowedAlgs: ['ES256'] },
-      { allowedAlgs: ['ES256'] },
-    ]
-  )
+    assert.equal(verifyCalls.length, 2)
+    assert.deepEqual(
+      verifyCalls.map((call) => call.arguments[1]),
+      [{ allowedAlgs: ['ES256'] }, { allowedAlgs: ['ES256'] }]
+    )
   })
 
   test('should throw VERIFIER_VP_FORMATS_NOT_SUPPORTED when VP alg is not in allowedAlgs', async () => {


### PR DESCRIPTION
## 概要
前回(#359)の際に、複数VCのAllowedAlgsテストを修正するようにCoderabbitに指摘されました。この修正は今回のスコープに収まっていると感じたため、以下の修正を追加させていただきます。
JWT VP JSONの検証に複数のVCが含まれる場合、すべてのVCに対して `allowedAlgs` が渡されることを確認する回帰テストを追加しました。

## 変更内容

既存の `should pass allowedAlgs to credential verifier` テストを、VCが1件の場合だけでなく、複数件の場合も検証できるように変更しました。

このテストでは、以下を確認しています。

* Credential VerifierがVCの件数分呼び出されること
* 1件目のVC検証に `{ allowedAlgs: ['ES256'] }` が渡されること
* 2件目のVC検証にも `{ allowedAlgs: ['ES256'] }` が渡されること

## 背景

先行するPRで、JWT VP JSON内のすべてのVCを検証するよう処理を変更しました。

本PRは、そのループ内で各VCの検証に `allowedAlgs` が正しく伝播することを、単体テストで明示的に保証するものです。実装の動作は変更せず、テストのみを強化しています。

## テスト

以下のコマンドを実行し、対象の単体テストがすべて通過することを確認しました。

```bash
pnpm --filter @trustknots/vcknots exec \
  node --import tsx --test \
  test/providers/verify-presentation-jwt-vp-json.provider.spec.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 複数のクレデンシャルを含むVP JWTの検証テストを強化しました。
  * すべてのクレデンシャル検証で、許可されたアルゴリズム（ES256）が正しく適用されることを確認します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->