### PR TITLE
fix(verifier): remove authorize path from OID4VP request URI

### DIFF
--- a/docs/en/verifier.md
+++ b/docs/en/verifier.md
@@ -59,7 +59,7 @@ Introduction:
 
 ### 1. Creating an Authorization Request
 
-The Verifier generates an authorization request (openid4vp://authorize?...) to ask the Wallet to present credentials.
+The Verifier generates an authorization request (openid4vp:?...) to ask the Wallet to present credentials.
 
 #### 1-1. Basic Authorization Request
 
@@ -71,7 +71,7 @@ This endpoint uses an authorization request format compliant with OAuth 2.0.
   - `state` (string, required): Identifier that links the authorization request to the response. Must be a random, hard-to-predict value.
   - `client_id` (string, optional): Specifies the Verifier's client_id in `prefix:value` format. Defaults to `redirect_uri:localhost` if omitted.
 - **Response**
-  - `200 OK`: Returns an authorization request URL in the `openid4vp://authorize?...` format as text.
+  - `200 OK`: Returns an authorization request URL in the `openid4vp:?...` format as text.
   - `400 Bad Request`: For example, when `credentialId` or `state` is not specified.
 
 - **Actual code**
@@ -142,7 +142,7 @@ verifyApp.post('/request', async (c) => {
         return `${encodeURIComponent(key)}=${encodeURIComponent(encode)}`
       })
       .join('&')
-      return c.text(`openid4vp://authorize?${encoded}`)
+      return c.text(`openid4vp:?${encoded}`)
   } catch (err) {
     const errorResponse = handleError(err)
     const status = errorResponse.error === 'internal_server_error' ? 500 : 400
@@ -167,7 +167,7 @@ curl --location 'http://localhost:8080/request' \
 **Response**
 
 ```
-openid4vp://authorize?response_type=vp_token&client_id=redirect_uri%3Alocalhost&state=example-state&client_metadata=...&nonce=cf0736e6f68d4bf094b38850169e8c04&response_mode=direct_post&response_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback&dcql_query=%7B%22credentials%22%3A%5B%7B%22id%22%3A%220d67e47b-a5f0-48ae-b880-60b94c61fbfd%22%2C%22require_cryptographic_holder_binding%22%3Atrue%2C%22multiple%22%3Afalse%2C%22format%22%3A%22jwt_vc_json%22%2C%22meta%22%3A%7B%22type_values%22%3A%5B%5B%22UniversityDegreeCredential%22%5D%5D%7D%7D%5D%7D
+openid4vp:?response_type=vp_token&client_id=redirect_uri%3Alocalhost&state=example-state&client_metadata=...&nonce=cf0736e6f68d4bf094b38850169e8c04&response_mode=direct_post&response_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback&dcql_query=%7B%22credentials%22%3A%5B%7B%22id%22%3A%220d67e47b-a5f0-48ae-b880-60b94c61fbfd%22%2C%22require_cryptographic_holder_binding%22%3Atrue%2C%22multiple%22%3Afalse%2C%22format%22%3A%22jwt_vc_json%22%2C%22meta%22%3A%7B%22type_values%22%3A%5B%5B%22UniversityDegreeCredential%22%5D%5D%7D%7D%5D%7D
 ```
 
 
@@ -184,7 +184,7 @@ This endpoint uses a JWT Authorization Request (JAR) to generate and store a Req
   - `is_transaction_data` (boolean, optional): If `true`, attaches transaction_data (default: `false`).
   - `response_uri` (string, optional): Callback URI for the Wallet to send the response. Defaults to `${baseUrl}/callback` if omitted.
 - **Response**
-  - `200 OK`: Returns an authorization request URL in the `openid4vp://authorize?...` format as text (including `request_uri` information).
+  - `200 OK`: Returns an authorization request URL in the `openid4vp:?...` format as text (including `request_uri` information).
   - `400 Bad Request`: When the JSON is invalid or when there is an issue with the request content.
 
 - Actual code
@@ -274,7 +274,7 @@ verifyApp.post('/request-object', async (c) => {
       })
       .join('&')
 
-    return c.text(`openid4vp://authorize?${encoded}`)
+    return c.text(`openid4vp:?${encoded}`)
   } catch (err) {
     if (reserved?.ok) {
       vpAudTx.consume(requestObject.state)
@@ -321,7 +321,7 @@ curl --location 'http://localhost:8080/request-object' \
 
 **Response**
 ```
-openid4vp://authorize?client_id=x509_san_dns%3Alocalhost&request_uri=http%3A%2F%2Flocalhost%3A8080%2Frequest.jwt%2F98feadd6e5d94254b91b132f4de0782e
+openid4vp:?client_id=x509_san_dns%3Alocalhost&request_uri=http%3A%2F%2Flocalhost%3A8080%2Frequest.jwt%2F98feadd6e5d94254b91b132f4de0782e
 ```
 
 

--- a/docs/en/wallet.md
+++ b/docs/en/wallet.md
@@ -330,7 +330,7 @@ Notes on `ReceiveCredentialRequest`:
 
 ### 3-3. Presenting a Credential (OpenID4VP)
 
-After receiving a request URI in the form `openid4vp://authorize?...` from the verifier (typically by scanning a QR code; with the local sample server, via `POST /request` or `POST /request-object`), call `PresentCredential`:
+After receiving a request URI in the form `openid4vp:?...` from the verifier (typically by scanning a QR code; with the local sample server, via `POST /request` or `POST /request-object`), call `PresentCredential`:
 
 ```go
 import (
@@ -506,7 +506,7 @@ func (w *Wallet) PresentCredential(uriString string, key IKeyEntry, options seri
 ```
 
 **Parameters**:
-- `uriString`: The OID4VP request URI (`openid4vp://authorize?...`)
+- `uriString`: The OID4VP request URI (`openid4vp:?...`)
 - `key`: The key used to sign the presentation ([IKeyEntry](#IKeyEntry))
 - `options`: Format-specific presentation options (for SD-JWT VC, [SdJwtVcPresentationOptions](#SdJwtVcPresentationOptions)); pass `nil` to use the defaults for the credential's format
 
@@ -522,7 +522,7 @@ func (w *Wallet) PresentCredentialWithOptions(uriString string, key IKeyEntry, o
 ```
 
 **Parameters**:
-- `uriString`: The OID4VP request URI (`openid4vp://authorize?...`)
+- `uriString`: The OID4VP request URI (`openid4vp:?...`)
 - `key`: The key used to sign the presentation ([IKeyEntry](#IKeyEntry))
 - `options`: Serialization options and redirect callback ([PresentCredentialOptions](#PresentCredentialOptions))
 

--- a/docs/en/wallet.md
+++ b/docs/en/wallet.md
@@ -9,7 +9,7 @@ This tutorial explains how to set up the VCKnots wallet library (a Go library), 
 The wallet implements the OpenID for Verifiable Credentials specifications:
 
 * **Receiving credentials (OID4VCI):** the wallet obtains a credential from an issuer using a credential offer and the pre-authorized code flow.
-* **Presenting credentials (OID4VP):** the wallet responds to an `openid4vp://` authorization request and submits a Verifiable Presentation to a verifier.
+* **Presenting credentials (OID4VP):** the wallet responds to an `openid4vp:` authorization request and submits a Verifiable Presentation to a verifier.
 
 Both **JWT-VC** (`application/vc+jwt`) and **SD-JWT VC** (`application/dc+sd-jwt`) are supported for receiving and presenting, including selective disclosure and Key Binding JWT for SD-JWT VC.
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/verifier.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/verifier.md
@@ -59,7 +59,7 @@ const verifierFlow = initializeVerifierFlow(context);
 
 ### 1. Authorizationリクエストの作成
 
-Verifier が Wallet に提示を依頼するための認可リクエスト（openid4vp://authorize?...）を生成します。
+Verifier が Wallet に提示を依頼するための認可リクエスト（openid4vp:?...）を生成します。
 
 #### 1-1. 基本的な認可リクエスト
 
@@ -71,7 +71,7 @@ Verifier が Wallet に提示を依頼するための認可リクエスト（ope
   - `state` (string, 必須): 認可リクエストとレスポンスを紐づける識別子。予測困難なランダム値を指定すること。
   - `client_id` (string, 任意): Verifier の client_id を prefix:value 形式で指定。省略時は redirect_uri:localhost が使用されます。
 - **レスポンス**
-  - `200 OK`: テキストで `openid4vp://authorize?...` 形式の認可リクエスト URL を返却。
+  - `200 OK`: テキストで `openid4vp:?...` 形式の認可リクエスト URL を返却。
   - `400 Bad Request`: `credentialId` 、 `state`未指定時など。
 
 - **実際のコード**
@@ -142,7 +142,7 @@ verifyApp.post('/request', async (c) => {
         return `${encodeURIComponent(key)}=${encodeURIComponent(encode)}`
       })
       .join('&')
-      return c.text(`openid4vp://authorize?${encoded}`)
+      return c.text(`openid4vp:?${encoded}`)
   } catch (err) {
     const errorResponse = handleError(err)
     const status = errorResponse.error === 'internal_server_error' ? 500 : 400
@@ -167,7 +167,7 @@ curl --location 'http://localhost:8080/request' \
 **レスポンス**
 
 ```
-openid4vp://authorize?response_type=vp_token&client_id=redirect_uri%3Alocalhost&state=example-state&client_metadata=...&nonce=cf0736e6f68d4bf094b38850169e8c04&response_mode=direct_post&response_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback&dcql_query=%7B%22credentials%22%3A%5B%7B%22id%22%3A%220d67e47b-a5f0-48ae-b880-60b94c61fbfd%22%2C%22require_cryptographic_holder_binding%22%3Atrue%2C%22multiple%22%3Afalse%2C%22format%22%3A%22jwt_vc_json%22%2C%22meta%22%3A%7B%22type_values%22%3A%5B%5B%22UniversityDegreeCredential%22%5D%5D%7D%7D%5D%7D
+openid4vp:?response_type=vp_token&client_id=redirect_uri%3Alocalhost&state=example-state&client_metadata=...&nonce=cf0736e6f68d4bf094b38850169e8c04&response_mode=direct_post&response_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback&dcql_query=%7B%22credentials%22%3A%5B%7B%22id%22%3A%220d67e47b-a5f0-48ae-b880-60b94c61fbfd%22%2C%22require_cryptographic_holder_binding%22%3Atrue%2C%22multiple%22%3Afalse%2C%22format%22%3A%22jwt_vc_json%22%2C%22meta%22%3A%7B%22type_values%22%3A%5B%5B%22UniversityDegreeCredential%22%5D%5D%7D%7D%5D%7D
 ```
 
 
@@ -184,7 +184,7 @@ openid4vp://authorize?response_type=vp_token&client_id=redirect_uri%3Alocalhost&
   - `is_transaction_data` (boolean, 任意): `true` の場合 transaction_data を付与（デフォルト: `false`）。
   - `response_uri` (string, 任意): Wallet がレスポンスを送信するコールバック URI。省略時は `${baseUrl}/callback`。
 - **レスポンス**
-  - `200 OK`: テキストで `openid4vp://authorize?...` 形式の認可リクエスト URL を返却（`request_uri` 情報を含みます）。
+  - `200 OK`: テキストで `openid4vp:?...` 形式の認可リクエスト URL を返却（`request_uri` 情報を含みます）。
   - `400 Bad Request`: JSON が不正な場合など、リクエスト内容に問題があるとき。
 
 - 実際のコード
@@ -273,7 +273,7 @@ verifyApp.post('/request-object', async (c) => {
         return `${encodeURIComponent(key)}=${encodeURIComponent(encode)}`
       })
       .join('&')
-    return c.text(`openid4vp://authorize?${encoded}`)
+    return c.text(`openid4vp:?${encoded}`)
   } catch (err) {
     if (reserved?.ok) {
       vpAudTx.consume(requestObject.state)
@@ -319,7 +319,7 @@ curl --location 'http://localhost:8080/request-object' \
 
 **レスポンス**
 ```
-openid4vp://authorize?client_id=x509_san_dns%3Alocalhost&request_uri=http%3A%2F%2Flocalhost%3A8080%2Frequest.jwt%2F98feadd6e5d94254b91b132f4de0782e
+openid4vp:?client_id=x509_san_dns%3Alocalhost&request_uri=http%3A%2F%2Flocalhost%3A8080%2Frequest.jwt%2F98feadd6e5d94254b91b132f4de0782e
 ```
 
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/wallet.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/wallet.md
@@ -9,7 +9,7 @@ sidebar_position: 13
 wallet は OpenID for Verifiable Credentials の各仕様を実装しています。
 
 * **Credential の受領（OID4VCI）:** Credential Offer と pre-authorized code フローを使って、Issuer から Credential を受け取ります。
-* **Credential の提示（OID4VP）:** `openid4vp://` 形式の Authorization Request に応答し、Verifiable Presentation を Verifier に送信します。
+* **Credential の提示（OID4VP）:** `openid4vp:` 形式の Authorization Request に応答し、Verifiable Presentation を Verifier に送信します。
 
 受領と提示のどちらも **JWT-VC**（`application/vc+jwt`）と **SD-JWT VC**（`application/dc+sd-jwt`）に対応しています。
 SD-JWT VC では選択的開示と Key Binding JWT も利用できます。

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/wallet.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/wallet.md
@@ -346,7 +346,7 @@ func receiveSDJwtCredential(w *wallet.Wallet, key wallet.IKeyEntry, offerURI str
 
 ### 3-3. Credentialの提示 (OpenID4VP)
 
-Verifier から `openid4vp://authorize?...` 形式のリクエスト URI を受け取ったら（通常は QR コードのスキャンで取得します。ローカルのサンプルサーバーでは `POST /request` または `POST /request-object` で作成できます）、`PresentCredential` を呼び出します。
+Verifier から `openid4vp:?...` 形式のリクエスト URI を受け取ったら（通常は QR コードのスキャンで取得します。ローカルのサンプルサーバーでは `POST /request` または `POST /request-object` で作成できます）、`PresentCredential` を呼び出します。
 
 ```go
 import (
@@ -530,7 +530,7 @@ func (w *Wallet) PresentCredential(uriString string, key IKeyEntry, options seri
 ```
 
 **パラメータ**:
-- `uriString`: OID4VP リクエスト URI（`openid4vp://authorize?...`）
+- `uriString`: OID4VP リクエスト URI（`openid4vp:?...`）
 - `key`: Presentation の署名に使用する鍵（[IKeyEntry](#IKeyEntry)）
 - `options`: フォーマット固有の提示オプション（SD-JWT VC では [SdJwtVcPresentationOptions](#SdJwtVcPresentationOptions)）。`nil` を渡すと、その Credential のフォーマットのデフォルトが使われます
 
@@ -546,7 +546,7 @@ func (w *Wallet) PresentCredentialWithOptions(uriString string, key IKeyEntry, o
 ```
 
 **パラメータ**:
-- `uriString`: OID4VP リクエスト URI（`openid4vp://authorize?...`）
+- `uriString`: OID4VP リクエスト URI（`openid4vp:?...`）
 - `key`: Presentation の署名に使用する鍵（[IKeyEntry](#IKeyEntry)）
 - `options`: シリアライズオプションとリダイレクトコールバック（[PresentCredentialOptions](#PresentCredentialOptions)）
 

--- a/issuer+verifier/README.ja.md
+++ b/issuer+verifier/README.ja.md
@@ -283,7 +283,7 @@ const encoded = Object.entries(request)
   })
   .join('&')
 
-const scheme = `openid4vp://authorize?${encoded}`
+const scheme = `openid4vp:?${encoded}`
 
 console.log('Authorization Request', scheme)
 ```

--- a/issuer+verifier/README.md
+++ b/issuer+verifier/README.md
@@ -283,7 +283,7 @@ const encoded = Object.entries(request)
   })
   .join('&')
 
-const scheme = `openid4vp://authorize?${encoded}`
+const scheme = `openid4vp:?${encoded}`
 
 console.log('Authorization Request', scheme)
 ```

--- a/server/core/src/routes/verify.ts
+++ b/server/core/src/routes/verify.ts
@@ -146,7 +146,7 @@ export const createVerifierRouter = (context: VcknotsContext, baseUrl: string) =
         })
         .join('&')
 
-      return c.text(`openid4vp://authorize?${encoded}`)
+      return c.text(`openid4vp:?${encoded}`)
     } catch (err) {
       const errorResponse = handleError(err)
       const status = errorResponse.error === 'internal_server_error' ? 500 : 400
@@ -361,7 +361,7 @@ export const createVerifierRouter = (context: VcknotsContext, baseUrl: string) =
         })
         .join('&')
 
-      return c.text(`openid4vp://authorize?${encoded}`)
+      return c.text(`openid4vp:?${encoded}`)
     } catch (err) {
       if (reserved?.ok) {
         vpAudTx.consume(requestObject.state)

--- a/server/multi/src/routes/verify.ts
+++ b/server/multi/src/routes/verify.ts
@@ -100,7 +100,7 @@ export const createVerifierRouter = (context: VcknotsContext, baseUrl: string) =
         })
         .join('&')
 
-      return c.text(`openid4vp://authorize?${encoded}`)
+      return c.text(`openid4vp:?${encoded}`)
     } catch (err) {
       return c.json(handleError(err), 400)
     }
@@ -223,7 +223,7 @@ export const createVerifierRouter = (context: VcknotsContext, baseUrl: string) =
         })
         .join('&')
 
-      return c.text(`openid4vp://authorize?${encoded}`)
+      return c.text(`openid4vp:?${encoded}`)
     } catch (err) {
       return c.json(handleError(err), 400)
     }

--- a/server/single/README.ja.md
+++ b/server/single/README.ja.md
@@ -501,7 +501,7 @@ Authorization Server メタデータの取得
 - `redirect_uri:{uri}` - リダイレクトURIベースの識別子
 
 **レスポンス:**
-- `200 OK` - `openid4vp://authorize?{encoded_params}` 形式のテキスト
+- `200 OK` - `openid4vp:?{encoded_params}` 形式のテキスト
 - `400 Bad Request` - リクエストが無効な場合（例: `credentialId` 未指定）
 
 <a id="post-request-object"></a>
@@ -528,7 +528,7 @@ Request Object を JAR 形式で作成します。
 - デフォルト: `"x509_san_dns:localhost"`
 
 **レスポンス:**
-- `200 OK` - `openid4vp://authorize?{encoded_params}` 形式のテキスト
+- `200 OK` - `openid4vp:?{encoded_params}` 形式のテキスト
 - `400 Bad Request` - リクエストが無効な場合
 
 <a id="post-callback"></a>

--- a/server/single/README.ja.md
+++ b/server/single/README.ja.md
@@ -486,7 +486,7 @@ Authorization Server メタデータの取得
 <a id="post-request"></a>
 #### `POST /request`
 
-認証リクエストの作成。DCQL クエリを含む認可リクエストを生成し、`openid4vp://` スキームのURIを返します。
+認証リクエストの作成。DCQL クエリを含む認可リクエストを生成し、`openid4vp:?{encoded_params}` 形式のテキストを返します。
 
 **リクエストボディ (JSON):**
 ```json

--- a/server/single/README.md
+++ b/server/single/README.md
@@ -487,7 +487,7 @@ The following illustrates typical fields on the single server. During initializa
 <a id="post-request"></a>
 #### `POST /request`
 
-Create authorization request. Generates an authorization request using a DCQL query and returns a URI with the `openid4vp://` scheme.
+Create authorization request. Generates an authorization request using a DCQL query and returns text in the `openid4vp:?{encoded_params}` format.
 
 **Request Body (JSON):**
 ```json

--- a/server/single/README.md
+++ b/server/single/README.md
@@ -502,7 +502,7 @@ Create authorization request. Generates an authorization request using a DCQL qu
 - `redirect_uri:{uri}` - Redirect URI-based identifier
 
 **Response:**
-- `200 OK` - Text in the format `openid4vp://authorize?{encoded_params}`
+- `200 OK` - Text in the format `openid4vp:?{encoded_params}`
 - `400 Bad Request` - Invalid request (e.g., `credentialId` not specified)
 
 <a id="post-request-object"></a>
@@ -529,7 +529,7 @@ Create Request Object in JAR format.
 - Default: `"x509_san_dns:localhost"`
 
 **Response:**
-- `200 OK` - Text in the format `openid4vp://authorize?{encoded_params}`
+- `200 OK` - Text in the format `openid4vp:?{encoded_params}`
 - `400 Bad Request` - Invalid request
 
 <a id="post-callback"></a>

--- a/wallet/examples/README.ja.md
+++ b/wallet/examples/README.ja.md
@@ -240,7 +240,7 @@ time=2025-11-27T14:03:25.152+09:00 level=INFO msg="Decoding received credential 
 time=2025-11-27T14:03:25.152+09:00 level=INFO msg="Decoded credential" credential="map[iss:http://localhost:8080 sub:did:key:zDnaeYiwHNeMYaj21Wo9jPCowtnBrY8he8UCK8ZZN1mhhx8PM vc:map[@context:[https://www.w3.org/2018/credentials/v1] credentialSubject:map[degree:5 family_name:taro given_name:test gpa:test id:did:key:zDnaeYiwHNeMYaj21Wo9jPCowtnBrY8he8UCK8ZZN1mhhx8PM] id:http://localhost:8080/vc/7ea9225bc1d34fe19bdbf09e868db4f1 issuanceDate:2025-11-27T05:03:25.142Z issuer:http://localhost:8080 type:[VerifiableCredential UniversityDegreeCredential]]]"
 time=2025-11-27T14:03:25.152+09:00 level=INFO msg="Credential analysis" types="[VerifiableCredential UniversityDegreeCredential]" subject_fields="[gpa id given_name family_name degree]"
 time=2025-11-27T14:03:25.152+09:00 level=INFO msg="Generated presentation definition" json="{\n\t\t\"query\": {\n\t\t\t\"presentation_definition\": {\n\t\t\t\"id\": \"dynamic-presentation-UniversityDegreeCredential\",\n\t\t\t\"input_descriptors\": [\n\t\t\t{\n\t\t\t\t\"id\": \"credential-request\",\n\t\t\t\t\"name\": \"UniversityDegreeCredential\",\n\t\t\t\t\"purpose\": \"Verify credential\",\n\t\t\t\t\"format\": {\n\t\t\t\t\"jwt_vc_json\": {\n\t\t\t\t\t\"alg\": [\"ES256\"]\n\t\t\t\t}\n\t\t\t\t},\n\t\t\t\t\"constraints\": {\n\t\t\t\t\"fields\": [\n\t\t{\n\t\t\t\"path\": [\"$.type\"],\n\t\t\t\"filter\": {\n\t\t\t\t\"type\": \"array\",\n\t\t\t\t\"contains\": {\"const\": \"UniversityDegreeCredential\"}\n\t\t\t}\n\t\t},\n\t\t{\n\t\t\t\"path\": [\"$.credentialSubject.gpa\"],\n\t\t\t\"intent_to_retain\": false\n\t\t},\n\t\t{\n\t\t\t\"path\": [\"$.credentialSubject.given_name\"],\n\t\t\t\"intent_to_retain\": false\n\t\t},\n\t\t{\n\t\t\t\"path\": [\"$.credentialSubject.family_name\"],\n\t\t\t\"intent_to_retain\": false\n\t\t},\n\t\t{\n\t\t\t\"path\": [\"$.credentialSubject.degree\"],\n\t\t\t\"intent_to_retain\": false\n\t\t}\n\t]\n\t\t\t\t}\n\t\t\t}\n\t\t\t]\n\t\t}\n\t\t},\n\t\t\"state\": \"example-state\",\n\t\t\"base_url\": \"http://localhost:8080\",\n\t\t\"is_request_uri\": true,\n\t\t\"response_uri\": \"http://localhost:8080/callback\",\n\t\t\"client_id\": \"x509_san_dns:localhost\"\n\t}"
-time=2025-11-27T14:03:25.155+09:00 level=INFO msg="Authorization RequestURI" status="200 OK" body="openid4vp://authorize?client_id=x509_san_dns%3Alocalhost&request_uri=http%3A%2F%2Flocalhost%3A8080%2Frequest.jwt%2F9855a937fda74c3f8de9d7f92537206e"
+time=2025-11-27T14:03:25.155+09:00 level=INFO msg="Authorization RequestURI" status="200 OK" body="openid4vp:?client_id=x509_san_dns%3Alocalhost&request_uri=http%3A%2F%2Flocalhost%3A8080%2Frequest.jwt%2F9855a937fda74c3f8de9d7f92537206e"
 time=2025-11-27T14:03:25.155+09:00 level=INFO msg="Request URI is valid" scheme=openid4vp
 time=2025-11-27T14:03:25.174+09:00 level=INFO msg="Credential presented successfully"
 ```
@@ -260,7 +260,7 @@ time=2025-11-27T14:03:25.174+09:00 level=INFO msg="Credential presented successf
 
 ```bash
 cd /path/to/vcknots/wallet/examples/server_integration_sdjwt
-go run server_integration_sdjwt.go "openid4vp://authorize?client_id=...&request_uri=..."
+go run server_integration_sdjwt.go "openid4vp:?client_id=...&request_uri=..."
 ```
 
 **重要**: OpenID4VP URIを引数に指定すると、自動的にコンフォーマンステストモードで動作します。
@@ -302,7 +302,7 @@ go run server_integration_sdjwt.go --credential-offer-uri "$OFFER_URI" --tx-code
 **モード2: コンフォーマンステストモード（OpenID4VP URI引数あり）**
 ```bash
 cd /path/to/vcknots/wallet/examples/server_integration_sdjwt
-go run server_integration_sdjwt.go "openid4vp://authorize?..."
+go run server_integration_sdjwt.go "openid4vp:?..."
 ```
 - 外部のOpenID4VPコンフォーマンステストサービスに対してテスト
 - システムルート証明書プールを使用

--- a/wallet/examples/README.md
+++ b/wallet/examples/README.md
@@ -240,7 +240,7 @@ time=2025-11-27T14:03:25.152+09:00 level=INFO msg="Decoding received credential 
 time=2025-11-27T14:03:25.152+09:00 level=INFO msg="Decoded credential" credential="map[iss:http://localhost:8080 sub:did:key:zDnaeYiwHNeMYaj21Wo9jPCowtnBrY8he8UCK8ZZN1mhhx8PM vc:map[@context:[https://www.w3.org/2018/credentials/v1] credentialSubject:map[degree:5 family_name:taro given_name:test gpa:test id:did:key:zDnaeYiwHNeMYaj21Wo9jPCowtnBrY8he8UCK8ZZN1mhhx8PM] id:http://localhost:8080/vc/7ea9225bc1d34fe19bdbf09e868db4f1 issuanceDate:2025-11-27T05:03:25.142Z issuer:http://localhost:8080 type:[VerifiableCredential UniversityDegreeCredential]]]"
 time=2025-11-27T14:03:25.152+09:00 level=INFO msg="Credential analysis" types="[VerifiableCredential UniversityDegreeCredential]" subject_fields="[gpa id given_name family_name degree]"
 time=2025-11-27T14:03:25.152+09:00 level=INFO msg="Generated presentation definition" json="{\n\t\t\"query\": {\n\t\t\t\"presentation_definition\": {\n\t\t\t\"id\": \"dynamic-presentation-UniversityDegreeCredential\",\n\t\t\t\"input_descriptors\": [\n\t\t\t{\n\t\t\t\t\"id\": \"credential-request\",\n\t\t\t\t\"name\": \"UniversityDegreeCredential\",\n\t\t\t\t\"purpose\": \"Verify credential\",\n\t\t\t\t\"format\": {\n\t\t\t\t\"jwt_vc_json\": {\n\t\t\t\t\t\"alg\": [\"ES256\"]\n\t\t\t\t}\n\t\t\t\t},\n\t\t\t\t\"constraints\": {\n\t\t\t\t\"fields\": [\n\t\t{\n\t\t\t\"path\": [\"$.type\"],\n\t\t\t\"filter\": {\n\t\t\t\t\"type\": \"array\",\n\t\t\t\t\"contains\": {\"const\": \"UniversityDegreeCredential\"}\n\t\t\t}\n\t\t},\n\t\t{\n\t\t\t\"path\": [\"$.credentialSubject.gpa\"],\n\t\t\t\"intent_to_retain\": false\n\t\t},\n\t\t{\n\t\t\t\"path\": [\"$.credentialSubject.given_name\"],\n\t\t\t\"intent_to_retain\": false\n\t\t},\n\t\t{\n\t\t\t\"path\": [\"$.credentialSubject.family_name\"],\n\t\t\t\"intent_to_retain\": false\n\t\t},\n\t\t{\n\t\t\t\"path\": [\"$.credentialSubject.degree\"],\n\t\t\t\"intent_to_retain\": false\n\t\t}\n\t]\n\t\t\t\t}\n\t\t\t}\n\t\t\t]\n\t\t}\n\t\t},\n\t\t\"state\": \"example-state\",\n\t\t\"base_url\": \"http://localhost:8080\",\n\t\t\"is_request_uri\": true,\n\t\t\"response_uri\": \"http://localhost:8080/callback\",\n\t\t\"client_id\": \"x509_san_dns:localhost\"\n\t}"
-time=2025-11-27T14:03:25.155+09:00 level=INFO msg="Authorization RequestURI" status="200 OK" body="openid4vp://authorize?client_id=x509_san_dns%3Alocalhost&request_uri=http%3A%2F%2Flocalhost%3A8080%2Frequest.jwt%2F9855a937fda74c3f8de9d7f92537206e"
+time=2025-11-27T14:03:25.155+09:00 level=INFO msg="Authorization RequestURI" status="200 OK" body="openid4vp:?client_id=x509_san_dns%3Alocalhost&request_uri=http%3A%2F%2Flocalhost%3A8080%2Frequest.jwt%2F9855a937fda74c3f8de9d7f92537206e"
 time=2025-11-27T14:03:25.155+09:00 level=INFO msg="Request URI is valid" scheme=openid4vp
 time=2025-11-27T14:03:25.174+09:00 level=INFO msg="Credential presented successfully"
 ```
@@ -260,7 +260,7 @@ Click the `Testing a wallet` button to proceed.
 
 ```bash
 cd /path/to/vcknots/wallet/examples/server_integration_sdjwt
-go run server_integration_sdjwt.go "openid4vp://authorize?client_id=...&request_uri=..."
+go run server_integration_sdjwt.go "openid4vp:?client_id=...&request_uri=..."
 ```
 
 **Important**: Providing an OpenID4VP URI as an argument automatically uses Conformance Test mode.
@@ -302,7 +302,7 @@ go run server_integration_sdjwt.go --credential-offer-uri "$OFFER_URI" --tx-code
 **Mode 2: Conformance test mode (with OpenID4VP URI argument)**
 ```bash
 cd /path/to/vcknots/wallet/examples/server_integration_sdjwt
-go run server_integration_sdjwt.go "openid4vp://authorize?..."
+go run server_integration_sdjwt.go "openid4vp:?..."
 ```
 - Tests against external OpenID4VP conformance test services
 - Uses system root certificate pool

--- a/wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go
+++ b/wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go
@@ -106,8 +106,8 @@ func (o runOptions) validate() error {
 	if o.CredentialOfferURI != "" && !strings.HasPrefix(o.CredentialOfferURI, credentialOfferURIPrefix) {
 		return fmt.Errorf("--credential-offer-uri must start with %q", credentialOfferURIPrefix)
 	}
-	if o.OID4VPURI != "" && !strings.HasPrefix(o.OID4VPURI, "openid4vp://") {
-		return fmt.Errorf("OID4VP URI must use the openid4vp:// scheme")
+	if o.OID4VPURI != "" && !strings.HasPrefix(o.OID4VPURI, "openid4vp:") {
+		return fmt.Errorf("OID4VP URI must use the openid4vp: scheme")
 	}
 	return nil
 }

--- a/wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go
+++ b/wallet/examples/server_integration_sdjwt/server_integration_sdjwt.go
@@ -14,7 +14,7 @@ package main
 // Mode 2: Conformance Test (with OID4VP URI argument)
 //   - Tests against external conformance test services
 //   - Usage: go run server_integration_sdjwt.go "<OID4VP_URI>"
-//   - Example: go run server_integration_sdjwt.go "openid4vp://authorize?client_id=...&request_uri=..."
+//   - Example: go run server_integration_sdjwt.go "openid4vp:?client_id=...&request_uri=..."
 //
 // Mode 1 flow: receive SD-JWT VC via OID4VCI from local issuer -> present via OID4VP to local verifier.
 // Mode 2 flow: load credential from file -> present via OID4VP to external verifier.

--- a/wallet/presenter/plugins/oid4vp/oid4vp_test.go
+++ b/wallet/presenter/plugins/oid4vp/oid4vp_test.go
@@ -271,6 +271,12 @@ func TestOid4vpPresenter_ParsePresentationRequest(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name:    "Query parameters without authority",
+			uri:     "openid4vp:?client_id=redirect_uri:http://example.com/callback&response_type=vp_token&nonce=test-nonce&dcql_query=" + testDcqlQueryParam + "&response_mode=direct_post&response_uri=https://example.com/response",
+			setup:   nil,
+			wantErr: false,
+		},
+		{
 			name:    "Query parameters",
 			uri:     "openid4vp://present?client_id=redirect_uri:http://example.com/callback&response_type=vp_token&nonce=test-nonce&dcql_query=" + testDcqlQueryParam + "&response_mode=direct_post&response_uri=https://example.com/response",
 			setup:   nil,


### PR DESCRIPTION
Closes https://github.com/trustknots/vcknots/issues/361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * OpenID4VP 認可リクエスト URI の形式を `openid4vp:?` に変更しました。
  * 通常の認可リクエストと Request Object 形式の両方に適用されています。

* **ドキュメント**
  * 日本語・英語のガイド、README、サンプル内の URI 表記を更新しました。

* **テスト**
  * authority を含まない新しい URI 形式を処理できるテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->